### PR TITLE
feat: update syntax for `permutation` to `defpermutation`

### DIFF
--- a/pkg/hir/lower.go
+++ b/pkg/hir/lower.go
@@ -24,8 +24,8 @@ func (p *Schema) LowerToMir() *mir.Schema {
 		mirSchema.AddDataColumn(col.Context(), col.Name(), col.Type())
 	}
 	// Lower assignments (nothing to do here)
-	for _, asn := range p.assignments {
-		mirSchema.AddAssignment(asn)
+	for _, a := range p.assignments {
+		mirSchema.AddAssignment(a)
 	}
 	// Lower constraints
 	for _, c := range p.constraints {

--- a/pkg/schema/assignment/sorted_permutation.go
+++ b/pkg/schema/assignment/sorted_permutation.go
@@ -152,7 +152,7 @@ func (p *SortedPermutation) Lisp(schema sc.Schema) sexp.SExp {
 	}
 
 	return sexp.NewList([]sexp.SExp{
-		sexp.NewSymbol("sort"),
+		sexp.NewSymbol("defpermutation"),
 		targets,
 		sources,
 	})

--- a/pkg/schema/constraint/permutation.go
+++ b/pkg/schema/constraint/permutation.go
@@ -86,7 +86,7 @@ func (p *PermutationConstraint) Lisp(schema sc.Schema) sexp.SExp {
 	}
 
 	return sexp.NewList([]sexp.SExp{
-		sexp.NewSymbol("permutation"),
+		sexp.NewSymbol("defpermutation"),
 		targets,
 		sources,
 	})

--- a/testdata/memory.lisp
+++ b/testdata/memory.lisp
@@ -19,7 +19,7 @@
 ;; Value being Read/Written
 (defcolumns (VAL :u8))
 ;; Permutation
-(permute (ADDR' PC' RW' VAL') (+ADDR +PC +RW +VAL))
+(defpermutation (ADDR' PC' RW' VAL') ((+ ADDR) (+ PC) (+ RW) (+ VAL)))
 ;; PC[0]=0
 (defconstraint heartbeat_1 (:domain {0}) PC)
 ;; PC[k]=0 || PC[k]=PC[k-1]+1

--- a/testdata/module_06.lisp
+++ b/testdata/module_06.lisp
@@ -1,6 +1,6 @@
 (defcolumns X)
 (module m1)
 (defcolumns ST (X :u16))
-(permute (Y) (+X))
+(defpermutation (Y) ((+ X)))
 ;; Ensure sorted column increments by 1
 (defconstraint increment () (* ST (- (shift Y 1) (+ 1 Y))))

--- a/testdata/module_07.lisp
+++ b/testdata/module_07.lisp
@@ -2,5 +2,5 @@
 ;;
 (module m1)
 (defcolumns (X :u8) (Y :u8))
-(permute (A B) (+X +Y))
+(defpermutation (A B) ((+ X) (+ Y)))
 (defconstraint diag_ab () (- (shift A 1) B))

--- a/testdata/mxp.lisp
+++ b/testdata/mxp.lisp
@@ -52,7 +52,7 @@
   (mxp:DEPLOYS :u1)
   (mxp:MXP_TYPE_2 :u1))
 
-(permute (mxp:CN_perm mxp:STAMP_perm mxp:C_MEM_perm mxp:C_MEM_NEW_perm mxp:WORDS_perm mxp:WORDS_NEW_perm) (+mxp:CN +mxp:STAMP +mxp:C_MEM +mxp:C_MEM_NEW +mxp:WORDS +mxp:WORDS_NEW))
+(defpermutation (mxp:CN_perm mxp:STAMP_perm mxp:C_MEM_perm mxp:C_MEM_NEW_perm mxp:WORDS_perm mxp:WORDS_NEW_perm) ((+ mxp:CN) (+ mxp:STAMP) (+ mxp:C_MEM) (+ mxp:C_MEM_NEW) (+ mxp:WORDS) (+ mxp:WORDS_NEW)))
 
 (defconstraint mxp:counter-constancy () (begin (ifnot mxp:CT (- mxp:INST (shift mxp:INST -1))) (ifnot mxp:CT (- mxp:OFFSET_1_LO (shift mxp:OFFSET_1_LO -1))) (ifnot mxp:CT (- mxp:OFFSET_1_HI (shift mxp:OFFSET_1_HI -1))) (ifnot mxp:CT (- mxp:OFFSET_2_LO (shift mxp:OFFSET_2_LO -1))) (ifnot mxp:CT (- mxp:OFFSET_2_HI (shift mxp:OFFSET_2_HI -1))) (ifnot mxp:CT (- mxp:SIZE_1_LO (shift mxp:SIZE_1_LO -1))) (ifnot mxp:CT (- mxp:SIZE_1_HI (shift mxp:SIZE_1_HI -1))) (ifnot mxp:CT (- mxp:SIZE_2_LO (shift mxp:SIZE_2_LO -1))) (ifnot mxp:CT (- mxp:SIZE_2_HI (shift mxp:SIZE_2_HI -1))) (ifnot mxp:CT (- mxp:WORDS (shift mxp:WORDS -1))) (ifnot mxp:CT (- mxp:WORDS_NEW (shift mxp:WORDS_NEW -1))) (ifnot mxp:CT (- mxp:C_MEM (shift mxp:C_MEM -1))) (ifnot mxp:CT (- mxp:C_MEM_NEW (shift mxp:C_MEM_NEW -1))) (ifnot mxp:CT (- mxp:COMP (shift mxp:COMP -1))) (ifnot mxp:CT (- mxp:MXPX (shift mxp:MXPX -1))) (ifnot mxp:CT (- mxp:EXPANDS (shift mxp:EXPANDS -1))) (ifnot mxp:CT (- mxp:QUAD_COST (shift mxp:QUAD_COST -1))) (ifnot mxp:CT (- mxp:LIN_COST (shift mxp:LIN_COST -1))) (ifnot mxp:CT (- mxp:GAS_MXP (shift mxp:GAS_MXP -1)))))
 

--- a/testdata/permute_01.lisp
+++ b/testdata/permute_01.lisp
@@ -1,2 +1,5 @@
 (defcolumns (X :u16))
-(permute (Y) (+X))
+(defpermutation (Y) ((↓ X)))
+(defpermutation (Z) ((+ X)))
+;; Y == Z
+(defconstraint eq () (- Y Z))

--- a/testdata/permute_02.lisp
+++ b/testdata/permute_02.lisp
@@ -1,3 +1,3 @@
 (defcolumns (X :u16))
-(permute (Y) (+X))
+(defpermutation (Y) ((+ X)))
 (defconstraint first-row (:domain {0}) Y)

--- a/testdata/permute_03.lisp
+++ b/testdata/permute_03.lisp
@@ -1,4 +1,4 @@
 (defcolumns ST (X :u16))
-(permute (Y) (+X))
+(defpermutation (Y) ((↓ X)))
 ;; Ensure sorted column increments by 1
 (defconstraint increment () (* ST (- (shift Y 1) (+ 1 Y))))

--- a/testdata/permute_04.lisp
+++ b/testdata/permute_04.lisp
@@ -1,5 +1,5 @@
 (defcolumns
   (ST :u16)
   (X :u16))
-(permute (ST' Y) (+ST -X))
+(defpermutation (ST' Y) ((↓ ST) (↑ X)))
 (defconstraint first-row (:domain {-1}) (- Y 5))

--- a/testdata/permute_05.lisp
+++ b/testdata/permute_05.lisp
@@ -1,5 +1,5 @@
 (defcolumns
   (X :u8)
   (Y :u8))
-(permute (A B) (+X +Y))
+(defpermutation (A B) ((+ X) (+ Y)))
 (defconstraint diag_ab () (- (shift A 1) B))

--- a/testdata/permute_06.lisp
+++ b/testdata/permute_06.lisp
@@ -1,5 +1,5 @@
 (defcolumns
   (X :u16)
   (Y :u16))
-(permute (A B) (+X +Y))
+(defpermutation (A B) ((+ X) (+ Y)))
 (defconstraint diag_ab () (- (shift A 1) B))

--- a/testdata/permute_07.lisp
+++ b/testdata/permute_07.lisp
@@ -2,5 +2,5 @@
   (ST :u16)
   (X :u16)
   (Y :u16))
-(permute (ST' A B) (+ST -X +Y))
+(defpermutation (ST' A B) ((+ ST) (- X) (+ Y)))
 (defconstraint diag_ab () (* ST' (- (shift A 1) B)))

--- a/testdata/permute_08.lisp
+++ b/testdata/permute_08.lisp
@@ -1,5 +1,5 @@
 (defcolumns
   (X :u16)
   (Y :u16))
-(permute (A B) (+X -Y))
+(defpermutation (A B) ((+ X) (- Y)))
 (defconstraint diag_ab () (* A (- (shift A 1) B)))

--- a/testdata/permute_09.lisp
+++ b/testdata/permute_09.lisp
@@ -2,5 +2,5 @@
   (ST :u16)
   (X :u16)
   (Y :u16))
-(permute (ST' A B) (+ST -X -Y))
+(defpermutation (ST' A B) ((+ ST) (- X) (- Y)))
 (defconstraint diag_ab () (* ST' (- (shift A 1) B)))


### PR DESCRIPTION
This brings the accepted source syntax closer to that of the original corset tool.  However, there is still work to do in properly separating the HIR level from the MIR / AIR levels.