### PR TITLE
Support set-based `:domain` specifiers

### DIFF
--- a/pkg/binfile/constraint.go
+++ b/pkg/binfile/constraint.go
@@ -1,6 +1,8 @@
 package binfile
 
-import "github.com/consensys/go-corset/pkg/hir"
+import (
+	"github.com/consensys/go-corset/pkg/hir"
+)
 
 // JsonConstraint аn enumeration of constraint forms.  Exactly one of these fields
 // must be non-nil to signify its form.
@@ -8,11 +10,15 @@ type jsonConstraint struct {
 	Vanishes *jsonVanishingConstraint
 }
 
+type jsonDomain struct {
+	Set []int
+}
+
 // JsonVanishingConstraint corresponds to a constraint whose expression must evaluate to zero
 // for every row of the table.
 type jsonVanishingConstraint struct {
 	Handle string        `json:"handle"`
-	Domain string        `json:"domain"`
+	Domain jsonDomain    `json:"domain"`
 	Expr   jsonTypedExpr `json:"expr"`
 }
 
@@ -20,13 +26,26 @@ type jsonVanishingConstraint struct {
 // Translation
 // =============================================================================
 
-func (e jsonConstraint) ToHir() hir.Constraint {
+func (e jsonConstraint) toHir() hir.Constraint {
 	if e.Vanishes != nil {
 		// Translate the vanishing expression
 		expr := e.Vanishes.Expr.ToHir()
+		// Translate Domain
+		domain := e.Vanishes.Domain.toHir()
 		// Construct the vanishing constraint
-		return &hir.VanishingConstraint{Handle: e.Vanishes.Handle, Expr: expr}
+		return &hir.VanishingConstraint{Handle: e.Vanishes.Handle, Domain: domain, Expr: expr}
 	}
 
 	panic("Unknown JSON constraint encountered")
+}
+
+func (e jsonDomain) toHir() *int {
+	if len(e.Set) == 1 {
+		domain := e.Set[0]
+		return &domain
+	} else if e.Set != nil {
+		panic("Unknown domain")
+	}
+	// Default
+	return nil
 }

--- a/pkg/binfile/constraint_set.go
+++ b/pkg/binfile/constraint_set.go
@@ -109,7 +109,7 @@ func HirSchemaFromJson(bytes []byte) (schema *hir.Schema, err error) {
 		// translated.  Unproven types are purely cosmetic and
 		// should be ignored.
 		if c.MustProve {
-			hType = c.Type.ToHir()
+			hType = c.Type.toHir()
 		} else {
 			hType = &mir.FieldType{}
 		}
@@ -118,7 +118,7 @@ func HirSchemaFromJson(bytes []byte) (schema *hir.Schema, err error) {
 	}
 	// Add constraints
 	for _, c := range res.Constraints {
-		schema.AddConstraint(c.ToHir())
+		schema.AddConstraint(c.toHir())
 	}
 
 	// For now return directly.

--- a/pkg/binfile/type.go
+++ b/pkg/binfile/type.go
@@ -21,7 +21,7 @@ type jsonType struct {
 // Translation
 // =============================================================================
 
-func (e *jsonType) ToHir() mir.Type {
+func (e *jsonType) toHir() mir.Type {
 	// Check whether magma is string
 	if str, ok := e.Magma.(string); ok {
 		switch str {

--- a/pkg/table/constraints.go
+++ b/pkg/table/constraints.go
@@ -103,5 +103,11 @@ func VanishesLocally[E Evaluable](k int, handle string, expr E, tr Trace) error 
 }
 
 func (p *VanishingConstraint[T]) String() string {
-	return fmt.Sprintf("(vanishes %s %s)", p.Handle, any(p.Expr))
+	if p.Domain == nil {
+		return fmt.Sprintf("(vanishes %s %s)", p.Handle, any(p.Expr))
+	} else if *p.Domain == 0 {
+		return fmt.Sprintf("(vanishes:first %s %s)", p.Handle, any(p.Expr))
+	}
+	//
+	return fmt.Sprintf("(vanishes:last %s %s)", p.Handle, any(p.Expr))
 }


### PR DESCRIPTION
This adds support for two domain specifiers: `:domain {0}` and `:domain {-1}`.  These are then converted into either _first_ or _last_ constraints.