### PR TITLE
Enable filter using regex

### DIFF
--- a/pkg/cmd/debug.go
+++ b/pkg/cmd/debug.go
@@ -106,6 +106,7 @@ func printStats(hirSchema *hir.Schema, hir bool, mir bool, air bool) {
 		for j := 0; j < len(schemas); j++ {
 			row[j+1] = ith.summary(schemas[j])
 		}
+
 		tbl.SetRow(i, row...)
 	}
 	//

--- a/pkg/test/ir_test.go
+++ b/pkg/test/ir_test.go
@@ -553,14 +553,12 @@ func checkTrace(t *testing.T, inputs []trace.RawColumn, expand bool, id traceId,
 		// Process what happened versus what was supposed to happen.
 		if !accepted && id.expected {
 			//table.PrintTrace(tr)
-			msg := fmt.Sprintf("Trace rejected incorrectly (%s, %s.accepts, line %d with padding %d): %s",
+			t.Errorf("Trace rejected incorrectly (%s, %s.accepts, line %d with padding %d): %s",
 				id.ir, id.test, id.line, id.padding, errs)
-			t.Errorf(msg)
 		} else if accepted && !id.expected {
 			//printTrace(tr)
-			msg := fmt.Sprintf("Trace accepted incorrectly (%s, %s.rejects, line %d with padding %d)",
+			t.Errorf("Trace accepted incorrectly (%s, %s.rejects, line %d with padding %d)",
 				id.ir, id.test, id.line, id.padding)
-			t.Errorf(msg)
 		}
 	}
 }

--- a/pkg/trace/array_trace.go
+++ b/pkg/trace/array_trace.go
@@ -119,9 +119,11 @@ func (p *ArrayTrace) String() string {
 
 				id.WriteString(jth.String())
 			}
+
 			id.WriteString("}")
 		}
 	}
+
 	id.WriteString("}")
 	//
 	return id.String()

--- a/pkg/trace/json/writer.go
+++ b/pkg/trace/json/writer.go
@@ -37,6 +37,7 @@ func ToJsonString(columns []trace.RawColumn) string {
 			jth := data.Get(j)
 			builder.WriteString(jth.String())
 		}
+
 		builder.WriteString("]")
 	}
 	//

--- a/pkg/trace/printer.go
+++ b/pkg/trace/printer.go
@@ -224,6 +224,7 @@ func printHorizontalRule(widths []int) {
 		for i := 0; i < w; i++ {
 			fmt.Print("-")
 		}
+
 		fmt.Print("-+")
 	}
 


### PR DESCRIPTION
This updates the trace --filter option to be a regex, rather than simply a prefix.