### PR TITLE
Reduce Memory Pressure

### DIFF
--- a/pkg/air/eval.go
+++ b/pkg/air/eval.go
@@ -9,54 +9,56 @@ import (
 // value at that row of the column in question or nil is that row is
 // out-of-bounds.
 func (e *ColumnAccess) EvalAt(k int, tr trace.Trace) *fr.Element {
-	val := tr.Column(e.Column).Get(k + e.Shift)
-
-	var clone fr.Element
-	// Clone original value
-	return clone.Set(val)
+	return tr.Column(e.Column).Get(k + e.Shift)
 }
 
 // EvalAt evaluates a constant at a given row in a trace, which simply returns
 // that constant.
 func (e *Constant) EvalAt(k int, tr trace.Trace) *fr.Element {
-	var clone fr.Element
-	// Clone original value
-	return clone.Set(e.Value)
+	return e.Value
 }
 
 // EvalAt evaluates a sum at a given row in a trace by first evaluating all of
 // its arguments at that row.
 func (e *Add) EvalAt(k int, tr trace.Trace) *fr.Element {
-	fn := func(l *fr.Element, r *fr.Element) { l.Add(l, r) }
-	return evalExprsAt(k, tr, e.Args, fn)
+	var val fr.Element
+	// Evaluate first argument
+	val.Set(e.Args[0].EvalAt(k, tr))
+	// Continue evaluating the rest
+	for i := 1; i < len(e.Args); i++ {
+		ith := e.Args[i].EvalAt(k, tr)
+		val.Add(&val, ith)
+	}
+	// Done
+	return &val
 }
 
 // EvalAt evaluates a product at a given row in a trace by first evaluating all of
 // its arguments at that row.
 func (e *Mul) EvalAt(k int, tr trace.Trace) *fr.Element {
-	fn := func(l *fr.Element, r *fr.Element) { l.Mul(l, r) }
-	return evalExprsAt(k, tr, e.Args, fn)
+	var val fr.Element
+	// Evaluate first argument
+	val.Set(e.Args[0].EvalAt(k, tr))
+	// Continue evaluating the rest
+	for i := 1; i < len(e.Args); i++ {
+		ith := e.Args[i].EvalAt(k, tr)
+		val.Mul(&val, ith)
+	}
+	// Done
+	return &val
 }
 
 // EvalAt evaluates a subtraction at a given row in a trace by first evaluating all of
 // its arguments at that row.
 func (e *Sub) EvalAt(k int, tr trace.Trace) *fr.Element {
-	fn := func(l *fr.Element, r *fr.Element) { l.Sub(l, r) }
-	return evalExprsAt(k, tr, e.Args, fn)
-}
-
-// EvalExprsAt evaluates all expressions in a given slice at a given row on the
-// table, and fold their results together using a combinator.
-func evalExprsAt(k int, tr trace.Trace, exprs []Expr, fn func(*fr.Element, *fr.Element)) *fr.Element {
+	var val fr.Element
 	// Evaluate first argument
-	val := exprs[0].EvalAt(k, tr)
-
+	val.Set(e.Args[0].EvalAt(k, tr))
 	// Continue evaluating the rest
-	for i := 1; i < len(exprs); i++ {
-		ith := exprs[i].EvalAt(k, tr)
-		fn(val, ith)
+	for i := 1; i < len(e.Args); i++ {
+		ith := e.Args[i].EvalAt(k, tr)
+		val.Sub(&val, ith)
 	}
-
 	// Done
-	return val
+	return &val
 }


### PR DESCRIPTION
This reduces memory pressure during evaluation by allocating onto the heap lazily.  Specifically, only when an operation is actually being performed.  This appears to make a fairly reasonable improvement.