### PR TITLE
Complete `LowerToMir` for HIR expressions

### DIFF
--- a/pkg/ir/air.go
+++ b/pkg/ir/air.go
@@ -57,42 +57,31 @@ func (e *AirConstant) EvalAt(k int, tbl trace.Table) *big.Int {
 }
 
 func (e *AirAdd) EvalAt(k int, tbl trace.Table) *big.Int {
-	// Evaluate first argument
-	val := e.arguments[0].EvalAt(k,tbl)
-	if val == nil { return nil }
-	// Continue evaluating the rest
-	for i := 1; i < len(e.arguments); i++ {
-		ith := e.arguments[i].EvalAt(k,tbl)
-		if ith == nil { return ith }
-		val.Add(val, ith)
-	}
-	// Done
-	return val
+	fn := func(l *big.Int, r*big.Int) { l.Add(l,r) }
+	return EvalAirExprsAt(k,tbl,e.arguments,fn)
 }
 
 func (e *AirSub) EvalAt(k int, tbl trace.Table) *big.Int {
-	// Evaluate first argument
-	val := e.arguments[0].EvalAt(k,tbl)
-	if val == nil { return nil }
-	// Continue evaluating the rest
-	for i := 1; i < len(e.arguments); i++ {
-		ith := e.arguments[i].EvalAt(k,tbl)
-		if ith == nil { return ith }
-		val.Sub(val, ith)
-	}
-	// Done
-	return val
+	fn := func(l *big.Int, r*big.Int) { l.Sub(l,r) }
+	return EvalAirExprsAt(k,tbl,e.arguments,fn)
 }
 
 func (e *AirMul) EvalAt(k int, tbl trace.Table) *big.Int {
+	fn := func(l *big.Int, r*big.Int) { l.Mul(l,r) }
+	return EvalAirExprsAt(k,tbl,e.arguments,fn)
+}
+
+// Evaluate all expressions in a given slice at a given row on the
+// table, and fold their results together using a combinator.
+func EvalAirExprsAt(k int, tbl trace.Table, exprs []AirExpr, fn func(*big.Int,*big.Int)) *big.Int {
 	// Evaluate first argument
-	val := e.arguments[0].EvalAt(k,tbl)
+	val := exprs[0].EvalAt(k,tbl)
 	if val == nil { return nil }
 	// Continue evaluating the rest
-	for i := 1; i < len(e.arguments); i++ {
-		ith := e.arguments[i].EvalAt(k,tbl)
+	for i := 1; i < len(exprs); i++ {
+		ith := exprs[i].EvalAt(k,tbl)
 		if ith == nil { return ith }
-		val.Mul(val, ith)
+		fn(val,ith)
 	}
 	// Done
 	return val

--- a/pkg/ir/hir.go
+++ b/pkg/ir/hir.go
@@ -1,5 +1,9 @@
 package ir
 
+import (
+	"math/big"
+)
+
 // An expression in the High-Level Intermediate Representation (HIR).
 type HirExpr interface {
 	// Lower this expression into the Mid-Level Intermediate
@@ -14,6 +18,8 @@ type HirExpr interface {
 // ============================================================================
 
 type HirAdd Add[HirExpr]
+type HirSub Sub[HirExpr]
+type HirMul Mul[HirExpr]
 type HirConstant = Constant
 type HirIfZero IfZero[HirExpr]
 type HirList List[HirExpr]
@@ -21,6 +27,23 @@ type HirList List[HirExpr]
 // ============================================================================
 // Lowering
 // ============================================================================
+
+func (e *HirAdd) LowerToMir() []MirExpr {
+	return LowerWithNaryConstructor(e.arguments,func(nargs []MirExpr) MirExpr {
+		return &MirAdd{nargs}
+	})
+}
+
+// Lowering a constant is straightforward as it is already in the correct form.
+func (e *HirConstant) LowerToMir() []MirExpr {
+	return []MirExpr{e}
+}
+
+func (e *HirMul) LowerToMir() []MirExpr {
+	return LowerWithNaryConstructor(e.arguments,func(nargs []MirExpr) MirExpr {
+		return &MirMul{nargs}
+	})
+}
 
 // A list is lowered by eliminating it altogether.
 func (e *HirList) LowerToMir() []MirExpr {
@@ -44,15 +67,20 @@ func (e *HirIfZero) LowerToMir() []MirExpr {
 	f := e.falseBranch
 	// Add constraints arising from true branch
 	if t != nil {
+		// (1 - NORM(x)) * y for true branch
 		ts := LowerWithBinaryConstructor(c, t, func(x MirExpr, y MirExpr) MirExpr {
-			panic("got here")
+			one := &MirConstant{big.NewInt(1)}
+			norm_x := &MirNormalise{x}
+			one_minus_norm_x := &MirSub{[]MirExpr{one,norm_x}}
+			return &MirMul{[]MirExpr{one_minus_norm_x,y}}
 		})
 		res = append(res, ts...)
 	}
 	// Add constraints arising from false branch
 	if f != nil {
+		// x * y for false branch
 		fs := LowerWithBinaryConstructor(c, f, func(x MirExpr, y MirExpr) MirExpr {
-			panic("got here")
+			return &MirMul{[]MirExpr{x,y}}
 		})
 		res = append(res, fs...)
 	}
@@ -60,9 +88,10 @@ func (e *HirIfZero) LowerToMir() []MirExpr {
 	return res
 }
 
-// Lowering a constant is straightforward as it is already in the correct form.
-func (e *HirConstant) LowerToMir() []MirExpr {
-	return []MirExpr{e}
+func (e *HirSub) LowerToMir() []MirExpr {
+	return LowerWithNaryConstructor(e.arguments,func(nargs []MirExpr) MirExpr {
+		return &MirSub{nargs}
+	})
 }
 
 // ============================================================================
@@ -70,6 +99,7 @@ func (e *HirConstant) LowerToMir() []MirExpr {
 // ============================================================================
 
 type BinaryConstructor func(MirExpr, MirExpr) MirExpr
+type NaryConstructor func([]MirExpr) MirExpr
 
 // A generic mechanism for lowering down to a binary expression.
 func LowerWithBinaryConstructor(lhs HirExpr, rhs HirExpr, create BinaryConstructor) []MirExpr {
@@ -87,4 +117,56 @@ func LowerWithBinaryConstructor(lhs HirExpr, rhs HirExpr, create BinaryConstruct
 		}
 	}
 	return res
+}
+
+// Perform the cross-product expansion of an nary HIR expression.
+// This is necessary because each argument of that expression will
+// itself turn into one or more MIR expressions.  For example,
+// consider lowering the following HIR expression:
+//
+// > (if X Y Z) + 10
+//
+// Here, (if X Y Z) will lower into two MIR expressions: (1-NORM(X))*Y
+// and X*Z.  Thus, we need to generate two MIR expressions for our
+// example:
+//
+// > ((1 - NORM(X)) * Y) + 10
+// > (X * Y) + 10
+//
+// Finally, consider an expression such as the following:
+//
+// > (if X Y Z) + (if A B C)
+//
+// This will expand into *four* MIR expressions (i.e. the cross
+// product of the left and right ifs).
+func LowerWithNaryConstructor(args []HirExpr, constructor NaryConstructor) []MirExpr {
+	// Accumulator is initially empty
+	acc := make([]MirExpr,len(args))
+	// Start from the first argument
+	return LowerWithNaryConstructorHelper(0,acc,args,constructor)
+}
+
+// This manages progress through the cross-product expansion.
+// Specifically, "i" determines how much of args has been lowered thus
+// far, whilst "acc" represents the current array being generated.
+func LowerWithNaryConstructorHelper(i int, acc []MirExpr, args []HirExpr, constructor NaryConstructor) []MirExpr {
+	if i == len(acc) {
+		// Base Case
+		nacc := make([]MirExpr, len(acc))
+		// Clone the slice because it is used as a temporary
+		// working storage during the expansion.
+		copy(nacc,acc)
+		// Apply the constructor to produce the appropriate
+		// MirExpr.
+		return []MirExpr{constructor(nacc)}
+	} else {
+		// Recursive Case
+		nargs := []MirExpr{}
+		for _,ith := range args[i].LowerToMir() {
+			acc[i] = ith
+			iths := LowerWithNaryConstructorHelper(i+1,acc,args,constructor)
+			nargs = append(nargs,iths...)
+		}
+		return nargs
+	}
 }

--- a/pkg/ir/mir.go
+++ b/pkg/ir/mir.go
@@ -12,7 +12,12 @@ type MirExpr interface {
 	// expressions by introducing new columns into the enclosing table (with
 	// appropriate constraints).
 	LowerToAir() AirExpr
-	// Evaluate this expression in the context of a given table.
+	// Evaluate this expression in a given tabular context.
+	// Observe that if this expression is *undefined* within this
+	// context then it returns "nil".  An expression can be
+	// undefined for several reasons: firstly, if it accesses a
+	// row which does not exist (e.g. at index -1); secondly, if
+	// it accesses a column which does not exist.
 	EvalAt(int, trace.Table) *big.Int
 }
 
@@ -21,6 +26,8 @@ type MirExpr interface {
 // ============================================================================
 
 type MirAdd Add[MirExpr]
+type MirSub Sub[MirExpr]
+type MirMul Mul[MirExpr]
 type MirConstant = Constant
 type MirNormalise Normalise[MirExpr]
 
@@ -29,12 +36,15 @@ type MirNormalise Normalise[MirExpr]
 // ============================================================================
 
 func (e *MirAdd) LowerToAir() AirExpr {
-	n := len(e.arguments)
-	nargs := make([]AirExpr, n)
-	for i := 0; i < n; i++ {
-		nargs[i] = e.arguments[i].LowerToAir()
-	}
-	return &AirAdd{nargs}
+	return &AirAdd{LowerMirExprs(e.arguments)}
+}
+
+func (e *MirSub) LowerToAir() AirExpr {
+	return &AirSub{LowerMirExprs(e.arguments)}
+}
+
+func (e *MirMul) LowerToAir() AirExpr {
+	return &AirMul{LowerMirExprs(e.arguments)}
 }
 
 func (e *MirNormalise) LowerToAir() AirExpr {
@@ -46,19 +56,60 @@ func (e *MirConstant) LowerToAir() AirExpr {
 	return e
 }
 
+// Lower a set of zero or more MIR expressions.
+func LowerMirExprs(exprs []MirExpr) []AirExpr {
+	n := len(exprs)
+	nexprs := make([]AirExpr, n)
+	for i := 0; i < n; i++ {
+		nexprs[i] = exprs[i].LowerToAir()
+	}
+	return nexprs
+}
+
 // ============================================================================
 // Evaluation
 // ============================================================================
 
 func (e *MirAdd) EvalAt(k int, tbl trace.Table) *big.Int {
 	// Evaluate first argument
-	sum := e.arguments[0].EvalAt(k,tbl)
+	val := e.arguments[0].EvalAt(k,tbl)
+	if val == nil { return nil }
 	// Continue evaluating the rest
 	for i := 1; i < len(e.arguments); i++ {
-		sum.Add(sum, e.arguments[i].EvalAt(k,tbl))
+		ith := e.arguments[i].EvalAt(k,tbl)
+		if ith == nil { return ith }
+		val.Add(val, ith)
 	}
 	// Done
-	return sum
+	return val
+}
+
+func (e *MirSub) EvalAt(k int, tbl trace.Table) *big.Int {
+	// Evaluate first argument
+	val := e.arguments[0].EvalAt(k,tbl)
+	if val == nil { return nil }
+	// Continue evaluating the rest
+	for i := 1; i < len(e.arguments); i++ {
+		ith := e.arguments[i].EvalAt(k,tbl)
+		if ith == nil { return ith }
+		val.Sub(val, ith)
+	}
+	// Done
+	return val
+}
+
+func (e *MirMul) EvalAt(k int, tbl trace.Table) *big.Int {
+	// Evaluate first argument
+	val := e.arguments[0].EvalAt(k,tbl)
+	if val == nil { return nil }
+	// Continue evaluating the rest
+	for i := 1; i < len(e.arguments); i++ {
+		ith := e.arguments[i].EvalAt(k,tbl)
+		if ith == nil { return ith }
+		val.Mul(val, ith)
+	}
+	// Done
+	return val
 }
 
 func (e *MirNormalise) EvalAt(k int, tbl trace.Table) *big.Int {
@@ -68,4 +119,20 @@ func (e *MirNormalise) EvalAt(k int, tbl trace.Table) *big.Int {
 	} else {
 		return big.NewInt(1)
 	}
+}
+
+// Evaluate all expressions in a given slice at a given row on the
+// table, and fold their results together using a combinator.
+func EvalMirExprsAt(k int, tbl trace.Table, exprs []MirExpr, fn func(*big.Int,*big.Int)) *big.Int {
+	// Evaluate first argument
+	val := exprs[0].EvalAt(k,tbl)
+	if val == nil { return nil }
+	// Continue evaluating the rest
+	for i := 1; i < len(exprs); i++ {
+		ith := exprs[i].EvalAt(k,tbl)
+		if ith == nil { return ith }
+		fn(val,ith)
+	}
+	// Done
+	return val
 }


### PR DESCRIPTION
This completes the `LowerToMir` collection of methods for HIR expressions, including for n-ary operators.  However, it has not been tested!  Therefore, we need to put together a simple parser for HIR and MIR expressions, and then writing some "lowering" tests.