### PR TITLE
Enable Purity Checking

### DIFF
--- a/pkg/corset/ast.go
+++ b/pkg/corset/ast.go
@@ -754,8 +754,6 @@ func (p *DefProperty) Lisp() sexp.SExp {
 // defined within its enclosing context.
 type DefFun struct {
 	name string
-	// Specify whether is pure (or not)
-	pure bool
 	// Parameters
 	parameters []*DefParameter
 	//

--- a/pkg/corset/binding.go
+++ b/pkg/corset/binding.go
@@ -134,6 +134,11 @@ func NewFunctionBinding(pure bool, paramTypes []sc.Type, returnType sc.Type, bod
 	return FunctionBinding{pure, paramTypes, returnType, body}
 }
 
+// IsPure checks whether this is a defpurefun or not
+func (p *FunctionBinding) IsPure() bool {
+	return p.pure
+}
+
 // IsFinalised checks whether this binding has been finalised yet or not.
 func (p *FunctionBinding) IsFinalised() bool {
 	return p.returnType != nil

--- a/pkg/corset/parser.go
+++ b/pkg/corset/parser.go
@@ -628,9 +628,9 @@ func (p *Parser) parseDefFun(pure bool, elements []sexp.SExp) (Declaration, []Sy
 		paramTypes[i] = p.DataType
 	}
 	// Construct binding
-	binding := NewFunctionBinding(true, paramTypes, ret, body)
+	binding := NewFunctionBinding(pure, paramTypes, ret, body)
 	//
-	return &DefFun{name, pure, params, binding}, nil
+	return &DefFun{name, params, binding}, nil
 }
 
 func (p *Parser) parseFunctionSignature(elements []sexp.SExp) (string, sc.Type, []*DefParameter, []SyntaxError) {

--- a/pkg/test/invalid_corset_test.go
+++ b/pkg/test/invalid_corset_test.go
@@ -128,6 +128,18 @@ func Test_Invalid_Constant_14(t *testing.T) {
 	CheckInvalid(t, "constant_invalid_14")
 }
 
+func Test_Invalid_Constant_15(t *testing.T) {
+	CheckInvalid(t, "constant_invalid_15")
+}
+
+func Test_Invalid_Constant_16(t *testing.T) {
+	CheckInvalid(t, "constant_invalid_16")
+}
+
+func Test_Invalid_Constant_17(t *testing.T) {
+	CheckInvalid(t, "constant_invalid_17")
+}
+
 // ===================================================================
 // Alias Tests
 // ===================================================================
@@ -373,11 +385,10 @@ func Test_Invalid_PureFun_03(t *testing.T) {
 	CheckInvalid(t, "purefun_invalid_03")
 }
 
-/*
-	func Test_Invalid_PureFun_04(t *testing.T) {
-		CheckInvalid(t, "purefun_invalid_04")
-	}
-*/
+func Test_Invalid_PureFun_04(t *testing.T) {
+	CheckInvalid(t, "purefun_invalid_04")
+}
+
 func Test_Invalid_PureFun_05(t *testing.T) {
 	CheckInvalid(t, "purefun_invalid_05")
 }
@@ -387,6 +398,10 @@ func Test_Invalid_PureFun_05(t *testing.T) {
 		CheckInvalid(t, "purefun_invalid_06")
 	}
 */
+
+func Test_Invalid_PureFun_07(t *testing.T) {
+	CheckInvalid(t, "purefun_invalid_07")
+}
 
 // ===================================================================
 // Test Helpers

--- a/testdata/constant_invalid_15.lisp
+++ b/testdata/constant_invalid_15.lisp
@@ -1,0 +1,2 @@
+(defun (ONE) 1)
+(defconst X (ONE))

--- a/testdata/constant_invalid_16.lisp
+++ b/testdata/constant_invalid_16.lisp
@@ -1,0 +1,3 @@
+(defcolumns X)
+(defun (ONE) 1)
+(defconstraint c1 () (* X (^ 2 (ONE))))

--- a/testdata/constant_invalid_17.lisp
+++ b/testdata/constant_invalid_17.lisp
@@ -1,0 +1,3 @@
+(defcolumns X)
+(defun (ONE) 1)
+(defconstraint c1 () (shift X (ONE)))

--- a/testdata/purefun_invalid_07.lisp
+++ b/testdata/purefun_invalid_07.lisp
@@ -1,0 +1,5 @@
+(defcolumns A)
+(defun (getA) A)
+;; not pure!
+(defpurefun (id x) (+ x (getA)))
+(defconstraint test () (id 1))


### PR DESCRIPTION
This puts in place purity checking which is used in a few different contexts.  For example, in checking the body of a defpurefun definition. Likewise, constants cannot refer to defun declarations, etc.