### PR TITLE
Integration: exports the fields needed by the prover for integration

### DIFF
--- a/pkg/schema/constraint/permutation.go
+++ b/pkg/schema/constraint/permutation.go
@@ -76,6 +76,14 @@ func (p *PermutationConstraint) String() string {
 	return fmt.Sprintf("(permutation (%s) (%s))", targets, sources)
 }
 
+func (p *PermutationConstraint) Targets() []uint {
+	return p.targets
+}
+
+func (p *PermutationConstraint) Sources() []uint {
+	return p.sources
+}
+
 func sliceColumns(columns []uint, tr trace.Trace) []util.FrArray {
 	// Allocate return array
 	cols := make([]util.FrArray, len(columns))

--- a/pkg/schema/constraint/permutation.go
+++ b/pkg/schema/constraint/permutation.go
@@ -76,10 +76,14 @@ func (p *PermutationConstraint) String() string {
 	return fmt.Sprintf("(permutation (%s) (%s))", targets, sources)
 }
 
+// Targets returns the indices of the columns composing the "left" table of the
+// permutation.
 func (p *PermutationConstraint) Targets() []uint {
 	return p.targets
 }
 
+// Sources returns the indices of the columns composing the "right" table of the
+// permutation.
 func (p *PermutationConstraint) Sources() []uint {
 	return p.sources
 }

--- a/pkg/schema/constraint/range.go
+++ b/pkg/schema/constraint/range.go
@@ -59,3 +59,13 @@ func (p *RangeConstraint) Accepts(tr trace.Trace) error {
 func (p *RangeConstraint) String() string {
 	return fmt.Sprintf("(range #%d %s)", p.column, p.bound)
 }
+
+func (p *RangeConstraint) Column() uint {
+	return p.column
+}
+
+// Note: the bound is returned in the form of a uint because this is simpler
+// and more straightforward to understand.
+func (p *RangeConstraint) Bound() uint64 {
+	return p.bound.Uint64()
+}

--- a/pkg/schema/constraint/range.go
+++ b/pkg/schema/constraint/range.go
@@ -60,10 +60,13 @@ func (p *RangeConstraint) String() string {
 	return fmt.Sprintf("(range #%d %s)", p.column, p.bound)
 }
 
+// Column returns the index of the column subjected to the constraint.
 func (p *RangeConstraint) Column() uint {
 	return p.column
 }
 
+// Bound returns the range boundary of the constraint.
+//
 // Note: the bound is returned in the form of a uint because this is simpler
 // and more straightforward to understand.
 func (p *RangeConstraint) Bound() uint64 {

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -75,6 +75,7 @@ type Assignment interface {
 // with an error (or eventually perhaps report a warning).
 type Constraint interface {
 	Accepts(tr.Trace) error
+	String() string
 }
 
 // Evaluable captures something which can be evaluated on a given table row to

--- a/pkg/trace/array_trace.go
+++ b/pkg/trace/array_trace.go
@@ -152,6 +152,12 @@ func (p ArrayModule) Name() string {
 	return p.name
 }
 
+// Height returns the height of this module, meaning the number of assigned
+// rows.
+func (p ArrayModule) Height() uint {
+	return p.height
+}
+
 // ----------------------------------------------------------------------------
 
 // ArrayColumn describes an individual column of data within a trace table.

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -14,6 +14,8 @@ type Trace interface {
 	Width() uint
 	// Returns the height of the given context (i.e. module).
 	Height(Context) uint
+	// Module returns the list of assigned modules and their respective heights
+	Modules() util.Iterator[ArrayModule]
 }
 
 // Column describes an individual column of data within a trace table.


### PR DESCRIPTION
This PR takes part in the prover-corset integration and exposes fields from corset to the prover that are necessary to scan a air.Schema and a trace.Trace from an external package.