### PR TITLE
Support constraint checking in batches

### DIFF
--- a/pkg/air/eval.go
+++ b/pkg/air/eval.go
@@ -50,9 +50,6 @@ func (e *Sub) EvalAt(k int, tr trace.Trace) *fr.Element {
 func evalExprsAt(k int, tr trace.Trace, exprs []Expr, fn func(*fr.Element, *fr.Element)) *fr.Element {
 	// Evaluate first argument
 	val := exprs[0].EvalAt(k, tr)
-	if val == nil {
-		return nil
-	}
 
 	// Continue evaluating the rest
 	for i := 1; i < len(exprs); i++ {

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"runtime"
 	"strings"
-	"time"
 
 	"github.com/consensys/go-corset/pkg/binfile"
 	"github.com/consensys/go-corset/pkg/hir"
@@ -14,7 +12,6 @@ import (
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/trace/json"
 	"github.com/consensys/go-corset/pkg/trace/lt"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -194,37 +191,4 @@ func maxHeightColumns(cols []trace.RawColumn) uint {
 	}
 	// Done
 	return h
-}
-
-// PerfStats provides a snapshot of memory allocation at a given point in time.
-type PerfStats struct {
-	// Starting time
-	startTime time.Time
-	// Starting total memory allocation
-	startMem uint64
-	// Starting number of gc events
-	startGc uint32
-}
-
-// NewPerfStats creates a new snapshot of the current amount of memory allocated.
-func NewPerfStats() *PerfStats {
-	var m runtime.MemStats
-
-	startTime := time.Now()
-
-	runtime.ReadMemStats(&m)
-
-	return &PerfStats{startTime, m.TotalAlloc, m.NumGC}
-}
-
-// Log logs the difference between the state now and as it was when the PerfStats object was created.
-func (p *PerfStats) Log(prefix string) {
-	var m runtime.MemStats
-
-	runtime.ReadMemStats(&m)
-	alloc := (m.TotalAlloc - p.startMem) / 1024 / 1024 / 1024
-	gcs := m.NumGC - p.startGc
-	exectime := time.Since(p.startTime).Seconds()
-
-	log.Debugf("%s took %0.2fs using %v Gb (%v GC events)", prefix, exectime, alloc, gcs)
 }

--- a/pkg/test/ir_test.go
+++ b/pkg/test/ir_test.go
@@ -527,7 +527,7 @@ func checkTrace(t *testing.T, inputs []trace.RawColumn, expand bool, id traceId,
 		}
 	} else {
 		// Check
-		err := sc.Accepts(schema, tr)
+		err := sc.Accepts(100, schema, tr)
 		// Determine whether trace accepted or not.
 		accepted := (err == nil)
 		// Process what happened versus what was supposed to happen.

--- a/pkg/util/perfstats.go
+++ b/pkg/util/perfstats.go
@@ -1,0 +1,41 @@
+package util
+
+import (
+	"runtime"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// PerfStats provides a snapshot of memory allocation at a given point in time.
+type PerfStats struct {
+	// Starting time
+	startTime time.Time
+	// Starting total memory allocation
+	startMem uint64
+	// Starting number of gc events
+	startGc uint32
+}
+
+// NewPerfStats creates a new snapshot of the current amount of memory allocated.
+func NewPerfStats() *PerfStats {
+	var m runtime.MemStats
+
+	startTime := time.Now()
+
+	runtime.ReadMemStats(&m)
+
+	return &PerfStats{startTime, m.TotalAlloc, m.NumGC}
+}
+
+// Log logs the difference between the state now and as it was when the PerfStats object was created.
+func (p *PerfStats) Log(prefix string) {
+	var m runtime.MemStats
+
+	runtime.ReadMemStats(&m)
+	alloc := (m.TotalAlloc - p.startMem) / 1024 / 1024 / 1024
+	gcs := m.NumGC - p.startGc
+	exectime := time.Since(p.startTime).Seconds()
+
+	log.Debugf("%s took %0.2fs using %v Gb (%v GC events) [%v Gb]", prefix, exectime, alloc, gcs, m.Alloc/1024/1024/1024)
+}


### PR DESCRIPTION
This enables support for constraint checking in batches.  The benefit of using batches is that it can help throttle the number of go-routines being generated and, hence, reduce the overall memory pressure.