### PR TITLE
feat: refactor `Evaluable` to return `fr.Element`

### DIFF
--- a/pkg/air/eval.go
+++ b/pkg/air/eval.go
@@ -8,57 +8,54 @@ import (
 // EvalAt evaluates a column access at a given row in a trace, which returns the
 // value at that row of the column in question or nil is that row is
 // out-of-bounds.
-func (e *ColumnAccess) EvalAt(k int, tr trace.Trace) *fr.Element {
+func (e *ColumnAccess) EvalAt(k int, tr trace.Trace) fr.Element {
 	return tr.Column(e.Column).Get(k + e.Shift)
 }
 
 // EvalAt evaluates a constant at a given row in a trace, which simply returns
 // that constant.
-func (e *Constant) EvalAt(k int, tr trace.Trace) *fr.Element {
+func (e *Constant) EvalAt(k int, tr trace.Trace) fr.Element {
 	return e.Value
 }
 
 // EvalAt evaluates a sum at a given row in a trace by first evaluating all of
 // its arguments at that row.
-func (e *Add) EvalAt(k int, tr trace.Trace) *fr.Element {
-	var val fr.Element
+func (e *Add) EvalAt(k int, tr trace.Trace) fr.Element {
 	// Evaluate first argument
-	val.Set(e.Args[0].EvalAt(k, tr))
+	val := e.Args[0].EvalAt(k, tr)
 	// Continue evaluating the rest
 	for i := 1; i < len(e.Args); i++ {
 		ith := e.Args[i].EvalAt(k, tr)
-		val.Add(&val, ith)
+		val.Add(&val, &ith)
 	}
 	// Done
-	return &val
+	return val
 }
 
 // EvalAt evaluates a product at a given row in a trace by first evaluating all of
 // its arguments at that row.
-func (e *Mul) EvalAt(k int, tr trace.Trace) *fr.Element {
-	var val fr.Element
+func (e *Mul) EvalAt(k int, tr trace.Trace) fr.Element {
 	// Evaluate first argument
-	val.Set(e.Args[0].EvalAt(k, tr))
+	val := e.Args[0].EvalAt(k, tr)
 	// Continue evaluating the rest
 	for i := 1; i < len(e.Args); i++ {
 		ith := e.Args[i].EvalAt(k, tr)
-		val.Mul(&val, ith)
+		val.Mul(&val, &ith)
 	}
 	// Done
-	return &val
+	return val
 }
 
 // EvalAt evaluates a subtraction at a given row in a trace by first evaluating all of
 // its arguments at that row.
-func (e *Sub) EvalAt(k int, tr trace.Trace) *fr.Element {
-	var val fr.Element
+func (e *Sub) EvalAt(k int, tr trace.Trace) fr.Element {
 	// Evaluate first argument
-	val.Set(e.Args[0].EvalAt(k, tr))
+	val := e.Args[0].EvalAt(k, tr)
 	// Continue evaluating the rest
 	for i := 1; i < len(e.Args); i++ {
 		ith := e.Args[i].EvalAt(k, tr)
-		val.Sub(&val, ith)
+		val.Sub(&val, &ith)
 	}
 	// Done
-	return &val
+	return val
 }

--- a/pkg/air/expr.go
+++ b/pkg/air/expr.go
@@ -152,10 +152,10 @@ func (p *Mul) Bounds() util.Bounds { return util.BoundsForArray(p.Args) }
 // ============================================================================
 
 // Constant represents a constant value within an expression.
-type Constant struct{ Value *fr.Element }
+type Constant struct{ Value fr.Element }
 
 // NewConst construct an AIR expression representing a given constant.
-func NewConst(val *fr.Element) Expr {
+func NewConst(val fr.Element) Expr {
 	return &Constant{val}
 }
 
@@ -163,18 +163,7 @@ func NewConst(val *fr.Element) Expr {
 // uint64.
 func NewConst64(val uint64) Expr {
 	element := fr.NewElement(val)
-	return &Constant{&element}
-}
-
-// NewConstCopy construct an AIR expression representing a given constant,
-// and also clones that constant.
-func NewConstCopy(val *fr.Element) Expr {
-	// Create ith term (for final sum)
-	var clone fr.Element
-	// Clone coefficient
-	clone.Set(val)
-	// DOne
-	return &Constant{&clone}
+	return &Constant{element}
 }
 
 // Context determines the evaluation context (i.e. enclosing module) for this

--- a/pkg/air/gadgets/bits.go
+++ b/pkg/air/gadgets/bits.go
@@ -49,7 +49,7 @@ func ApplyBitwidthGadget(col uint, nbits uint, schema *air.Schema) {
 	// Construct Columns
 	for i := uint(0); i < n; i++ {
 		// Create Column + Constraint
-		es[i] = air.NewColumnAccess(index+i, 0).Mul(air.NewConstCopy(&coefficient))
+		es[i] = air.NewColumnAccess(index+i, 0).Mul(air.NewConst(coefficient))
 
 		schema.AddRangeConstraint(index+i, &fr256)
 		// Update coefficient

--- a/pkg/air/gadgets/normalisation.go
+++ b/pkg/air/gadgets/normalisation.go
@@ -72,11 +72,14 @@ type Inverse struct{ Expr air.Expr }
 
 // EvalAt computes the multiplicative inverse of a given expression at a given
 // row in the table.
-func (e *Inverse) EvalAt(k int, tbl tr.Trace) *fr.Element {
-	inv := new(fr.Element)
+func (e *Inverse) EvalAt(k int, tbl tr.Trace) fr.Element {
+	var inv fr.Element
+
 	val := e.Expr.EvalAt(k, tbl)
 	// Go syntax huh?
-	return inv.Inverse(val)
+	inv.Inverse(&val)
+	// Done
+	return inv
 }
 
 // Bounds returns max shift in either the negative (left) or positive

--- a/pkg/binfile/expr.go
+++ b/pkg/binfile/expr.go
@@ -101,9 +101,9 @@ func (e *jsonExprConst) ToHir(schema *hir.Schema) hir.Expr {
 		panic(fmt.Sprintf("Unknown BigInt sign: %d", sign))
 	}
 	// Construct Field Value
-	num := new(fr.Element)
-	num.SetBigInt(val)
+	var num fr.Element
 
+	num.SetBigInt(val)
 	// Done!
 	return &hir.Constant{Val: num}
 }

--- a/pkg/cmd/check.go
+++ b/pkg/cmd/check.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"math"
 	"os"
 
 	"github.com/consensys/go-corset/pkg/hir"
@@ -243,7 +244,7 @@ func validateColumn(colType sc.Type, col trace.Column, mod sc.Module) error {
 		jth := col.Get(j)
 		if !colType.Accept(jth) {
 			qualColName := trace.QualifiedColumnName(mod.Name(), col.Name())
-			return fmt.Errorf("row %d of column %s is out-of-bounds (%s)", j, qualColName, jth)
+			return fmt.Errorf("row %d of column %s is out-of-bounds (%s)", j, qualColName, jth.String())
 		}
 	}
 	// success
@@ -284,7 +285,7 @@ func init() {
 	checkCmd.Flags().BoolP("quiet", "q", false, "suppress output (e.g. warnings)")
 	checkCmd.Flags().Bool("sequential", false, "perform sequential trace expansion")
 	checkCmd.Flags().Uint("padding", 0, "specify amount of (front) padding to apply")
-	checkCmd.Flags().UintP("batch", "b", 1000, "specify batch size for constraint checking")
+	checkCmd.Flags().UintP("batch", "b", math.MaxUint, "specify batch size for constraint checking")
 	checkCmd.Flags().Int("spillage", -1,
 		"specify amount of splillage to account for (where -1 indicates this should be inferred)")
 }

--- a/pkg/cmd/trace.go
+++ b/pkg/cmd/trace.go
@@ -96,7 +96,8 @@ func printTrace(start uint, end uint, max_width uint, cols []trace.RawColumn) {
 		if start < ith.Len() {
 			ith_height := min(ith.Len(), end) - start
 			for j := uint(0); j < ith_height; j++ {
-				tbl.Set(j+1, i+1, ith.Get(j+start).String())
+				jth := ith.Get(j + start)
+				tbl.Set(j+1, i+1, jth.String())
 			}
 		}
 	}

--- a/pkg/hir/expr.go
+++ b/pkg/hir/expr.go
@@ -30,7 +30,7 @@ type Expr interface {
 	// undefined for several reasons: firstly, if it accesses a
 	// row which does not exist (e.g. at index -1); secondly, if
 	// it accesses a column which does not exist.
-	EvalAllAt(int, trace.Trace) []*fr.Element
+	EvalAllAt(int, trace.Trace) []fr.Element
 	// String produces a string representing this as an S-Expression.
 	String() string
 }
@@ -171,7 +171,7 @@ func (p *List) RequiredColumns() *util.SortedSet[uint] {
 // ============================================================================
 
 // Constant represents a constant value within an expression.
-type Constant struct{ Val *fr.Element }
+type Constant struct{ Val fr.Element }
 
 // Bounds returns max shift in either the negative (left) or positive
 // direction (right).  A constant has zero shift.

--- a/pkg/hir/lower.go
+++ b/pkg/hir/lower.go
@@ -223,13 +223,10 @@ func extractIfZeroCondition(e *IfZero, schema *mir.Schema) mir.Expr {
 		panic(fmt.Sprintf("unexpanded expression (%s)", e.String()))
 	} else if e.TrueBranch != nil {
 		// (1 - NORM(cb)) for true branch
-		one := new(fr.Element)
-		one.SetOne()
-
 		normBody := &mir.Normalise{Arg: cb}
 		oneMinusNormBody := &mir.Sub{
 			Args: []mir.Expr{
-				&mir.Constant{Value: one},
+				&mir.Constant{Value: fr.One()},
 				normBody,
 			},
 		}

--- a/pkg/hir/parser.go
+++ b/pkg/hir/parser.go
@@ -443,15 +443,15 @@ func beginParserRule(args []Expr) (Expr, error) {
 
 func constantParserRule(symbol string) (Expr, bool, error) {
 	if symbol[0] >= '0' && symbol[0] < '9' {
-		num := new(fr.Element)
+		var num fr.Element
 		// Attempt to parse
-		c, err := num.SetString(symbol)
+		_, err := num.SetString(symbol)
 		// Check for errors
 		if err != nil {
 			return nil, true, err
 		}
 		// Done
-		return &Constant{Val: c}, true, nil
+		return &Constant{Val: num}, true, nil
 	}
 	// Not applicable
 	return nil, false, nil

--- a/pkg/hir/util.go
+++ b/pkg/hir/util.go
@@ -26,7 +26,7 @@ func (p ZeroArrayTest) TestAt(row int, tr trace.Trace) bool {
 	vals := p.Expr.EvalAllAt(row, tr)
 	// Check each value in turn against zero.
 	for _, val := range vals {
-		if val != nil && !val.IsZero() {
+		if !val.IsZero() {
 			// This expression does not evaluat to zero, hence failure.
 			return false
 		}
@@ -84,7 +84,7 @@ func NewUnitExpr(expr Expr) UnitExpr {
 // EvalAt evaluates a column access at a given row in a trace, which returns the
 // value at that row of the column in question or nil is that row is
 // out-of-bounds.
-func (e UnitExpr) EvalAt(k int, tr trace.Trace) *fr.Element {
+func (e UnitExpr) EvalAt(k int, tr trace.Trace) fr.Element {
 	vals := e.expr.EvalAllAt(k, tr)
 	// Check we got exactly one thing
 	if len(vals) == 1 {

--- a/pkg/mir/eval.go
+++ b/pkg/mir/eval.go
@@ -9,43 +9,51 @@ import (
 // EvalAt evaluates a column access at a given row in a trace, which returns the
 // value at that row of the column in question or nil is that row is
 // out-of-bounds.
-func (e *ColumnAccess) EvalAt(k int, tr trace.Trace) *fr.Element {
-	val := tr.Column(e.Column).Get(k + e.Shift)
-
-	var clone fr.Element
-	// Clone original value
-	return clone.Set(val)
+func (e *ColumnAccess) EvalAt(k int, tr trace.Trace) fr.Element {
+	return tr.Column(e.Column).Get(k + e.Shift)
 }
 
 // EvalAt evaluates a constant at a given row in a trace, which simply returns
 // that constant.
-func (e *Constant) EvalAt(k int, tr trace.Trace) *fr.Element {
-	var clone fr.Element
-	// Clone original value
-	return clone.Set(e.Value)
+func (e *Constant) EvalAt(k int, tr trace.Trace) fr.Element {
+	return e.Value
 }
 
 // EvalAt evaluates a sum at a given row in a trace by first evaluating all of
 // its arguments at that row.
-func (e *Add) EvalAt(k int, tr trace.Trace) *fr.Element {
-	fn := func(l *fr.Element, r *fr.Element) { l.Add(l, r) }
-	return evalExprsAt(k, tr, e.Args, fn)
+func (e *Add) EvalAt(k int, tr trace.Trace) fr.Element {
+	// Evaluate first argument
+	val := e.Args[0].EvalAt(k, tr)
+	// Continue evaluating the rest
+	for i := 1; i < len(e.Args); i++ {
+		ith := e.Args[i].EvalAt(k, tr)
+		val.Add(&val, &ith)
+	}
+
+	return val
 }
 
 // EvalAt evaluates a product at a given row in a trace by first evaluating all of
 // its arguments at that row.
-func (e *Mul) EvalAt(k int, tr trace.Trace) *fr.Element {
-	fn := func(l *fr.Element, r *fr.Element) { l.Mul(l, r) }
-	return evalExprsAt(k, tr, e.Args, fn)
+func (e *Mul) EvalAt(k int, tr trace.Trace) fr.Element {
+	// Evaluate first argument
+	val := e.Args[0].EvalAt(k, tr)
+	// Continue evaluating the rest
+	for i := 1; i < len(e.Args); i++ {
+		ith := e.Args[i].EvalAt(k, tr)
+		val.Mul(&val, &ith)
+	}
+
+	return val
 }
 
 // EvalAt evaluates a product at a given row in a trace by first evaluating all of
 // its arguments at that row.
-func (e *Exp) EvalAt(k int, tr trace.Trace) *fr.Element {
+func (e *Exp) EvalAt(k int, tr trace.Trace) fr.Element {
 	// Check whether argument evaluates to zero or not.
 	val := e.Arg.EvalAt(k, tr)
 	// Compute exponent
-	util.Pow(val, e.Pow)
+	util.Pow(&val, e.Pow)
 	// Done
 	return val
 }
@@ -53,7 +61,7 @@ func (e *Exp) EvalAt(k int, tr trace.Trace) *fr.Element {
 // EvalAt evaluates the normalisation of some expression by first evaluating
 // that expression.  Then, zero is returned if the result is zero; otherwise one
 // is returned.
-func (e *Normalise) EvalAt(k int, tr trace.Trace) *fr.Element {
+func (e *Normalise) EvalAt(k int, tr trace.Trace) fr.Element {
 	// Check whether argument evaluates to zero or not.
 	val := e.Arg.EvalAt(k, tr)
 	// Normalise value (if necessary)
@@ -66,21 +74,13 @@ func (e *Normalise) EvalAt(k int, tr trace.Trace) *fr.Element {
 
 // EvalAt evaluates a subtraction at a given row in a trace by first evaluating all of
 // its arguments at that row.
-func (e *Sub) EvalAt(k int, tr trace.Trace) *fr.Element {
-	fn := func(l *fr.Element, r *fr.Element) { l.Sub(l, r) }
-	return evalExprsAt(k, tr, e.Args, fn)
-}
-
-// Evaluate all expressions in a given slice at a given row on the
-// table, and fold their results together using a combinator.
-func evalExprsAt(k int, tr trace.Trace, exprs []Expr, fn func(*fr.Element, *fr.Element)) *fr.Element {
+func (e *Sub) EvalAt(k int, tr trace.Trace) fr.Element {
 	// Evaluate first argument
-	val := exprs[0].EvalAt(k, tr)
+	val := e.Args[0].EvalAt(k, tr)
 	// Continue evaluating the rest
-	for i := 1; i < len(exprs); i++ {
-		ith := exprs[i].EvalAt(k, tr)
-
-		fn(val, ith)
+	for i := 1; i < len(e.Args); i++ {
+		ith := e.Args[i].EvalAt(k, tr)
+		val.Sub(&val, &ith)
 	}
 	// Done
 	return val

--- a/pkg/mir/expr.go
+++ b/pkg/mir/expr.go
@@ -129,7 +129,7 @@ func (p *Exp) RequiredColumns() *util.SortedSet[uint] {
 // ============================================================================
 
 // Constant represents a constant value within an expression.
-type Constant struct{ Value *fr.Element }
+type Constant struct{ Value fr.Element }
 
 // Bounds returns max shift in either the negative (left) or positive
 // direction (right).  A constant has zero shift.

--- a/pkg/schema/assignment/byte_decomposition.go
+++ b/pkg/schema/assignment/byte_decomposition.go
@@ -105,29 +105,20 @@ func (p *ByteDecomposition) Dependencies() []uint {
 
 // Decompose a given element into n bytes in little endian form.  For example,
 // decomposing 41b into 2 bytes gives [0x1b,0x04].
-func decomposeIntoBytes(val *fr.Element, n int) []*fr.Element {
+func decomposeIntoBytes(val fr.Element, n int) []fr.Element {
 	// Construct return array
-	elements := make([]*fr.Element, n)
+	elements := make([]fr.Element, n)
 
-	if val == nil {
-		// Special case where value being decomposed is actually undefined (i.e.
-		// because its before the start of the table).  In this case, we assume
-		// a default decomposition of zero.
-		for i := 0; i < n; i++ {
-			ith := fr.NewElement(0)
-			elements[i] = &ith
-		}
-	} else {
-		// Determine bytes of this value (in big endian form).
-		bytes := val.Bytes()
-		m := len(bytes) - 1
-		// Convert each byte into a field element
-		for i := 0; i < n; i++ {
-			j := m - i
-			ith := fr.NewElement(uint64(bytes[j]))
-			elements[i] = &ith
-		}
+	// Determine bytes of this value (in big endian form).
+	bytes := val.Bytes()
+	m := len(bytes) - 1
+	// Convert each byte into a field element
+	for i := 0; i < n; i++ {
+		j := m - i
+		ith := fr.NewElement(uint64(bytes[j]))
+		elements[i] = ith
 	}
+
 	// Done
 	return elements
 }

--- a/pkg/schema/assignment/computed_column.go
+++ b/pkg/schema/assignment/computed_column.go
@@ -3,7 +3,6 @@ package assignment
 import (
 	"fmt"
 
-	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	sc "github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
@@ -83,12 +82,7 @@ func (p *ComputedColumn[E]) ComputeColumns(tr trace.Trace) ([]trace.ArrayColumn,
 	// Expand the trace
 	for i := uint(0); i < data.Len(); i++ {
 		val := p.expr.EvalAt(int(i), tr)
-		if val != nil {
-			data.Set(i, val)
-		} else {
-			zero := fr.NewElement(0)
-			data.Set(i, &zero)
-		}
+		data.Set(i, val)
 	}
 	// Determine padding value.  A negative row index is used here to ensure
 	// that all columns return their padding value which is then used to compute

--- a/pkg/schema/assignment/lexicographic_sort.go
+++ b/pkg/schema/assignment/lexicographic_sort.go
@@ -84,41 +84,41 @@ func (p *LexicographicSort) ComputeColumns(tr trace.Trace) ([]trace.ArrayColumn,
 	bit_width := uint(0)
 	//
 	delta := util.NewFrArray(nrows, bit_width)
-	cols[0] = trace.NewArrayColumn(first.Context(), first.Name(), delta, &zero)
+	cols[0] = trace.NewArrayColumn(first.Context(), first.Name(), delta, zero)
 	//
 	for i := 0; i < nbits; i++ {
 		target := p.targets[1+i]
 		source := tr.Column(p.sources[i])
 		data := util.NewFrArray(nrows, 1)
-		cols[i+1] = trace.NewArrayColumn(target.Context(), target.Name(), data, &zero)
+		cols[i+1] = trace.NewArrayColumn(target.Context(), target.Name(), data, zero)
 		bit_width = max(bit_width, source.Data().BitWidth())
 	}
 
 	for i := uint(0); i < nrows; i++ {
 		set := false
 		// Initialise delta to zero
-		delta.Set(i, &zero)
+		delta.Set(i, zero)
 		// Decide which row is the winner (if any)
 		for j := 0; j < nbits; j++ {
 			prev := tr.Column(p.sources[j]).Get(int(i - 1))
 			curr := tr.Column(p.sources[j]).Get(int(i))
 
-			if !set && prev != nil && prev.Cmp(curr) != 0 {
+			if !set && prev.Cmp(&curr) != 0 {
 				var diff fr.Element
 
-				cols[j+1].Data().Set(i, &one)
+				cols[j+1].Data().Set(i, one)
 				// Compute curr - prev
 				if p.signs[j] {
-					diff.Set(curr)
-					delta.Set(i, diff.Sub(&diff, prev))
+					diff.Set(&curr)
+					delta.Set(i, *diff.Sub(&diff, &prev))
 				} else {
-					diff.Set(prev)
-					delta.Set(i, diff.Sub(&diff, curr))
+					diff.Set(&prev)
+					delta.Set(i, *diff.Sub(&diff, &curr))
 				}
 
 				set = true
 			} else {
-				cols[j+1].Data().Set(i, &zero)
+				cols[j+1].Data().Set(i, zero)
 			}
 		}
 	}

--- a/pkg/schema/builder.go
+++ b/pkg/schema/builder.go
@@ -162,7 +162,7 @@ func (tb TraceBuilder) initialiseTraceColumns() ([]trace.ArrayColumn, map[column
 // Fill columns in the corresponding trace from the given input columns
 func fillTraceColumns(modmap map[string]uint, colmap map[columnKey]uint,
 	cols []trace.RawColumn, tr *trace.ArrayTrace) []error {
-	var zero fr.Element = fr.NewElement((0))
+	var zero fr.Element = fr.NewElement(0)
 	// Errs contains the set of filling errors which are accumulated
 	var errs []error
 	// Assign data from each input column given
@@ -185,7 +185,7 @@ func fillTraceColumns(modmap map[string]uint, colmap map[columnKey]uint,
 				errs = append(errs, fmt.Errorf("duplicate column '%s' in trace", c.QualifiedName()))
 			} else {
 				// Assign data
-				tr.FillColumn(cid, c.Data, &zero)
+				tr.FillColumn(cid, c.Data, zero)
 			}
 		}
 	}
@@ -194,7 +194,7 @@ func fillTraceColumns(modmap map[string]uint, colmap map[columnKey]uint,
 }
 
 func validateTraceColumns(schema Schema, tr *trace.ArrayTrace) (error, []error) {
-	var zero fr.Element = fr.NewElement((0))
+	var zero fr.Element = fr.NewElement(0)
 	// Determine how many input columns to expect
 	ninputs := schema.InputColumns().Count()
 	warnings := []error{}
@@ -215,7 +215,7 @@ func validateTraceColumns(schema Schema, tr *trace.ArrayTrace) (error, []error) 
 			// Ok, treat as warning
 			warnings = append(warnings, err)
 			// Fill with a column of height zero.
-			tr.FillColumn(i, util.NewFrArray(0, 256), &zero)
+			tr.FillColumn(i, util.NewFrArray(0, 256), zero)
 		}
 	}
 	// Done

--- a/pkg/schema/constraint/range.go
+++ b/pkg/schema/constraint/range.go
@@ -44,7 +44,7 @@ func (p *RangeConstraint) Accepts(tr trace.Trace) error {
 		// Get the value on the kth row
 		kth := column.Get(k)
 		// Perform the bounds check
-		if kth != nil && kth.Cmp(p.bound) >= 0 {
+		if kth.Cmp(p.bound) >= 0 {
 			name := column.Name()
 			// Construct useful error message
 			msg := fmt.Sprintf("value out-of-bounds (row %d, %s)", kth, name)

--- a/pkg/schema/constraint/type.go
+++ b/pkg/schema/constraint/type.go
@@ -47,7 +47,7 @@ func (p *TypeConstraint) Accepts(tr trace.Trace) error {
 		// Get the value on the kth row
 		kth := column.Get(k)
 		// Perform the type check
-		if kth != nil && !p.expected.Accept(kth) {
+		if !p.expected.Accept(kth) {
 			name := column.Name()
 			// Construct useful error message
 			msg := fmt.Sprintf("value out-of-bounds (row %d, %s)", kth, name)

--- a/pkg/schema/constraint/vanishing.go
+++ b/pkg/schema/constraint/vanishing.go
@@ -20,7 +20,7 @@ type ZeroTest[E sc.Evaluable] struct {
 // Observe that if the expression is undefined, then it is assumed not to hold.
 func (p ZeroTest[E]) TestAt(row int, tr trace.Trace) bool {
 	val := p.Expr.EvalAt(row, tr)
-	return val != nil && val.IsZero()
+	return val.IsZero()
 }
 
 // Bounds determines the bounds for this zero test.

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -91,7 +91,7 @@ type Evaluable interface {
 	// undefined for several reasons: firstly, if it accesses a
 	// row which does not exist (e.g. at index -1); secondly, if
 	// it accesses a column which does not exist.
-	EvalAt(int, tr.Trace) *fr.Element
+	EvalAt(int, tr.Trace) fr.Element
 }
 
 // Testable captures the notion of a constraint which can be tested on a given

--- a/pkg/schema/type.go
+++ b/pkg/schema/type.go
@@ -18,7 +18,7 @@ type Type interface {
 	// field element, then this returns nil.
 	AsField() *FieldType
 	// Accept checks whether a specific value is accepted by this type
-	Accept(*fr.Element) bool
+	Accept(fr.Element) bool
 	// Return the number of bytes required represent any element of this type.
 	ByteWidth() uint
 	// Return the minimum number of bits required represent any element of this type.
@@ -75,7 +75,7 @@ func (p *UintType) ByteWidth() uint {
 
 // Accept determines whether a given value is an element of this type.  For
 // example, 123 is an element of the type u8 whilst 256 is not.
-func (p *UintType) Accept(val *fr.Element) bool {
+func (p *UintType) Accept(val fr.Element) bool {
 	return val.Cmp(p.bound) < 0
 }
 
@@ -132,7 +132,7 @@ func (p *FieldType) BitWidth() uint {
 
 // Accept determines whether a given value is an element of this type.  In
 // fact, all field elements are members of this type.
-func (p *FieldType) Accept(val *fr.Element) bool {
+func (p *FieldType) Accept(val fr.Element) bool {
 	return true
 }
 

--- a/pkg/trace/array_trace.go
+++ b/pkg/trace/array_trace.go
@@ -49,7 +49,7 @@ func (p *ArrayTrace) Column(cid uint) Column {
 
 // FillColumn sets the data and padding for the given column.  This will panic
 // if the data is already set.
-func (p *ArrayTrace) FillColumn(cid uint, data util.FrArray, padding *fr.Element) {
+func (p *ArrayTrace) FillColumn(cid uint, data util.FrArray, padding fr.Element) {
 	// Find column to fill
 	col := &p.columns[cid]
 	// Find enclosing module
@@ -117,11 +117,7 @@ func (p *ArrayTrace) String() string {
 					id.WriteString(",")
 				}
 
-				if jth == nil {
-					id.WriteString("_")
-				} else {
-					id.WriteString(jth.String())
-				}
+				id.WriteString(jth.String())
 			}
 			id.WriteString("}")
 		}
@@ -169,12 +165,12 @@ type ArrayColumn struct {
 	// Holds the raw data making up this column
 	data util.FrArray
 	// Value to be used when padding this column
-	padding *fr.Element
+	padding fr.Element
 }
 
 // NewArrayColumn constructs a  with the give name, data and padding.
 func NewArrayColumn(context Context, name string, data util.FrArray,
-	padding *fr.Element) ArrayColumn {
+	padding fr.Element) ArrayColumn {
 	col := EmptyArrayColumn(context, name)
 	col.fill(data, padding)
 	//
@@ -183,7 +179,7 @@ func NewArrayColumn(context Context, name string, data util.FrArray,
 
 // EmptyArrayColumn constructs a  with the give name, data and padding.
 func EmptyArrayColumn(context Context, name string) ArrayColumn {
-	return ArrayColumn{context, name, nil, nil}
+	return ArrayColumn{context, name, nil, fr.NewElement(0)}
 }
 
 // Context returns the evaluation context this column provides.
@@ -202,7 +198,7 @@ func (p *ArrayColumn) Height() uint {
 }
 
 // Padding returns the value which will be used for padding this column.
-func (p *ArrayColumn) Padding() *fr.Element {
+func (p *ArrayColumn) Padding() fr.Element {
 	return p.padding
 }
 
@@ -214,7 +210,7 @@ func (p *ArrayColumn) Data() util.FrArray {
 // Get the value at a given row in this column.  If the row is
 // out-of-bounds, then the column's padding value is returned instead.
 // Thus, this function always succeeds.
-func (p *ArrayColumn) Get(row int) *fr.Element {
+func (p *ArrayColumn) Get(row int) fr.Element {
 	if row < 0 || uint(row) >= p.data.Len() {
 		// out-of-bounds access
 		return p.padding
@@ -223,7 +219,7 @@ func (p *ArrayColumn) Get(row int) *fr.Element {
 	return p.data.Get(uint(row))
 }
 
-func (p *ArrayColumn) fill(data util.FrArray, padding *fr.Element) {
+func (p *ArrayColumn) fill(data util.FrArray, padding fr.Element) {
 	// Sanity check this column has not already been filled.
 	if p.data != nil {
 		panic(fmt.Sprintf("computed column %s has already been filled", p.name))

--- a/pkg/trace/json/writer.go
+++ b/pkg/trace/json/writer.go
@@ -34,7 +34,8 @@ func ToJsonString(columns []trace.RawColumn) string {
 				builder.WriteString(", ")
 			}
 
-			builder.WriteString(data.Get(j).String())
+			jth := data.Get(j)
+			builder.WriteString(jth.String())
 		}
 		builder.WriteString("]")
 	}

--- a/pkg/trace/lt/reader.go
+++ b/pkg/trace/lt/reader.go
@@ -104,8 +104,10 @@ func readColumnData(header columnHeader, bytes []byte) util.FrArray {
 		var ith fr.Element
 		// Calculate position of next element
 		next := offset + header.width
+		// Initialise element
+		ith.SetBytes(bytes[offset:next])
 		// Construct ith field element
-		data.Set(i, ith.SetBytes(bytes[offset:next]))
+		data.Set(i, ith)
 		// Move offset to next element
 		offset = next
 	}

--- a/pkg/trace/printer.go
+++ b/pkg/trace/printer.go
@@ -32,7 +32,8 @@ func traceColumnData(tr Trace, col uint) []string {
 	data[1] = tr.Column(col).Name()
 
 	for row := 0; row < int(n); row++ {
-		data[row+2] = tr.Column(col).Get(row).String()
+		ith := tr.Column(col).Get(row)
+		data[row+2] = ith.String()
 	}
 
 	return data

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -27,12 +27,12 @@ type Column interface {
 	// Get the value at a given row in this column.  If the row is
 	// out-of-bounds, then the column's padding value is returned instead.
 	// Thus, this function always succeeds.
-	Get(row int) *fr.Element
+	Get(row int) fr.Element
 	// Access the underlying data array for this column.  This is useful in
 	// situations where we want to clone the entire column, etc.
 	Data() util.FrArray
 	// Value to be used when padding this column
-	Padding() *fr.Element
+	Padding() fr.Element
 }
 
 // RawColumn represents a raw column of data which has not (yet) been indexed as

--- a/pkg/util/field_pool.go
+++ b/pkg/util/field_pool.go
@@ -10,10 +10,10 @@ import (
 // duplication of elements.
 type FrPool[K any] interface {
 	// Allocate an item into the pool, returning its index.
-	Put(*fr.Element) K
+	Put(fr.Element) K
 
 	// Lookup a given item in the pool using an index.
-	Get(K) *fr.Element
+	Get(K) fr.Element
 }
 
 // ----------------------------------------------------------------------------
@@ -31,25 +31,25 @@ func NewFrMapPool(bitwidth uint) FrMapPool {
 }
 
 // Get looks up the given item in the pool.
-func (p FrMapPool) Get(index uint32) *fr.Element {
+func (p FrMapPool) Get(index uint32) fr.Element {
 	poolMapLock.RLock()
-	item := &poolMapArray[index]
+	item := poolMapArray[index]
 	poolMapLock.RUnlock()
 
 	return item
 }
 
 // Put allocates an item into the pool, returning its index.
-func (p FrMapPool) Put(element *fr.Element) uint32 {
+func (p FrMapPool) Put(element fr.Element) uint32 {
 	// Lock items
 	poolMapLock.Lock()
-	index, ok := poolMapIndex[*element]
+	index, ok := poolMapIndex[element]
 	//
 	if !ok {
 		len := uint32(len(poolMapArray))
 		index = poolMapSize
 		// Update index
-		poolMapIndex[*element] = index
+		poolMapIndex[element] = index
 		//
 		if index == len {
 			// capacity reached, so double it.
@@ -58,7 +58,7 @@ func (p FrMapPool) Put(element *fr.Element) uint32 {
 			poolMapArray = tmp
 		}
 		//
-		poolMapArray[index] = *element
+		poolMapArray[index] = element
 		poolMapSize++
 	}
 	// Done
@@ -97,17 +97,17 @@ func NewFrBitPool() FrBitPool {
 }
 
 // Get looks up the given item in the pool.
-func (p FrBitPool) Get(index bool) *fr.Element {
+func (p FrBitPool) Get(index bool) fr.Element {
 	if index {
-		return &pool16bit[1]
+		return pool16bit[1]
 	}
 	//
-	return &pool16bit[0]
+	return pool16bit[0]
 }
 
 // Put allocates an item into the pool, returning its index.  Since the pool is
 // fixed, then so is the index.
-func (p FrBitPool) Put(element *fr.Element) bool {
+func (p FrBitPool) Put(element fr.Element) bool {
 	val := element.Uint64()
 	// Sanity checks
 	if !element.IsUint64() || val >= 2 {
@@ -134,13 +134,13 @@ func NewFrIndexPool[K uint8 | uint16]() FrIndexPool[K] {
 }
 
 // Get looks up the given item in the pool.
-func (p FrIndexPool[K]) Get(index K) *fr.Element {
-	return &pool16bit[index]
+func (p FrIndexPool[K]) Get(index K) fr.Element {
+	return pool16bit[index]
 }
 
 // Put allocates an item into the pool, returning its index.  Since the pool is
 // fixed, then so is the index.
-func (p FrIndexPool[K]) Put(element *fr.Element) K {
+func (p FrIndexPool[K]) Put(element fr.Element) K {
 	val := element.Uint64()
 	// Sanity checks
 	if !element.IsUint64() || val >= 65536 {

--- a/pkg/util/fields.go
+++ b/pkg/util/fields.go
@@ -29,7 +29,7 @@ func Pow(val *fr.Element, n uint64) {
 }
 
 // FrElementToBytes converts a given field element into a slice of 32 bytes.
-func FrElementToBytes(element *fr.Element) [32]byte {
+func FrElementToBytes(element fr.Element) [32]byte {
 	// Each fr.Element is 4 x 64bit words.
 	var bytes [32]byte
 	// Copy over each element

--- a/pkg/util/permutation.go
+++ b/pkg/util/permutation.go
@@ -16,7 +16,7 @@ import (
 //
 // This function operators by cloning the arrays, sorting them and checking they
 // are the same.
-func ArePermutationOf[T Array[*fr.Element]](dst []T, src []T) bool {
+func ArePermutationOf[T Array[fr.Element]](dst []T, src []T) bool {
 	if len(dst) != len(src) {
 		return false
 	}
@@ -61,7 +61,7 @@ func permutationFunc(lhs []fr.Element, rhs []fr.Element) int {
 // NOTE: the current implementation is not intended to be particularly
 // efficient.  In particular, would be better to do the sort directly
 // on the columns array without projecting into the row-wise form.
-func PermutationSort[T Array[*fr.Element]](cols []T, signs []bool) {
+func PermutationSort[T Array[fr.Element]](cols []T, signs []bool) {
 	n := cols[0].Len()
 	m := len(cols)
 	// Rotate input matrix
@@ -74,7 +74,7 @@ func PermutationSort[T Array[*fr.Element]](cols []T, signs []bool) {
 	for i := uint(0); i < n; i++ {
 		row := rows[i]
 		for j := 0; j < m; j++ {
-			cols[j].Set(i, &row[j])
+			cols[j].Set(i, row[j])
 		}
 	}
 }
@@ -123,14 +123,14 @@ func permutationSortFunc(lhs []fr.Element, rhs []fr.Element, signs []bool) int {
 }
 
 // Clone and rotate a 2-dimensional array assuming a given geometry.
-func rotate[T Array[*fr.Element]](src []T, ncols int, nrows uint) [][]fr.Element {
+func rotate[T Array[fr.Element]](src []T, ncols int, nrows uint) [][]fr.Element {
 	// Copy outer arrays
 	dst := make([][]fr.Element, nrows)
 	// Copy inner arrays
 	for i := uint(0); i < nrows; i++ {
 		row := make([]fr.Element, ncols)
 		for j := 0; j < ncols; j++ {
-			row[j] = *src[j].Get(i)
+			row[j] = src[j].Get(i)
 		}
 
 		dst[i] = row


### PR DESCRIPTION
This makes a fairly large change to the handling of values being moved around to reduce the amount loaded onto the heap.  For example, the `Evaluable` interface now returns `fr.Element` rather than `*fr.Element`.  However, the changes are far wider reaching than this, since in many other places `*fr.Element` was being used where `fr.Element` could be.