### PR TITLE
Fix: Use custom `HashSet` implementation for lookup constraints

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,10 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/go-set v0.1.14 h1:ZU7JyS6QGueDuXYldjcuyKLR0XV14eOKcsQlGddXGgA=
+github.com/hashicorp/go-set v0.1.14/go.mod h1:FH9zJxnQYHPlZ7j9JaoQjZOFPBStOrelKOE11Wjwirc=
+github.com/hashicorp/go-set/v2 v2.1.0 h1:iERPCQWks+I+4bTgy0CT2myZsCqNgBg79ZHqwniohXo=
+github.com/hashicorp/go-set/v2 v2.1.0/go.mod h1:6q4nh8UCVZODn2tJ5RbJi8+ki7pjZBsAEYGt6yaGeTo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/pkg/cmd/compute.go
+++ b/pkg/cmd/compute.go
@@ -1,11 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/consensys/go-corset/pkg/binfile"
-
 	"github.com/spf13/cobra"
 )
 
@@ -15,28 +10,7 @@ var computeCmd = &cobra.Command{
 	Short: "Given a set of constraints and a trace file, fill the computed columns.",
 	Long:  `Given a set of constraints and a trace file, fill the computed columns.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		file := args[0]
-		fmt.Printf("Reading JSON bin file: %s\n", file)
-		bytes, err := os.ReadFile(file)
-		if err != nil {
-			fmt.Println("Error")
-		} else {
-			// Parse binary file into HIR schema
-			schema, err := binfile.HirSchemaFromJson(bytes)
-			//
-			if err != nil {
-				panic(err)
-			}
-			// Print columns
-			for i := schema.Columns(); i.HasNext(); {
-				ith := i.Next()
-				fmt.Printf("column %s : %s\n", ith.Name(), ith.Type())
-			}
-			// Print constraints
-			for i := schema.Constraints(); i.HasNext(); {
-				fmt.Println(i.Next())
-			}
-		}
+		panic("todo")
 	},
 }
 

--- a/pkg/schema/constraint/vanishing.go
+++ b/pkg/schema/constraint/vanishing.go
@@ -123,6 +123,7 @@ func (p *VanishingConstraint[T]) Accepts(tr trace.Trace) error {
 func HoldsGlobally[T sc.Testable](handle string, ctx trace.Context, constraint T, tr trace.Trace) error {
 	// Determine height of enclosing module
 	height := tr.Modules().Get(ctx.Module()).Height() * ctx.LengthMultiplier()
+	//
 	// Determine well-definedness bounds for this constraint
 	bounds := constraint.Bounds()
 	// Sanity check enough rows

--- a/pkg/test/hashset_test.go
+++ b/pkg/test/hashset_test.go
@@ -1,0 +1,120 @@
+package test
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"sort"
+	"testing"
+
+	"github.com/consensys/go-corset/pkg/util"
+)
+
+func Test_HashSet_01(t *testing.T) {
+	items := []uint64{1, 2, 3, 4, 3, 2, 1}
+	check_HashSet(t, items)
+}
+
+func Test_HashSet_02(t *testing.T) {
+	items := generateRandomInputs(10, 32)
+	check_HashSet(t, items)
+}
+
+func Test_HashSet_03(t *testing.T) {
+	items := generateRandomInputs(100, 32)
+	check_HashSet(t, items)
+}
+
+func Test_HashSet_04(t *testing.T) {
+	items := generateRandomInputs(1000, 32)
+	check_HashSet(t, items)
+}
+
+func Test_HashSet_05(t *testing.T) {
+	items := generateRandomInputs(100000, 32)
+	check_HashSet(t, items)
+}
+
+func Test_HashSet_08(t *testing.T) {
+	items := generateRandomInputs(100000, 64)
+	check_HashSet(t, items)
+}
+
+func Test_HashSet_09(t *testing.T) {
+	items := generateRandomInputs(100000, 128)
+	check_HashSet(t, items)
+}
+
+// ===================================================================
+// Test Helpers
+// ===================================================================
+
+func check_HashSet(t *testing.T, items []uint64) {
+	set := util.NewHashSet[testKey](0)
+	dups := uint(0)
+	// Insert items
+	for _, item := range items {
+		if set.Insert(testKey{item}) {
+			// Duplicate item inserted
+			dups++
+		}
+	}
+	// Sort items
+	sort.Slice(items, func(i, j int) bool {
+		return items[i] < items[j]
+	})
+	//
+	count := uint(0)
+	// Count unique items
+	for i := 0; i < len(items); i++ {
+		if i == 0 || items[i-1] != items[i] {
+			count++
+		}
+	}
+	// Sanity check number of unique items
+	if set.Size() != count {
+		t.Errorf("expected %d unique items, got %d: %s", count, set.Size(), set.String())
+	}
+	// Sanity check duplicates calculation
+	if count+dups != uint(len(items)) {
+		t.Errorf("incorrect number of duplicates %d: %s", dups, set.String())
+	}
+	// Sanity check containership
+	for _, ith := range items {
+		if !set.Contains(testKey{ith}) {
+			t.Errorf("missing item %d: %s", ith, set.String())
+		}
+	}
+}
+
+func generateRandomInputs(n, m uint) []uint64 {
+	items := make([]uint64, n)
+
+	for i := uint(0); i < n; i++ {
+		items[i] = uint64(rand.UintN(m))
+	}
+
+	return items
+}
+
+// A simple wrapper around a uint64.  This is deliberately broken to ensure a
+// relatively limited spread of hash values.  This helps to ensure that we get
+// some collisions.
+type testKey struct {
+	value uint64
+}
+
+// Equals compares two Uint64Keys to check whether they represent the same
+// underlying byte array (or not).
+func (p testKey) Equals(other testKey) bool {
+	return p.value == other.value
+}
+
+// Hash generates a 64-bit hashcode from the underlying value.
+func (p testKey) Hash() uint64 {
+	// This is a deliberate act to limit the qualitfy of this hash function.
+	return p.value % 16
+}
+
+func (p testKey) String() string {
+	return fmt.Sprintf("%d", p.value)
+}

--- a/pkg/util/hash_set.go
+++ b/pkg/util/hash_set.go
@@ -1,0 +1,181 @@
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"hash/fnv"
+	"strings"
+)
+
+// A reasonably simple hashset implementation which permits collisions.  Observe
+// that, for example, hashicorp's go-set is *not* a suitable replacement here,
+// since that does not handle collisions.  Specifically, it assumes the hash
+// function always uniquely identifies the data in question.  I don't want to
+// make that assumption here.
+
+// Hasher provides a generic definition of a hashing function suitable for use
+// within the hashset.  This is similar to the Hasher interface provided in
+// go-set, except that it additionally includes equality.
+type Hasher[T any] interface {
+	// Check whether two items are equal (or not).
+	Equals(T) bool
+	// Return a suitable hashcode.
+	Hash() uint64
+}
+
+// HashSet defines a generic set implementation backed by a map.  This is a true
+// hashtable in that collisions are handle gracefully using buckets, rather than
+// simply discarding them.
+type HashSet[T Hasher[T]] struct {
+	// items maps hashcodes to *buckets* of items.
+	items map[uint64]bucket[T]
+}
+
+// NewHashSet creates a new HashSet with a given underlying capacity.
+func NewHashSet[T Hasher[T]](size uint) *HashSet[T] {
+	items := make(map[uint64]bucket[T], size)
+	return &HashSet[T]{items}
+}
+
+// Size returns the number of unique items stored in this HashSet.
+func (p *HashSet[T]) Size() uint {
+	count := uint(0)
+	for _, b := range p.items {
+		count += b.size()
+	}
+
+	return count
+}
+
+// MaxBucket returns the size of the largest bucket.
+func (p *HashSet[T]) MaxBucket() uint {
+	m := uint(0)
+	for _, b := range p.items {
+		m = max(m, b.size())
+	}
+
+	return m
+}
+
+// Insert a new item into this map, returning true if it was already contained
+// and false otherwise.
+func (p *HashSet[T]) Insert(item T) bool {
+	var b1 bucket[T]
+	// Compute item's hashcode
+	hash := item.Hash()
+	// Lookup existing bucket
+	b1 = p.items[hash]
+	// Insert new item
+	r := b1.insert(item)
+	// Update map
+	p.items[hash] = b1
+	// Done
+	return r
+}
+
+// Contains checks whether the given item is contained within this map, or not.
+func (p *HashSet[T]) Contains(item T) bool {
+	hash := item.Hash()
+
+	if bucket, ok := p.items[hash]; ok {
+		return bucket.contains(item)
+	}
+
+	return false
+}
+
+func (p *HashSet[T]) String() string {
+	var r strings.Builder
+	//
+	first := true
+	// Write opening brace
+	r.WriteString("{")
+	// Iterate all buckets
+	for _, b := range p.items {
+		// Iterate all items in bucket
+		for _, i := range b.items {
+			if !first {
+				r.WriteString(",")
+			}
+
+			first = false
+
+			r.WriteString(fmt.Sprintf("%s", any(i)))
+		}
+	}
+	// Write closing brace
+	r.WriteString("}")
+	// Done
+	return r.String()
+}
+
+// ============================================================================
+// Bucket
+// ============================================================================
+
+type bucket[T Hasher[T]] struct {
+	items []T
+}
+
+// Get the number of items in this bucket.
+//
+//nolint:revive
+func (b *bucket[T]) size() uint {
+	return uint(len(b.items))
+}
+
+// Insert a new item into this bucket
+//
+//nolint:revive
+func (b *bucket[T]) insert(item T) bool {
+	if b.contains(item) {
+		// Item already present, so nothing to do.
+		return true
+	}
+	// Append item
+	b.items = append(b.items, item)
+	// Item not present
+	return false
+}
+
+// Check whether this bucket contains a given item, or not.
+//
+//nolint:revive
+func (b *bucket[T]) contains(item T) bool {
+	for _, i := range b.items {
+		if item.Equals(i) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ============================================================================
+// Key Implementations
+// ============================================================================
+
+// BytesKey wraps a bytes array as something which can be safely placed into a
+// HashSet.
+type BytesKey struct {
+	bytes []byte
+}
+
+// NewBytesKey constructs a new bytes key.
+func NewBytesKey(bytes []byte) BytesKey {
+	return BytesKey{bytes}
+}
+
+// Equals compares two BytesKeys to check whether they represent the same
+// underlying byte array (or not).
+func (p BytesKey) Equals(other BytesKey) bool {
+	return bytes.Equal(p.bytes, other.bytes)
+}
+
+// Hash generat6es a 64-bit hashcode from the underlying bytes array.
+func (p BytesKey) Hash() uint64 {
+	hash := fnv.New64a()
+	hash.Write(p.bytes)
+	// Done
+	return hash.Sum64()
+}


### PR DESCRIPTION
This provides a custom `HashSet` implementation for use when checking lookup constraints.  This improves the time complexity for `LookupConstraint.Accepts()` from `O(n^2)` to approx `O(n)`.

The reason for using custom `HashSet` implementation is simply to ensure that collisions are handled correctly.  Existing `HashSet` implementations (e.g. hashicorp) do not safely support collisions.  That is, they assume the hash function never collides for two different items.  Since I do not want to make that assumption, I have implemented my own variation.  This is a true hashtable in the sense that it uses buckets to handle collisions, and requires an extended `Hasher` interface (compared with ithat in e.g. hashicorp's `go-set`). Specifically, the `Hasher` interface includes a notion of equality.

A reasonable number of tests have been added for this `HashSet` implementation.