### PR TITLE
Support batching for trace expansion

### DIFF
--- a/pkg/cmd/check.go
+++ b/pkg/cmd/check.go
@@ -136,7 +136,7 @@ func checkTraceWithLowering(cols []tr.RawColumn, schema *hir.Schema, cfg checkCo
 }
 
 func checkTrace(ir string, cols []tr.RawColumn, schema sc.Schema, cfg checkConfig) bool {
-	builder := sc.NewTraceBuilder(schema).Expand(cfg.expand).Parallel(cfg.parallelExpansion)
+	builder := sc.NewTraceBuilder(schema).Expand(cfg.expand).Parallel(cfg.parallelExpansion).BatchSize(cfg.batchSize)
 	//
 	for n := cfg.padding.Left; n <= cfg.padding.Right; n++ {
 		stats := util.NewPerfStats()


### PR DESCRIPTION
This puts in place a relatively simple approach to batching for trace expansion which reuses the existing batchsize parameter intended for constraint checking.  However, this does provide an effect means to throttle memory usage on larger machines.