### PR TITLE
feat: support constraints with `void` context

### DIFF
--- a/pkg/binfile/constraint.go
+++ b/pkg/binfile/constraint.go
@@ -62,8 +62,16 @@ func (e jsonConstraint) addToSchema(colmap map[uint]uint, schema *hir.Schema) {
 		domain := e.Vanishes.Domain.toHir()
 		// Determine enclosing module
 		ctx := expr.Context(schema)
-		// Construct the vanishing constraint
-		schema.AddVanishingConstraint(e.Vanishes.Handle, ctx, domain, expr)
+		// Check for vacuous constraint (i.e. one which evaluates to a constant)
+		if constant := expr.AsConstant(); constant != nil {
+			// Constraint outcome known at compile time.
+			if !constant.IsZero() {
+				panic(fmt.Sprintf("constraint %s always fails (i.e. evaluates to constant value %s)", e.Vanishes.Handle, constant))
+			}
+		} else {
+			// Construct the vanishing constraint
+			schema.AddVanishingConstraint(e.Vanishes.Handle, ctx, domain, expr)
+		}
 	} else if e.Lookup != nil {
 		sources := jsonExprsToHirUnit(e.Lookup.From, colmap, schema)
 		targets := jsonExprsToHirUnit(e.Lookup.To, colmap, schema)


### PR DESCRIPTION
This adds partial support for constraints with `void` context. Specifically, this is only support for constraints being read out of a binfile, and also the constant evaluation is fairly limited.  If necessary, it could be improved further down the track.