### PR TITLE
Add `Contextual` interface

### DIFF
--- a/pkg/air/gadgets/column_sort.go
+++ b/pkg/air/gadgets/column_sort.go
@@ -20,8 +20,10 @@ import (
 // computation.
 func ApplyColumnSortGadget(col uint, sign bool, bitwidth uint, schema *air.Schema) {
 	var deltaName string
+	// Identify target column
+	column := schema.Columns().Nth(col)
 	// Determine column name
-	name := schema.Columns().Nth(col).Name()
+	name := column.Name()
 	// Configure computation
 	Xk := air.NewColumnAccess(col, 0)
 	Xkm1 := air.NewColumnAccess(col, -1)
@@ -40,5 +42,5 @@ func ApplyColumnSortGadget(col uint, sign bool, bitwidth uint, schema *air.Schem
 	ApplyBitwidthGadget(deltaIndex, bitwidth, schema)
 	// Configure constraint: Delta[k] = X[k] - X[k-1]
 	Dk := air.NewColumnAccess(deltaIndex, 0)
-	schema.AddVanishingConstraint(deltaName, nil, Dk.Equate(Xdiff))
+	schema.AddVanishingConstraint(deltaName, column.Module(), nil, Dk.Equate(Xdiff))
 }

--- a/pkg/air/schema.go
+++ b/pkg/air/schema.go
@@ -71,9 +71,9 @@ func (p *Schema) AddPermutationConstraint(targets []uint, sources []uint) {
 }
 
 // AddVanishingConstraint appends a new vanishing constraint.
-func (p *Schema) AddVanishingConstraint(handle string, domain *int, expr Expr) {
+func (p *Schema) AddVanishingConstraint(handle string, module uint, domain *int, expr Expr) {
 	p.constraints = append(p.constraints,
-		constraint.NewVanishingConstraint(handle, domain, constraint.ZeroTest[Expr]{Expr: expr}))
+		constraint.NewVanishingConstraint(handle, module, domain, constraint.ZeroTest[Expr]{Expr: expr}))
 }
 
 // AddRangeConstraint appends a new range constraint.

--- a/pkg/binfile/constraint.go
+++ b/pkg/binfile/constraint.go
@@ -2,6 +2,7 @@ package binfile
 
 import (
 	"github.com/consensys/go-corset/pkg/hir"
+	sc "github.com/consensys/go-corset/pkg/schema"
 )
 
 // JsonConstraint аn enumeration of constraint forms.  Exactly one of these fields
@@ -43,8 +44,10 @@ func (e jsonConstraint) addToSchema(schema *hir.Schema) {
 		expr := e.Vanishes.Expr.ToHir(schema)
 		// Translate Domain
 		domain := e.Vanishes.Domain.toHir()
+		// Determine enclosing module
+		module := sc.DetermineEnclosingModuleOfExpression(expr, schema)
 		// Construct the vanishing constraint
-		schema.AddVanishingConstraint(e.Vanishes.Handle, domain, expr)
+		schema.AddVanishingConstraint(e.Vanishes.Handle, module, domain, expr)
 	} else if e.Permutation == nil {
 		// Catch all
 		panic("Unknown JSON constraint encountered")

--- a/pkg/hir/expr.go
+++ b/pkg/hir/expr.go
@@ -1,8 +1,11 @@
 package hir
 
 import (
+	"math"
+
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	"github.com/consensys/go-corset/pkg/mir"
+	sc "github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 )
@@ -17,6 +20,7 @@ import (
 // "compiled out" into one or more expressions at the MIR level.
 type Expr interface {
 	util.Boundable
+	sc.Contextual
 	// LowerTo lowers this expression into the Mid-Level Intermediate
 	// Representation.  Observe that a single expression at this
 	// level can expand into *multiple* expressions at the MIR
@@ -33,12 +37,26 @@ type Expr interface {
 	String() string
 }
 
+// ============================================================================
+// Addition
+// ============================================================================
+
 // Add represents the sum over zero or more expressions.
 type Add struct{ Args []Expr }
 
 // Bounds returns max shift in either the negative (left) or positive
 // direction (right).
 func (p *Add) Bounds() util.Bounds { return util.BoundsForArray(p.Args) }
+
+// Context determines the evaluation context (i.e. enclosing module) for this
+// expression.
+func (p *Add) Context(schema sc.Schema) (uint, bool) {
+	return sc.JoinContexts[Expr](p.Args, schema)
+}
+
+// ============================================================================
+// Subtraction
+// ============================================================================
 
 // Sub represents the subtraction over zero or more expressions.
 type Sub struct{ Args []Expr }
@@ -47,12 +65,32 @@ type Sub struct{ Args []Expr }
 // direction (right).
 func (p *Sub) Bounds() util.Bounds { return util.BoundsForArray(p.Args) }
 
+// Context determines the evaluation context (i.e. enclosing module) for this
+// expression.
+func (p *Sub) Context(schema sc.Schema) (uint, bool) {
+	return sc.JoinContexts[Expr](p.Args, schema)
+}
+
+// ============================================================================
+// Multiplication
+// ============================================================================
+
 // Mul represents the product over zero or more expressions.
 type Mul struct{ Args []Expr }
 
 // Bounds returns max shift in either the negative (left) or positive
 // direction (right).
 func (p *Mul) Bounds() util.Bounds { return util.BoundsForArray(p.Args) }
+
+// Context determines the evaluation context (i.e. enclosing module) for this
+// expression.
+func (p *Mul) Context(schema sc.Schema) (uint, bool) {
+	return sc.JoinContexts[Expr](p.Args, schema)
+}
+
+// ============================================================================
+// List
+// ============================================================================
 
 // List represents a block of zero or more expressions.
 type List struct{ Args []Expr }
@@ -61,12 +99,32 @@ type List struct{ Args []Expr }
 // direction (right).
 func (p *List) Bounds() util.Bounds { return util.BoundsForArray(p.Args) }
 
+// Context determines the evaluation context (i.e. enclosing module) for this
+// expression.
+func (p *List) Context(schema sc.Schema) (uint, bool) {
+	return sc.JoinContexts[Expr](p.Args, schema)
+}
+
+// ============================================================================
+// Constant
+// ============================================================================
+
 // Constant represents a constant value within an expression.
 type Constant struct{ Val *fr.Element }
 
 // Bounds returns max shift in either the negative (left) or positive
 // direction (right).  A constant has zero shift.
 func (p *Constant) Bounds() util.Bounds { return util.EMPTY_BOUND }
+
+// Context determines the evaluation context (i.e. enclosing module) for this
+// expression.
+func (p *Constant) Context(schema sc.Schema) (uint, bool) {
+	return math.MaxUint, true
+}
+
+// ============================================================================
+// IfZero
+// ============================================================================
 
 // IfZero returns the (optional) true branch when the condition evaluates to zero, and
 // the (optional false branch otherwise.
@@ -97,6 +155,17 @@ func (p *IfZero) Bounds() util.Bounds {
 	return c
 }
 
+// Context determines the evaluation context (i.e. enclosing module) for this
+// expression.
+func (p *IfZero) Context(schema sc.Schema) (uint, bool) {
+	args := []Expr{p.Condition, p.TrueBranch, p.FalseBranch}
+	return sc.JoinContexts[Expr](args, schema)
+}
+
+// ============================================================================
+// Normalise
+// ============================================================================
+
 // Normalise reduces the value of an expression to either zero (if it was zero)
 // or one (otherwise).
 type Normalise struct{ Arg Expr }
@@ -106,6 +175,16 @@ type Normalise struct{ Arg Expr }
 func (p *Normalise) Bounds() util.Bounds {
 	return p.Arg.Bounds()
 }
+
+// Context determines the evaluation context (i.e. enclosing module) for this
+// expression.
+func (p *Normalise) Context(schema sc.Schema) (uint, bool) {
+	return p.Arg.Context(schema)
+}
+
+// ============================================================================
+// ColumnAccess
+// ============================================================================
 
 // ColumnAccess represents reading the value held at a given column in the
 // tabular context.  Furthermore, the current row maybe shifted up (or down) by
@@ -127,4 +206,10 @@ func (p *ColumnAccess) Bounds() util.Bounds {
 	}
 	// Negative shift
 	return util.NewBounds(uint(-p.Shift), 0)
+}
+
+// Context determines the evaluation context (i.e. enclosing module) for this
+// expression.
+func (p *ColumnAccess) Context(schema sc.Schema) (uint, bool) {
+	return schema.Columns().Nth(p.Column).Module(), true
 }

--- a/pkg/hir/lower.go
+++ b/pkg/hir/lower.go
@@ -46,7 +46,7 @@ func lowerConstraintToMir(c sc.Constraint, schema *mir.Schema) {
 		mir_exprs := v.Constraint().Expr.LowerTo(schema)
 		// Add individual constraints arising
 		for _, mir_expr := range mir_exprs {
-			schema.AddVanishingConstraint(v.Handle(), v.Domain(), mir_expr)
+			schema.AddVanishingConstraint(v.Handle(), v.Module(), v.Domain(), mir_expr)
 		}
 	} else if v, ok := c.(*constraint.TypeConstraint); ok {
 		schema.AddTypeConstraint(v.Target(), v.Type())

--- a/pkg/hir/parser.go
+++ b/pkg/hir/parser.go
@@ -221,8 +221,9 @@ func (p *hirParser) parseVanishingDeclaration(elements []sexp.SExp, domain *int)
 	if err != nil {
 		return err
 	}
-
-	p.schema.AddVanishingConstraint(handle, domain, expr)
+	// TODO: support module syntax
+	module := uint(0)
+	p.schema.AddVanishingConstraint(handle, module, domain, expr)
 
 	return nil
 }

--- a/pkg/mir/lower.go
+++ b/pkg/mir/lower.go
@@ -41,7 +41,7 @@ func lowerConstraintToAir(c sc.Constraint, schema *air.Schema) {
 	// Check what kind of constraint we have
 	if v, ok := c.(VanishingConstraint); ok {
 		air_expr := v.Constraint().Expr.LowerTo(schema)
-		schema.AddVanishingConstraint(v.Handle(), v.Domain(), air_expr)
+		schema.AddVanishingConstraint(v.Handle(), v.Module(), v.Domain(), air_expr)
 	} else if v, ok := c.(*constraint.TypeConstraint); ok {
 		if t := v.Type().AsUint(); t != nil {
 			// Yes, a constraint is implied.  Now, decide whether to use a range

--- a/pkg/mir/schema.go
+++ b/pkg/mir/schema.go
@@ -64,9 +64,9 @@ func (p *Schema) AddPermutationColumns(targets []schema.Column, signs []bool, so
 }
 
 // AddVanishingConstraint appends a new vanishing constraint.
-func (p *Schema) AddVanishingConstraint(handle string, domain *int, expr Expr) {
+func (p *Schema) AddVanishingConstraint(handle string, module uint, domain *int, expr Expr) {
 	p.constraints = append(p.constraints,
-		constraint.NewVanishingConstraint(handle, domain, constraint.ZeroTest[Expr]{Expr: expr}))
+		constraint.NewVanishingConstraint(handle, module, domain, constraint.ZeroTest[Expr]{Expr: expr}))
 }
 
 // AddTypeConstraint appends a new range constraint.

--- a/pkg/schema/constraint/vanishing.go
+++ b/pkg/schema/constraint/vanishing.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/consensys/go-corset/pkg/schema"
+	sc "github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 )
@@ -26,6 +27,12 @@ func (p ZeroTest[E]) TestAt(row int, tr trace.Trace) bool {
 // Bounds determines the bounds for this zero test.
 func (p ZeroTest[E]) Bounds() util.Bounds {
 	return p.Expr.Bounds()
+}
+
+// Context determines the evaluation context (i.e. enclosing module) for this
+// expression.
+func (p ZeroTest[E]) Context(schema sc.Schema) (uint, bool) {
+	return p.Expr.Context(schema)
 }
 
 // String generates a human-readble string.
@@ -58,9 +65,9 @@ type VanishingConstraint[T schema.Testable] struct {
 }
 
 // NewVanishingConstraint constructs a new vanishing constraint!
-func NewVanishingConstraint[T schema.Testable](handle string, domain *int, constraint T) *VanishingConstraint[T] {
-	// FIXME: determine correct module index
-	return &VanishingConstraint[T]{handle, 0, domain, constraint}
+func NewVanishingConstraint[T schema.Testable](handle string, module uint,
+	domain *int, constraint T) *VanishingConstraint[T] {
+	return &VanishingConstraint[T]{handle, module, domain, constraint}
 }
 
 // Handle returns the handle associated with this constraint.
@@ -78,6 +85,13 @@ func (p *VanishingConstraint[T]) Constraint() T {
 // applies to a specific row (e.g. the first or last).
 func (p *VanishingConstraint[T]) Domain() *int {
 	return p.domain
+}
+
+// Module returns the enclosing module for this constraint, a.k.a the evaluation
+// context.  Every constraint must be situated within exactly one module in
+// order to be well-formed.
+func (p *VanishingConstraint[T]) Module() uint {
+	return p.module
 }
 
 // Accepts checks whether a vanishing constraint evaluates to zero on every row


### PR DESCRIPTION
This adds a `Contextual` interface which can be used to determine the _evaluation context_ (i.e. enclosing module) of a given expression.

This also fixes `VanishingConstraints` to require a module index be given to represent their context.