### PR TITLE
Prevent duplicate creation of computed columns

### DIFF
--- a/pkg/ir/air.go
+++ b/pkg/ir/air.go
@@ -142,7 +142,7 @@ func (e *AirMul) String() string {
 }
 
 func (e *AirInverse) String() string {
-	return fmt.Sprintf("(~ %s)",e.expr)
+	return fmt.Sprintf("(inv %s)",e.expr)
 }
 
 func AirNaryString(operator string, exprs []AirExpr) string {

--- a/pkg/ir/mir.go
+++ b/pkg/ir/mir.go
@@ -87,12 +87,15 @@ func (e *MirMul) LowerTo(tbl AirTable) AirExpr {
 func (e *MirNormalise) LowerTo(tbl AirTable) AirExpr {
 	// Lower the expression being normalised
 	ne := e.expr.LowerTo(tbl)
-	// Determine column name and height
-	name := fmt.Sprintf("C/INV[%s]",ne)
 	// Invert expression
 	ine := &AirInverse{ne}
-	// Add computed column
-	tbl.AddColumn(trace.NewComputedColumn(name,ine))
+	// Determine computed column name
+	name := ine.String()
+	// Add new column (if it does not already exist)
+	if !tbl.HasColumn(name) {
+		// Add computed column
+		tbl.AddColumn(trace.NewComputedColumn(name,ine))
+	}
 	// Add necessary constraints
 	return &AirMul{[]AirExpr{ne,&AirColumnAccess{name,0}}}
 }

--- a/pkg/trace/table.go
+++ b/pkg/trace/table.go
@@ -33,6 +33,8 @@ type Table[C any] interface {
 	// Check whether all constraints for a given trace evaluate to zero.
 	// If not, produce an error.
 	Check() error
+	// Check whether a given column already exists
+	HasColumn(string) bool
 	// Access Columns
 	Columns() []Column
 	// Access Constraints
@@ -83,6 +85,15 @@ func NewLazyTable[C Constraint](columns []Column, constraints []C) *LazyTable[C]
 	}
 	//
 	return p
+}
+
+func (p *LazyTable[C]) HasColumn(name string) bool {
+	for _,c := range p.columns {
+		if c.Name() == name {
+			return true
+		}
+	}
+	return false
 }
 
 // Check whether all constraints on the given table evaluate to zero.


### PR DESCRIPTION
Computed columns with identical names are only computed once.