### PR TITLE
Declare `air.PermutationConstraint`

### DIFF
--- a/pkg/air/schema.go
+++ b/pkg/air/schema.go
@@ -22,6 +22,10 @@ type LookupConstraint = *constraint.LookupConstraint[*ColumnAccess]
 // VanishingConstraint captures the essence of a vanishing constraint at the AIR level.
 type VanishingConstraint = *constraint.VanishingConstraint[constraint.ZeroTest[Expr]]
 
+// PermutationConstraint captures the essence of a permutation constraint at the AIR level.
+// Specifically, it represents a constraint that one (or more) columns are a permutation of another.
+type PermutationConstraint = *constraint.PermutationConstraint
+
 // PropertyAssertion captures the notion of an arbitrary property which should
 // hold for all acceptable traces.  However, such a property is not enforced by
 // the prover.

--- a/pkg/schema/constraint/permutation.go
+++ b/pkg/schema/constraint/permutation.go
@@ -8,7 +8,7 @@ import (
 	"github.com/consensys/go-corset/pkg/util"
 )
 
-// PermutationConstraint declares a constraint that one column is a permutation
+// PermutationConstraint declares a constraint that one (or more) columns are a permutation
 // of another.
 type PermutationConstraint struct {
 	// The target columns


### PR DESCRIPTION
The goal of this is purely to make a clean separation from the generic `constraint.PermutationConstraint` and the specific `air.PermutationConstraint`.