### PR TITLE
Reset internal primitive naming

### DIFF
--- a/pkg/schema/assignment/data_column.go
+++ b/pkg/schema/assignment/data_column.go
@@ -68,7 +68,7 @@ func (p *DataColumn) IsComputed() bool {
 // Lisp converts this schema element into a simple S-Expression, for example
 // so it can be printed.
 func (p *DataColumn) Lisp(schema sc.Schema) sexp.SExp {
-	col := sexp.NewSymbol("defcolumns")
+	col := sexp.NewSymbol("column")
 	name := sexp.NewSymbol(p.Columns().Next().QualifiedName(schema))
 	//
 	if p.datatype.AsField() != nil {

--- a/pkg/schema/assignment/sorted_permutation.go
+++ b/pkg/schema/assignment/sorted_permutation.go
@@ -152,7 +152,7 @@ func (p *SortedPermutation) Lisp(schema sc.Schema) sexp.SExp {
 	}
 
 	return sexp.NewList([]sexp.SExp{
-		sexp.NewSymbol("defpermutation"),
+		sexp.NewSymbol("sort"),
 		targets,
 		sources,
 	})

--- a/pkg/schema/constraint/lookup.go
+++ b/pkg/schema/constraint/lookup.go
@@ -156,7 +156,7 @@ func (p *LookupConstraint[E]) Lisp(schema sc.Schema) sexp.SExp {
 	}
 	// Done
 	return sexp.NewList([]sexp.SExp{
-		sexp.NewSymbol("deflookup"),
+		sexp.NewSymbol("lookup"),
 		sexp.NewSymbol(p.handle),
 		targets,
 		sources,

--- a/pkg/schema/constraint/permutation.go
+++ b/pkg/schema/constraint/permutation.go
@@ -86,7 +86,7 @@ func (p *PermutationConstraint) Lisp(schema sc.Schema) sexp.SExp {
 	}
 
 	return sexp.NewList([]sexp.SExp{
-		sexp.NewSymbol("defpermutation"),
+		sexp.NewSymbol("permutation"),
 		targets,
 		sources,
 	})

--- a/pkg/schema/constraint/vanishing.go
+++ b/pkg/schema/constraint/vanishing.go
@@ -215,20 +215,21 @@ func HoldsLocally[T sc.Testable](k uint, handle string, constraint T, tr tr.Trac
 //
 //nolint:revive
 func (p *VanishingConstraint[T]) Lisp(schema sc.Schema) sexp.SExp {
-	attributes := sexp.EmptyList()
+	name := p.handle
 	// Handle attributes
 	if p.domain == nil {
 		// Skip
 	} else if *p.domain == 0 {
-		attributes.Append(sexp.NewSymbol(":first"))
+		name = fmt.Sprintf("%s:first", name)
+	} else if *p.domain == -1 {
+		name = fmt.Sprintf("%s:last", name)
 	} else {
-		attributes.Append(sexp.NewSymbol(":last"))
+		panic(fmt.Sprintf("domain value %d not supported for local constraint", p.domain))
 	}
 	// Construct the list
 	return sexp.NewList([]sexp.SExp{
-		sexp.NewSymbol("defconstraint"),
-		sexp.NewSymbol(p.handle),
-		attributes,
+		sexp.NewSymbol("vanish"),
+		sexp.NewSymbol(name),
 		p.constraint.Lisp(schema),
 	})
 }


### PR DESCRIPTION
This resets some of the naming used for the internal primitives.  This is to make a clear separation from the original corset syntax.