### PR TITLE
feat: change `lookup` to `deflookup`

### DIFF
--- a/pkg/hir/parser.go
+++ b/pkg/hir/parser.go
@@ -98,7 +98,7 @@ func (p *hirParser) parseDeclaration(s sexp.SExp) error {
 			return p.parseAssertionDeclaration(e.Elements)
 		} else if e.Len() == 3 && e.MatchSymbols(1, "permute") {
 			return p.parseSortedPermutationDeclaration(e)
-		} else if e.Len() == 4 && e.MatchSymbols(1, "lookup") {
+		} else if e.Len() == 4 && e.MatchSymbols(1, "deflookup") {
 			return p.parseLookupDeclaration(e)
 		} else if e.Len() == 3 && e.MatchSymbols(1, "interleave") {
 			return p.parseInterleavingDeclaration(e)

--- a/pkg/schema/constraint/lookup.go
+++ b/pkg/schema/constraint/lookup.go
@@ -155,5 +155,10 @@ func (p *LookupConstraint[E]) Lisp(schema sc.Schema) sexp.SExp {
 		targets.Append(p.targets[i].Lisp(schema))
 	}
 	// Done
-	return sexp.NewList([]sexp.SExp{sexp.NewSymbol(p.handle)})
+	return sexp.NewList([]sexp.SExp{
+		sexp.NewSymbol("deflookup"),
+		sexp.NewSymbol(p.handle),
+		targets,
+		sources,
+	})
 }

--- a/testdata/bin-dynamic.lisp
+++ b/testdata/bin-dynamic.lisp
@@ -65,7 +65,7 @@
 
 (defconstraint bin:is-byte-result () (ifnot bin:IS_BYTE (if bin:CT_MAX (begin bin:RESULT_HI bin:RESULT_LO) (begin bin:RESULT_HI (- bin:RESULT_LO (* bin:SMALL bin:PIVOT))))))
 
-(defconstraint bin:result-via-lookup () (ifnot (+ bin:IS_AND bin:IS_OR bin:IS_XOR bin:IS_NOT) (begin (- bin:BYTE_5 bin:XXX_BYTE_HI) (- bin:BYTE_6 bin:XXX_BYTE_LO))))
+(defconstraint bin:result-via-deflookup () (ifnot (+ bin:IS_AND bin:IS_OR bin:IS_XOR bin:IS_NOT) (begin (- bin:BYTE_5 bin:XXX_BYTE_HI) (- bin:BYTE_6 bin:XXX_BYTE_LO))))
 
 (defconstraint bin:isnot-ctmax () (if (- bin:IS_NOT 1) (- bin:CT_MAX 15)))
 

--- a/testdata/bin-static.lisp
+++ b/testdata/bin-static.lisp
@@ -68,7 +68,7 @@
 
 (defconstraint bin:set-oli-mli () (if (+ bin:IS_BYTE bin:IS_SIGNEXTEND) bin:ONE_LINE_INSTRUCTION (if bin:ARGUMENT_1_HI bin:ONE_LINE_INSTRUCTION (- bin:ONE_LINE_INSTRUCTION 1))))
 
-(defconstraint bin:result-via-lookup () (ifnot (+ bin:IS_AND bin:IS_OR bin:IS_XOR bin:IS_NOT) (begin (- bin:BYTE_5 bin:XXX_BYTE_HI) (- bin:BYTE_6 bin:XXX_BYTE_LO))))
+(defconstraint bin:result-via-deflookup () (ifnot (+ bin:IS_AND bin:IS_OR bin:IS_XOR bin:IS_NOT) (begin (- bin:BYTE_5 bin:XXX_BYTE_HI) (- bin:BYTE_6 bin:XXX_BYTE_LO))))
 
 (defconstraint bin:oli-incrementation () (ifnot bin:ONE_LINE_INSTRUCTION (- (shift bin:STAMP 1) (+ bin:STAMP 1))))
 

--- a/testdata/interleave_04.lisp
+++ b/testdata/interleave_04.lisp
@@ -1,3 +1,3 @@
 (defcolumns X Y Z)
 (interleave A (X Y))
-(lookup l1 (A) (Z))
+(deflookup l1 (A) (Z))

--- a/testdata/lookup_01.lisp
+++ b/testdata/lookup_01.lisp
@@ -1,2 +1,2 @@
 (defcolumns X Y)
-(lookup test (Y) (X))
+(deflookup test (Y) (X))

--- a/testdata/lookup_02.lisp
+++ b/testdata/lookup_02.lisp
@@ -1,3 +1,3 @@
 (defcolumns A B X Y)
 ;; Inclusion A,B into X,Y
-(lookup test (X Y) (A B))
+(deflookup test (X Y) (A B))

--- a/testdata/lookup_03.lisp
+++ b/testdata/lookup_03.lisp
@@ -1,2 +1,2 @@
 (defcolumns X Y)
-(lookup test (Y) ((* X 2)))
+(deflookup test (Y) ((* X 2)))

--- a/testdata/lookup_04.lisp
+++ b/testdata/lookup_04.lisp
@@ -1,2 +1,2 @@
 (defcolumns ST X Y)
-(lookup test (Y) ((* ST (+ 1 X))))
+(deflookup test (Y) ((* ST (+ 1 X))))

--- a/testdata/lookup_05.lisp
+++ b/testdata/lookup_05.lisp
@@ -1,2 +1,2 @@
 (defcolumns A B X Y)
-(lookup test (X Y) (A (* B 3)))
+(deflookup test (X Y) (A (* B 3)))

--- a/testdata/lookup_06.lisp
+++ b/testdata/lookup_06.lisp
@@ -4,4 +4,4 @@
 (module m2)
 (defcolumns Y)
 ;;
-(lookup test (Y) (m1.X))
+(deflookup test (Y) (m1.X))

--- a/testdata/lookup_07.lisp
+++ b/testdata/lookup_07.lisp
@@ -1,2 +1,2 @@
 (defcolumns A B X)
-(lookup test (A B) (X 0))
+(deflookup test (A B) (X 0))

--- a/testdata/lookup_08.lisp
+++ b/testdata/lookup_08.lisp
@@ -1,2 +1,2 @@
 (defcolumns A B X)
-(lookup test (A B) (0 X))
+(deflookup test (A B) (0 X))


### PR DESCRIPTION
This brings the syntax closer to that of the original Corset language.