### PR TITLE
feat: Support Parallel Trace Expansion

### DIFF
--- a/pkg/test/ir_test.go
+++ b/pkg/test/ir_test.go
@@ -519,7 +519,7 @@ func CheckTraces(t *testing.T, test string, expected bool, expand bool,
 
 func checkTrace(t *testing.T, inputs []trace.RawColumn, expand bool, id traceId, schema sc.Schema) {
 	// Construct the trace
-	tr, errs := sc.NewTraceBuilder(schema).Expand(expand).Padding(id.padding).Build(inputs)
+	tr, errs := sc.NewTraceBuilder(schema).Expand(expand).Padding(id.padding).Parallel(true).Build(inputs)
 	// Sanity check construction
 	if len(errs) > 0 {
 		for _, err := range errs {

--- a/pkg/trace/array_trace.go
+++ b/pkg/trace/array_trace.go
@@ -147,6 +147,11 @@ func EmptyArrayModule(name string) ArrayModule {
 	return ArrayModule{name, math.MaxUint}
 }
 
+// Name returns the name of this module.
+func (p ArrayModule) Name() string {
+	return p.name
+}
+
 // ----------------------------------------------------------------------------
 
 // ArrayColumn describes an individual column of data within a trace table.


### PR DESCRIPTION
This puts in place a relatively straightfoward parallel algorithm for trace expansion using go routines.  Given all the previous refactoring to enable trace expansion to occurr out-of-order, this was relatively easy to implement.  Performance improvements are not substantial, but this is perhaps to be expected given that checking is more compute heavy.