### PR TITLE
Remove `Column.Data()`

### DIFF
--- a/pkg/cmd/trace.go
+++ b/pkg/cmd/trace.go
@@ -6,8 +6,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
+
 	"github.com/spf13/cobra"
 )
 
@@ -77,8 +79,14 @@ func filterColumns(tr trace.Trace, prefix string) trace.Trace {
 		//
 		if strings.HasPrefix(qName, prefix) {
 			ith := tr.Columns().Get(i)
+			// Copy column data
+			data := make([]*fr.Element, ith.Height())
+			//
+			for j := 0; j < int(ith.Height()); j++ {
+				data[j] = ith.Get(j)
+			}
 
-			err := builder.Add(qName, ith.Padding(), ith.Data())
+			err := builder.Add(qName, ith.Padding(), data)
 			// Sanity check
 			if err != nil {
 				panic(err)

--- a/pkg/schema/assignment/byte_decomposition.go
+++ b/pkg/schema/assignment/byte_decomposition.go
@@ -68,17 +68,15 @@ func (p *ByteDecomposition) ExpandTrace(tr trace.Trace) error {
 	n := len(p.targets)
 	// Identify source column
 	source := columns.Get(p.source)
-	// Extract column data to decompose
-	data := source.Data()
 	// Construct byte column data
 	cols := make([][]*fr.Element, n)
 	// Initialise columns
 	for i := 0; i < n; i++ {
-		cols[i] = make([]*fr.Element, len(data))
+		cols[i] = make([]*fr.Element, source.Height())
 	}
 	// Decompose each row of each column
-	for i := 0; i < len(data); i = i + 1 {
-		ith := decomposeIntoBytes(data[i], n)
+	for i := 0; i < int(source.Height()); i = i + 1 {
+		ith := decomposeIntoBytes(source.Get(i), n)
 		for j := 0; j < n; j++ {
 			cols[j][i] = ith[j]
 		}

--- a/pkg/schema/assignment/sorted_permutation.go
+++ b/pkg/schema/assignment/sorted_permutation.go
@@ -137,10 +137,15 @@ func (p *SortedPermutation) ExpandTrace(tr tr.Trace) error {
 	for i := 0; i < len(p.sources); i++ {
 		src := p.sources[i]
 		// Read column data to initialise permutation.
-		data := columns.Get(src).Data()
+		col := columns.Get(src)
 		// Copy column data to initialise permutation.
-		cols[i] = make([]*fr.Element, len(data))
-		copy(cols[i], data)
+		copy := make([]*fr.Element, col.Height())
+		//
+		for j := 0; j < int(col.Height()); j++ {
+			copy[j] = col.Get(j)
+		}
+		// Copy over
+		cols[i] = copy
 	}
 	// Sort target columns
 	util.PermutationSort(cols, p.signs)

--- a/pkg/schema/constraint/permutation.go
+++ b/pkg/schema/constraint/permutation.go
@@ -78,7 +78,14 @@ func sliceColumns(columns []uint, tr trace.Trace) [][]*fr.Element {
 	// Slice out the data
 	for i, n := range columns {
 		nth := tr.Columns().Get(n)
-		cols[i] = nth.Data()
+		// Copy column data to initialise permutation.
+		copy := make([]*fr.Element, nth.Height())
+		//
+		for j := 0; j < int(nth.Height()); j++ {
+			copy[j] = nth.Get(j)
+		}
+		// Copy over
+		cols[i] = copy
 	}
 	// Done
 	return cols

--- a/pkg/trace/bytes_column.go
+++ b/pkg/trace/bytes_column.go
@@ -96,24 +96,6 @@ func (p *BytesColumn) SetBytes(bytes []byte) {
 	p.bytes = bytes
 }
 
-// Data constructs an array of field elements from this column.
-func (p *BytesColumn) Data() []*fr.Element {
-	data := make([]*fr.Element, p.length)
-	offset := uint(0)
-
-	for i := uint(0); i < p.length; i++ {
-		var ith fr.Element
-		// Calculate position of next element
-		next := offset + uint(p.width)
-		// Construct ith field element
-		data[i] = ith.SetBytes(p.bytes[offset:next])
-		// Move offset to next element
-		offset = next
-	}
-	// Done
-	return data
-}
-
 // Pad this column with n copies of the column's padding value.
 func (p *BytesColumn) Pad(n uint) {
 	// Apply the length multiplier

--- a/pkg/trace/field_column.go
+++ b/pkg/trace/field_column.go
@@ -59,11 +59,6 @@ func (p *FieldColumn) Padding() *fr.Element {
 	return p.padding
 }
 
-// Data returns the data for the given column.
-func (p *FieldColumn) Data() []*fr.Element {
-	return p.data
-}
-
 // Get the value at a given row in this column.  If the row is
 // out-of-bounds, then the column's padding value is returned instead.
 // Thus, this function always succeeds.

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -38,8 +38,6 @@ type ColumnSet interface {
 type Column interface {
 	// Clone this column
 	Clone() Column
-	// Return the raw data stored in this column.
-	Data() []*fr.Element
 	// Get the value at a given row in this column.  If the row is
 	// out-of-bounds, then the column's padding value is returned instead.
 	// Thus, this function always succeeds.


### PR DESCRIPTION
This removes this function as it is currently quite inefficient. However, realistically, we will put it back once native arrays are being used.