### PR TITLE
Reenable `confusing-naming` check

### DIFF
--- a/.golangci-lint.yml
+++ b/.golangci-lint.yml
@@ -82,8 +82,8 @@ linters-settings:
         severity: warning
       - name: unreachable-code
         severity: warning
-      # - name: confusing-naming
-      #   severity: warning
+      - name: confusing-naming
+        severity: warning
 
   staticcheck:
     go: "1.22"

--- a/pkg/table/column.go
+++ b/pkg/table/column.go
@@ -26,6 +26,8 @@ func (c *DataColumn[T]) Get(row int, tr Trace) (*fr.Element, error) {
 // Accepts determines whether or not this column accepts the given trace.  For a
 // data column, this means ensuring that all elements are value for the columns
 // type.
+//
+//nolint:revive
 func (c *DataColumn[T]) Accepts(tr Trace) (bool, error) {
 	for i := 0; i < tr.Height(); i++ {
 		val, err := tr.GetByName(c.Name, i)

--- a/pkg/table/constraints.go
+++ b/pkg/table/constraints.go
@@ -43,6 +43,8 @@ func (p *VanishingConstraint[T]) GetHandle() string {
 
 // Accepts checks whether a vanishing constraint evaluates to zero on every row
 // of a table.  If so, return nil otherwise return an error.
+//
+//nolint:revive
 func (p *VanishingConstraint[T]) Accepts(tr Trace) (bool, error) {
 	if p.Domain == nil {
 		// Global Constraint


### PR DESCRIPTION
This re-enables the `confusing-naming` check but, instead, includes `//nolint:revive` comment.