### PR TITLE
Fix for reading `bin` files

### DIFF
--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -138,7 +138,7 @@ func readSchema(filenames []string) *hir.Schema {
 	if len(filenames) == 0 {
 		fmt.Println("source or binary constraint(s) file required.")
 		os.Exit(5)
-	} else if len(filenames) == 1 && path.Ext(filenames[0]) == "bin" {
+	} else if len(filenames) == 1 && path.Ext(filenames[0]) == ".bin" {
 		// Single (binary) file supplied
 		return readBinaryFile(filenames[0])
 	}


### PR DESCRIPTION
The problem was that the extension was not being correctly matched for `bin` files, leading the tool to try and parse them as lisp files.