### PR TITLE
Support `entropy` column summariser

### DIFF
--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -59,6 +59,17 @@ func getString(cmd *cobra.Command, flag string) string {
 	return r
 }
 
+// Get an expected string array, or panic if an error arises.
+func getStringArray(cmd *cobra.Command, flag string) []string {
+	r, err := cmd.Flags().GetStringArray(flag)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(4)
+	}
+
+	return r
+}
+
 // Write a given trace file to disk
 func writeTraceFile(filename string, columns []trace.RawColumn) {
 	var err error


### PR DESCRIPTION
This adds support for showing the "entropy" of a column.  That is a count of how much the column changes between each line.  High entropy signals few changes between lines (e.g. all 1s as 100% entropy).

This also refactors the column summariser process to allow selection of which summaries to show.