### PR TITLE
fix: check properties during testing

### DIFF
--- a/pkg/test/valid_corset_test.go
+++ b/pkg/test/valid_corset_test.go
@@ -853,8 +853,10 @@ func checkTrace(t *testing.T, inputs []trace.RawColumn, expand bool, id traceId,
 			t.Error(err)
 		}
 	} else {
-		// Check
+		// Check Constraints
 		errs := sc.Accepts(100, schema, tr)
+		// Check assertions
+		errs = append(errs, sc.Asserts(100, schema, tr)...)
 		// Determine whether trace accepted or not.
 		accepted := len(errs) == 0
 		// Process what happened versus what was supposed to happen.

--- a/testdata/fields_01.lisp
+++ b/testdata/fields_01.lisp
@@ -1,5 +1,5 @@
 (defcolumns
-    ST
+    (ST :binary@prove@bool)
     ;; Words
     (X :i8@prove)
     (Y :i8@prove)
@@ -10,7 +10,9 @@
     (CARRY :binary@prove))
 
 ;; Property: X == Y + 1
-(defproperty p1 (eq! X (+ Y 1)))
+(defproperty p1
+    (if ST
+        (eq! X (+ Y 1))))
 
 ;; Constructs two nibbles into a byte
 (defpurefun (as_u8 b1 b0) (+ (* 16 b1) b0))


### PR DESCRIPTION
Assertions (a.k.a properties) are now being checked propertly during testing.