### PR TITLE
feat: specify error for invalid tests

### DIFF
--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -208,7 +208,7 @@ func printSyntaxError(err *sexp.SyntaxError) {
 	length := min(line.Length()-lineOffset, span.Length())
 	// Print error + line number
 	fmt.Printf("%s:%d:%d-%d %s\n", err.SourceFile().Filename(),
-		line.Number(), lineOffset, lineOffset+length, err.Message())
+		line.Number(), 1+lineOffset, 1+lineOffset+length, err.Message())
 	// Print separator line
 	fmt.Println()
 	// Print line

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -203,17 +203,18 @@ func readSourceFiles(stdlib bool, debug bool, filenames []string) *hir.Schema {
 func printSyntaxError(err *sexp.SyntaxError) {
 	span := err.Span()
 	line := err.FirstEnclosingLine()
+	lineOffset := span.Start() - line.Start()
+	// Calculate length (ensures don't overflow line)
+	length := min(line.Length()-lineOffset, span.Length())
 	// Print error + line number
-	fmt.Printf("%s:%d: %s\n", err.SourceFile().Filename(), line.Number(), err.Message())
+	fmt.Printf("%s:%d:%d-%d %s\n", err.SourceFile().Filename(),
+		line.Number(), lineOffset, lineOffset+length, err.Message())
 	// Print separator line
 	fmt.Println()
 	// Print line
 	fmt.Println(line.String())
 	// Print indent (todo: account for tabs)
-	lineOffset := span.Start() - line.Start()
 	fmt.Print(strings.Repeat(" ", lineOffset))
-	// Calculate length (ensures don't overflow line)
-	length := min(line.Length()-lineOffset, span.Length())
 	// Print highlight
 	fmt.Println(strings.Repeat("^", length))
 }

--- a/pkg/corset/resolver.go
+++ b/pkg/corset/resolver.go
@@ -142,7 +142,7 @@ func (r *resolver) initialiseAliasesInModule(scope *ModuleScope, decls []Declara
 					err := r.srcmap.SyntaxError(alias, "symbol already exists")
 					errors = append(errors, *err)
 				} else {
-					err := r.srcmap.SyntaxError(symbol, "unknown symbol encountered during resolution")
+					err := r.srcmap.SyntaxError(symbol, "unknown symbol")
 					errors = append(errors, *err)
 				}
 			}
@@ -237,7 +237,7 @@ func (r *resolver) declarationDependenciesAreFinalised(scope *ModuleScope,
 		symbol := iter.Next()
 		// Attempt to resolve
 		if !symbol.IsResolved() && !scope.Bind(symbol) {
-			errors = append(errors, *r.srcmap.SyntaxError(symbol, "unknown symbol encountered during resolution"))
+			errors = append(errors, *r.srcmap.SyntaxError(symbol, "unknown symbol"))
 			// not finalised yet
 			finalised = false
 		} else {

--- a/pkg/corset/resolver.go
+++ b/pkg/corset/resolver.go
@@ -293,11 +293,10 @@ func (r *resolver) finaliseDefConstInModule(enclosing Scope, decl *DefConst) []S
 		// Accumulate errors
 		errors = append(errors, errs...)
 		// Check it is indeed constant!
-		if constant := c.binding.value.AsConstant(); constant == nil {
-			err := r.srcmap.SyntaxError(c, "definition not constant")
-			errors = append(errors, *err)
-		} else {
-			// Finalise constant binding
+		if constant := c.binding.value.AsConstant(); constant != nil {
+			// Finalise constant binding.  Note, no need to register a syntax
+			// error for the error case, because it would have already been
+			// accounted for during resolution.
 			c.binding.Finalise(datatype)
 		}
 	}

--- a/pkg/test/invalid_corset_test.go
+++ b/pkg/test/invalid_corset_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"testing"
@@ -600,5 +601,13 @@ func CheckInvalid(t *testing.T, test string) {
 	// Check program did not compile!
 	if len(errs) == 0 {
 		t.Fatalf("Error %s should not have compiled\n", filename)
+	}
+}
+
+func ExtractExpectedSyntaxErrors(bytes []byte) []sexp.SyntaxError {
+	scanner := bufio.NewScanner(bytes)
+	// optionally, resize scanner's capacity for lines over 64K, see next example
+	for scanner.Scan() {
+		fmt.Println(scanner.Text())
 	}
 }

--- a/pkg/test/invalid_corset_test.go
+++ b/pkg/test/invalid_corset_test.go
@@ -239,6 +239,10 @@ func Test_Invalid_If_02(t *testing.T) {
 	CheckInvalid(t, "if_invalid_02")
 }
 
+func Test_Invalid_If_03(t *testing.T) {
+	CheckInvalid(t, "if_invalid_03")
+}
+
 // ===================================================================
 // Types
 // ===================================================================

--- a/pkg/test/invalid_corset_test.go
+++ b/pkg/test/invalid_corset_test.go
@@ -589,6 +589,7 @@ func Test_Invalid_Debug_02(t *testing.T) {
 // ===================================================================
 
 // Check that a given source file fails to compiler.
+// nolint
 func CheckInvalid(t *testing.T, test string) {
 	filename := fmt.Sprintf("%s/%s.lisp", InvalidTestDir, test)
 	// Enable testing each trace in parallel

--- a/pkg/test/valid_corset_test.go
+++ b/pkg/test/valid_corset_test.go
@@ -1,10 +1,7 @@
 package test
 
 import (
-	"bufio"
-	"errors"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 	"testing"
@@ -15,6 +12,7 @@ import (
 	"github.com/consensys/go-corset/pkg/sexp"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/trace/json"
+	"github.com/consensys/go-corset/pkg/util"
 )
 
 // Determines the (relative) location of the test directory.  That is
@@ -899,7 +897,7 @@ type traceId struct {
 // ReadTracesFile reads a file containing zero or more traces expressed as JSON, where
 // each trace is on a separate line.
 func ReadTracesFile(filename string) [][]trace.RawColumn {
-	lines := ReadInputFile(filename)
+	lines := util.ReadInputFile(filename)
 	traces := make([][]trace.RawColumn, len(lines))
 	// Read constraints line by line
 	for i, line := range lines {
@@ -925,61 +923,5 @@ func ReadTracesFileIfExists(name string) [][]trace.RawColumn {
 		return nil
 	}
 	// Yes it does
-	return ReadTracesFile(name)
-}
-
-// ReadInputFile reads an input file as a sequence of lines.
-func ReadInputFile(filename string) []string {
-	filename = fmt.Sprintf("%s/%s", TestDir, filename)
-	file, err := os.Open(filename)
-	// Check whether file exists
-	if errors.Is(err, os.ErrNotExist) {
-		return []string{}
-	} else if err != nil {
-		panic(err)
-	}
-
-	reader := bufio.NewReaderSize(file, 1024*128)
-	lines := make([]string, 0)
-	// Read file line-by-line
-	for {
-		// Read the next line
-		line := readLine(reader)
-		// Check whether for EOF
-		if line == nil {
-			if err = file.Close(); err != nil {
-				panic(err)
-			}
-
-			return lines
-		}
-
-		lines = append(lines, *line)
-	}
-}
-
-// Read a single line
-func readLine(reader *bufio.Reader) *string {
-	var (
-		bytes []byte
-		bit   []byte
-		err   error
-	)
-	//
-	cont := true
-	//
-	for cont {
-		bit, cont, err = reader.ReadLine()
-		if err == io.EOF {
-			return nil
-		} else if err != nil {
-			panic(err)
-		}
-
-		bytes = append(bytes, bit...)
-	}
-	// Convert to string
-	str := string(bytes)
-	// Done
-	return &str
+	return ReadTracesFile(filename)
 }

--- a/pkg/util/files.go
+++ b/pkg/util/files.go
@@ -1,0 +1,63 @@
+package util
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"os"
+)
+
+// ReadInputFile reads an input file as a sequence of lines.
+func ReadInputFile(filename string) []string {
+	file, err := os.Open(filename)
+	// Check whether file exists
+	if errors.Is(err, os.ErrNotExist) {
+		return []string{}
+	} else if err != nil {
+		panic(err)
+	}
+
+	reader := bufio.NewReaderSize(file, 1024*128)
+	lines := make([]string, 0)
+	// Read file line-by-line
+	for {
+		// Read the next line
+		line := readLine(reader)
+		// Check whether for EOF
+		if line == nil {
+			if err = file.Close(); err != nil {
+				panic(err)
+			}
+
+			return lines
+		}
+
+		lines = append(lines, *line)
+	}
+}
+
+// Read a single line
+func readLine(reader *bufio.Reader) *string {
+	var (
+		bytes []byte
+		bit   []byte
+		err   error
+	)
+	//
+	cont := true
+	//
+	for cont {
+		bit, cont, err = reader.ReadLine()
+		if err == io.EOF {
+			return nil
+		} else if err != nil {
+			panic(err)
+		}
+
+		bytes = append(bytes, bit...)
+	}
+	// Convert to string
+	str := string(bytes)
+	// Done
+	return &str
+}

--- a/testdata/alias_invalid_01.lisp
+++ b/testdata/alias_invalid_01.lisp
@@ -1,1 +1,2 @@
+;;error:2:1-2:blah
 (defalias X Y)

--- a/testdata/alias_invalid_01.lisp
+++ b/testdata/alias_invalid_01.lisp
@@ -1,2 +1,2 @@
-;;error:2:1-2:blah
+;;error:2:13-14:unknown symbol
 (defalias X Y)

--- a/testdata/alias_invalid_02.lisp
+++ b/testdata/alias_invalid_02.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:5:7-8:unknown symbol
 (defcolumns Y)
 (defalias
     X Y

--- a/testdata/alias_invalid_02.lisp
+++ b/testdata/alias_invalid_02.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns Y)
 (defalias
     X Y

--- a/testdata/alias_invalid_03.lisp
+++ b/testdata/alias_invalid_03.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 (defalias X Y)

--- a/testdata/alias_invalid_03.lisp
+++ b/testdata/alias_invalid_03.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:11-12:symbol already exists
 (defcolumns X Y)
 (defalias X Y)

--- a/testdata/alias_invalid_04.lisp
+++ b/testdata/alias_invalid_04.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:14-16:unknown symbol
 (defpurefun (id x) x)
 (defalias fn id)

--- a/testdata/alias_invalid_04.lisp
+++ b/testdata/alias_invalid_04.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defpurefun (id x) x)
 (defalias fn id)

--- a/testdata/alias_invalid_05.lisp
+++ b/testdata/alias_invalid_05.lisp
@@ -1,2 +1,2 @@
-;;error:2:1-2:blah
+;;error:2:13-14:unknown symbol
 (defalias x x)

--- a/testdata/alias_invalid_05.lisp
+++ b/testdata/alias_invalid_05.lisp
@@ -1,1 +1,2 @@
+;;error:2:1-2:blah
 (defalias x x)

--- a/testdata/alias_invalid_06.lisp
+++ b/testdata/alias_invalid_06.lisp
@@ -1,3 +1,4 @@
-;;error:2:1-2:blah
+;;error:3:13-14:unknown symbol
+;;error:4:13-14:unknown symbol
 (defalias x y)
 (defalias y x)

--- a/testdata/alias_invalid_06.lisp
+++ b/testdata/alias_invalid_06.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defalias x y)
 (defalias y x)

--- a/testdata/alias_invalid_07.lisp
+++ b/testdata/alias_invalid_07.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:4:11-13:symbol already exists
 (defcolumns X Y)
 (defalias CT X)
 (defalias CT Y)

--- a/testdata/alias_invalid_07.lisp
+++ b/testdata/alias_invalid_07.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 (defalias CT X)
 (defalias CT Y)

--- a/testdata/array_invalid_01.lisp
+++ b/testdata/array_invalid_01.lisp
@@ -1,4 +1,4 @@
-;;error:4:24-30:not an array column
+;;error:4:24-31:expected array column
 (defcolumns (BIT :@loob))
 
 (defconstraint bits () [BIT 1])

--- a/testdata/array_invalid_02.lisp
+++ b/testdata/array_invalid_02.lisp
@@ -1,4 +1,4 @@
-;;error:4:24-25:expected loobean constraint (found (𝔽@loob)[4])
+;;error:4:24-27:expected loobean constraint (found (𝔽@loob)[4])
 (defcolumns (BIT :@loob :array [4]))
 
 (defconstraint bits () BIT)

--- a/testdata/array_invalid_03.lisp
+++ b/testdata/array_invalid_03.lisp
@@ -1,4 +1,4 @@
-;;error:4:24-30:expected constant array index
+;;error:4:29-30:expected constant array index
 (defcolumns X (BIT :@loob :array [4]))
 
 (defconstraint bits () [BIT X])

--- a/testdata/array_invalid_04.lisp
+++ b/testdata/array_invalid_04.lisp
@@ -1,4 +1,5 @@
-;;error:12:12-18:out-of-bounds array access
+;;error:13:17-18:array index out-of-bounds
+;;error:13:12-19:void expression not permitted here
 (defcolumns
     (BIT :binary@prove :array [3])
     (ARG :i16@loob))

--- a/testdata/array_invalid_05.lisp
+++ b/testdata/array_invalid_05.lisp
@@ -1,4 +1,5 @@
-;;error:12:12-18:out-of-bounds array access
+;;error:10:17-18:array index out-of-bounds
+;;error:10:12-19:void expression not permitted here
 (defcolumns
     (BIT :binary@prove :array [4])
     (ARG :i16@loob))

--- a/testdata/basic_invalid_01.lisp
+++ b/testdata/basic_invalid_01.lisp
@@ -1,2 +1,2 @@
-;;error:2:14-16:empty column declaration
+;;error:2:15-17:empty column declaration
 (defcolumns X ())

--- a/testdata/basic_invalid_01.lisp
+++ b/testdata/basic_invalid_01.lisp
@@ -1,1 +1,2 @@
+;;error:2:14-16:empty column declaration
 (defcolumns X ())

--- a/testdata/basic_invalid_02.lisp
+++ b/testdata/basic_invalid_02.lisp
@@ -1,1 +1,2 @@
+;;error:2:15-19:unknown type
 (defcolumns (X :odd))

--- a/testdata/basic_invalid_02.lisp
+++ b/testdata/basic_invalid_02.lisp
@@ -1,2 +1,2 @@
-;;error:2:15-19:unknown type
+;;error:2:16-20:unknown type
 (defcolumns (X :odd))

--- a/testdata/basic_invalid_03.lisp
+++ b/testdata/basic_invalid_03.lisp
@@ -1,1 +1,2 @@
+;;error:2:20-24:unknown type
 (defcolumns (X :i32 :odd))

--- a/testdata/basic_invalid_03.lisp
+++ b/testdata/basic_invalid_03.lisp
@@ -1,2 +1,2 @@
-;;error:2:20-24:unknown type
+;;error:2:21-25:unknown type
 (defcolumns (X :i32 :odd))

--- a/testdata/basic_invalid_04.lisp
+++ b/testdata/basic_invalid_04.lisp
@@ -1,2 +1,2 @@
-;;error:2:14-15:symbol X already declared
+;;error:2:15-16:symbol X already declared
 (defcolumns X X)

--- a/testdata/basic_invalid_04.lisp
+++ b/testdata/basic_invalid_04.lisp
@@ -1,1 +1,2 @@
+;;error:2:14-15:symbol X already declared
 (defcolumns X X)

--- a/testdata/basic_invalid_05.lisp
+++ b/testdata/basic_invalid_05.lisp
@@ -1,2 +1,3 @@
+;;error:3:13-14:symbol X already declared
 (defcolumns X)
 (defcolumns X)

--- a/testdata/basic_invalid_06.lisp
+++ b/testdata/basic_invalid_06.lisp
@@ -1,3 +1,4 @@
+;;error:4:21-22:unknown symbol
 (defcolumns X)
 
 (defconstraint c () Y)

--- a/testdata/basic_invalid_07.lisp
+++ b/testdata/basic_invalid_07.lisp
@@ -1,3 +1,4 @@
+;;error:4:26-27:unknown symbol
 (defcolumns X)
 
 (defconstraint c () (+ X Y))

--- a/testdata/basic_invalid_08.lisp
+++ b/testdata/basic_invalid_08.lisp
@@ -1,3 +1,4 @@
+;;error:4:26-27:unknown symbol
 (defcolumns X)
 
 (defconstraint c (:guard Y) X)

--- a/testdata/basic_invalid_09.lisp
+++ b/testdata/basic_invalid_09.lisp
@@ -1,3 +1,4 @@
+;;error:5:21-25:qualified access not permitted here
 (module m1)
 (defcolumns X)
 

--- a/testdata/basic_invalid_10.lisp
+++ b/testdata/basic_invalid_10.lisp
@@ -1,3 +1,5 @@
+;;error:6:26-30:qualified access not permitted here
+;;error:6:32-33:expected loobean constraint (found 𝔽)
 (module m1)
 (defcolumns X)
 

--- a/testdata/basic_invalid_11.lisp
+++ b/testdata/basic_invalid_11.lisp
@@ -1,2 +1,3 @@
-(defcolumns X)
+;;error:3:16-19:invalid constraint handle
+(defcolumns (X :@loob))
 (defconstraint (c) () X)

--- a/testdata/basic_invalid_12.lisp
+++ b/testdata/basic_invalid_12.lisp
@@ -1,1 +1,2 @@
+;;error:2:1-9:malformed declaration
 (module)

--- a/testdata/constant_invalid_01.lisp
+++ b/testdata/constant_invalid_01.lisp
@@ -1,1 +1,2 @@
+;;error:2:11-12:invalid constant name
 (defconst 2 2)

--- a/testdata/constant_invalid_02.lisp
+++ b/testdata/constant_invalid_02.lisp
@@ -1,1 +1,2 @@
+;;error:2:17-20:missing constant definition
 (defconst ONE 2 TWO)

--- a/testdata/constant_invalid_03.lisp
+++ b/testdata/constant_invalid_03.lisp
@@ -1,1 +1,2 @@
+;;error:2:15-16:unknown symbol
 (defconst ONE X)

--- a/testdata/constant_invalid_04.lisp
+++ b/testdata/constant_invalid_04.lisp
@@ -1,2 +1,3 @@
+;;error:3:15-16:not permitted in pure context
 (defcolumns X)
 (defconst ONE X)

--- a/testdata/constant_invalid_05.lisp
+++ b/testdata/constant_invalid_05.lisp
@@ -1,2 +1,3 @@
+;;error:3:20-21:not permitted in pure context
 (defcolumns X)
 (defconst ONE (+ 1 X))

--- a/testdata/constant_invalid_06.lisp
+++ b/testdata/constant_invalid_06.lisp
@@ -1,1 +1,2 @@
+;;error:2:1-2:blah
 (defconst ONE (+ 1 ONE))

--- a/testdata/constant_invalid_07.lisp
+++ b/testdata/constant_invalid_07.lisp
@@ -1,1 +1,2 @@
+;;error:2:1-2:blah
 (defconst ONE TWO TWO (+ 1 ONE))

--- a/testdata/constant_invalid_08.lisp
+++ b/testdata/constant_invalid_08.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defconst ONE TWO)
 (defconst TWO (+ 1 ONE))

--- a/testdata/constant_invalid_09.lisp
+++ b/testdata/constant_invalid_09.lisp
@@ -1,3 +1,4 @@
+;;error:4:18-23:not permitted in pure context
 (defcolumns A)
 (defun (get) A)
 (defconst BROKEN (get))

--- a/testdata/constant_invalid_10.lisp
+++ b/testdata/constant_invalid_10.lisp
@@ -1,3 +1,4 @@
+;;error:9:13-14:symbol X already declared
 (defconst
   X     1
   ONE   X

--- a/testdata/constant_invalid_11.lisp
+++ b/testdata/constant_invalid_11.lisp
@@ -1,2 +1,4 @@
+;;error:4:43-46:not permitted in pure context
+(defpurefun ((vanishes! :@loob) x) x)
 (defcolumns X Y TWO)
-(defconstraint c1 () (- Y (^ X TWO)))
+(defconstraint c1 () (vanishes! (- Y (^ X TWO))))

--- a/testdata/constant_invalid_12.lisp
+++ b/testdata/constant_invalid_12.lisp
@@ -1,3 +1,6 @@
+;;error:6:32-37:not permitted in pure context
+;;error:6:22-39:expected loobean constraint (found 𝔽)
+(defpurefun ((vanishes! :@loob) x) x)
 (defcolumns X Y Z)
 (defun (TWO) Z)
 (defconstraint c1 () (- Y (^ X (TWO))))

--- a/testdata/constant_invalid_13.lisp
+++ b/testdata/constant_invalid_13.lisp
@@ -1,2 +1,5 @@
+;;error:5:41-44:not permitted in pure context
+;;error:5:71-74:not permitted in pure context
+;;error:5:22-77:expected loobean constraint (found 𝔽)
 (defcolumns CT ONE)
 (defconstraint c1 () (* (- CT (shift CT ONE)) (- (+ CT ONE) (shift CT ONE))))

--- a/testdata/constant_invalid_14.lisp
+++ b/testdata/constant_invalid_14.lisp
@@ -1,3 +1,6 @@
+;;error:6:41-46:not permitted in pure context
+;;error:6:75-80:not permitted in pure context
+;;error:6:22-83:expected loobean constraint (found 𝔽)
 (defcolumns CT X)
 (defun (ONE) X)
 (defconstraint c1 () (* (- CT (shift CT (ONE))) (- (+ CT (ONE)) (shift CT (ONE)))))

--- a/testdata/constant_invalid_15.lisp
+++ b/testdata/constant_invalid_15.lisp
@@ -1,2 +1,3 @@
+;;error:3:13-18:not permitted in pure context
 (defun (ONE) 1)
 (defconst X (ONE))

--- a/testdata/constant_invalid_16.lisp
+++ b/testdata/constant_invalid_16.lisp
@@ -1,3 +1,5 @@
+;;error:5:32-37:not permitted in pure context
+;;error:5:22-39:expected loobean constraint (found 𝔽)
 (defcolumns X)
 (defun (ONE) 1)
 (defconstraint c1 () (* X (^ 2 (ONE))))

--- a/testdata/constant_invalid_17.lisp
+++ b/testdata/constant_invalid_17.lisp
@@ -1,3 +1,5 @@
+;;error:5:31-36:not permitted in pure context
+;;error:5:22-37:expected loobean constraint (found 𝔽)
 (defcolumns X)
 (defun (ONE) 1)
 (defconstraint c1 () (shift X (ONE)))

--- a/testdata/debug_invalid_01.lisp
+++ b/testdata/debug_invalid_01.lisp
@@ -1,3 +1,5 @@
+;;error:6:17-26:void expression not permitted here
+(defpurefun ((vanishes! :@loob :force) e0) e0)
 (defcolumns X Y)
 
 (defconstraint c1 ()

--- a/testdata/debug_invalid_02.lisp
+++ b/testdata/debug_invalid_02.lisp
@@ -1,3 +1,5 @@
+;;error:6:22-31:void expression not permitted here
+(defpurefun ((vanishes! :@loob :force) e0) e0)
 (defcolumns X Y)
 
 (defconstraint c1 ()

--- a/testdata/for_invalid_01.lisp
+++ b/testdata/for_invalid_01.lisp
@@ -1,3 +1,4 @@
+;;error:5:3-16:expected 3 arguments, found 2
 (defcolumns X)
 ;; X != 1 && X != 2 && X != 3
 (defconstraint X_t1 ()

--- a/testdata/for_invalid_02.lisp
+++ b/testdata/for_invalid_02.lisp
@@ -1,3 +1,4 @@
+;;error:5:8-11:invalid index variable
 (defcolumns X)
 
 (defconstraint X_t1 ()

--- a/testdata/for_invalid_03.lisp
+++ b/testdata/for_invalid_03.lisp
@@ -1,3 +1,7 @@
+;;error:8:10-12:invalid interval
+;;error:11:10-14:invalid interval
+;;error:14:10-14:invalid interval
+;;error:17:10-17:invalid interval
 (defcolumns X)
 
 (defconstraint X_t1 ()

--- a/testdata/fun_invalid_01.lisp
+++ b/testdata/fun_invalid_01.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:4:27-29:unknown symbol
 (defcolumns A)
 (defun (id x) x)
 (defconstraint test () (+ id A))

--- a/testdata/fun_invalid_01.lisp
+++ b/testdata/fun_invalid_01.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns A)
 (defun (id x) x)
 (defconstraint test () (+ id A))

--- a/testdata/fun_invalid_02.lisp
+++ b/testdata/fun_invalid_02.lisp
@@ -1,4 +1,5 @@
-;;error:2:1-2:blah
+;;error:5:24-32:incorrect number of arguments (found 2)
+;;error:5:24-32:ambiguous invocation
 (defcolumns A)
 (defun (id x) x)
 (defconstraint test () (id A A))

--- a/testdata/fun_invalid_02.lisp
+++ b/testdata/fun_invalid_02.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns A)
 (defun (id x) x)
 (defconstraint test () (id A A))

--- a/testdata/fun_invalid_03.lisp
+++ b/testdata/fun_invalid_03.lisp
@@ -1,1 +1,2 @@
+;;error:2:1-2:blah
 (defun (id x) (+ x y))

--- a/testdata/fun_invalid_03.lisp
+++ b/testdata/fun_invalid_03.lisp
@@ -1,2 +1,2 @@
-;;error:2:1-2:blah
+;;error:2:20-21:unknown symbol
 (defun (id x) (+ x y))

--- a/testdata/fun_invalid_04.lisp
+++ b/testdata/fun_invalid_04.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X)
 ;; recursive :)
 (defun (id x) (+ x (id x)))

--- a/testdata/funalias_invalid_01.lisp
+++ b/testdata/funalias_invalid_01.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns X)
 (defunalias INC X)

--- a/testdata/funalias_invalid_01.lisp
+++ b/testdata/funalias_invalid_01.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:17-18:unknown symbol
 (defcolumns X)
 (defunalias INC X)

--- a/testdata/funalias_invalid_02.lisp
+++ b/testdata/funalias_invalid_02.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defconst X 1)
 (defunalias INC X)

--- a/testdata/funalias_invalid_02.lisp
+++ b/testdata/funalias_invalid_02.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:17-18:unknown symbol
 (defconst X 1)
 (defunalias INC X)

--- a/testdata/funalias_invalid_03.lisp
+++ b/testdata/funalias_invalid_03.lisp
@@ -1,1 +1,2 @@
+;;error:2:1-2:blah
 (defunalias X Y)

--- a/testdata/funalias_invalid_03.lisp
+++ b/testdata/funalias_invalid_03.lisp
@@ -1,2 +1,2 @@
-;;error:2:1-2:blah
+;;error:2:15-16:unknown symbol
 (defunalias X Y)

--- a/testdata/funalias_invalid_04.lisp
+++ b/testdata/funalias_invalid_04.lisp
@@ -1,2 +1,2 @@
-;;error:2:1-2:blah
+;;error:2:15-16:unknown symbol
 (defunalias X X)

--- a/testdata/funalias_invalid_04.lisp
+++ b/testdata/funalias_invalid_04.lisp
@@ -1,1 +1,2 @@
+;;error:2:1-2:blah
 (defunalias X X)

--- a/testdata/funalias_invalid_05.lisp
+++ b/testdata/funalias_invalid_05.lisp
@@ -1,3 +1,4 @@
+;;error:3:13-14:symbol already exists
 (defpurefun (or x y) (* x y))
 (defunalias + or)
 

--- a/testdata/if_invalid_01.lisp
+++ b/testdata/if_invalid_01.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:22-28:incorrect number of arguments
 (defcolumns A)
 (defconstraint c1 () (if A))

--- a/testdata/if_invalid_01.lisp
+++ b/testdata/if_invalid_01.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns A)
 (defconstraint c1 () (if A))

--- a/testdata/if_invalid_02.lisp
+++ b/testdata/if_invalid_02.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:22-34:incorrect number of arguments
 (defcolumns A B C D)
 (defconstraint c1 () (if A B C D))

--- a/testdata/if_invalid_02.lisp
+++ b/testdata/if_invalid_02.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns A B C D)
 (defconstraint c1 () (if A B C D))

--- a/testdata/if_invalid_03.lisp
+++ b/testdata/if_invalid_03.lisp
@@ -1,0 +1,3 @@
+;;error:3:26-27:invalid condition (neither loobean nor boolean)
+(defcolumns A B C)
+(defconstraint c1 () (if A B C))

--- a/testdata/interleave_invalid_01.lisp
+++ b/testdata/interleave_invalid_01.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:17-18:symbol Z already declared
 (defcolumns X Y Z)
 (definterleaved Z (X Y))

--- a/testdata/interleave_invalid_01.lisp
+++ b/testdata/interleave_invalid_01.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns X Y Z)
 (definterleaved Z (X Y))

--- a/testdata/interleave_invalid_02.lisp
+++ b/testdata/interleave_invalid_02.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:17-19:malformed target column
 (defcolumns X Y)
 (definterleaved () (X Y))

--- a/testdata/interleave_invalid_02.lisp
+++ b/testdata/interleave_invalid_02.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 (definterleaved () (X Y))

--- a/testdata/interleave_invalid_03.lisp
+++ b/testdata/interleave_invalid_03.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 (definterleaved Z ((X) Y))

--- a/testdata/interleave_invalid_03.lisp
+++ b/testdata/interleave_invalid_03.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:20-23:malformed source column
 (defcolumns X Y)
 (definterleaved Z ((X) Y))

--- a/testdata/interleave_invalid_04.lisp
+++ b/testdata/interleave_invalid_04.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 (definterleaved A (X Y))
 (definterleaved B (A Y))

--- a/testdata/interleave_invalid_04.lisp
+++ b/testdata/interleave_invalid_04.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:4:1-25:source column Y has incompatible length multiplier
 (defcolumns X Y)
 (definterleaved A (X Y))
 (definterleaved B (A Y))

--- a/testdata/interleave_invalid_05.lisp
+++ b/testdata/interleave_invalid_05.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 (definterleaved A (X Y))
 (definterleaved B (X A))

--- a/testdata/interleave_invalid_05.lisp
+++ b/testdata/interleave_invalid_05.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:4:1-25:source column A has incompatible length multiplier
 (defcolumns X Y)
 (definterleaved A (X Y))
 (definterleaved B (X A))

--- a/testdata/interleave_invalid_06.lisp
+++ b/testdata/interleave_invalid_06.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 (definterleaved A (X Y))
 (defconstraint c1 () (+ A X))

--- a/testdata/interleave_invalid_06.lisp
+++ b/testdata/interleave_invalid_06.lisp
@@ -1,4 +1,5 @@
-;;error:2:1-2:blah
+;;error:5:27-28:conflicting context
+;;error:5:22-29:expected loobean constraint (found 𝔽)
 (defcolumns X Y)
 (definterleaved A (X Y))
 (defconstraint c1 () (+ A X))

--- a/testdata/interleave_invalid_07.lisp
+++ b/testdata/interleave_invalid_07.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:4:22-23:conflicting context
 (defcolumns X Y)
 (definterleaved A (X Y))
 (defproperty p1 (+ A X))

--- a/testdata/interleave_invalid_07.lisp
+++ b/testdata/interleave_invalid_07.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 (definterleaved A (X Y))
 (defproperty p1 (+ A X))

--- a/testdata/interleave_invalid_08.lisp
+++ b/testdata/interleave_invalid_08.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:4:18-19:conflicting context
 (defcolumns X Y)
 (definterleaved A (X Y))
 (deflookup l1 (A X) (Y Y))

--- a/testdata/interleave_invalid_08.lisp
+++ b/testdata/interleave_invalid_08.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 (definterleaved A (X Y))
 (deflookup l1 (A X) (Y Y))

--- a/testdata/interleave_invalid_09.lisp
+++ b/testdata/interleave_invalid_09.lisp
@@ -1,4 +1,5 @@
-;;error:2:1-2:blah
+;;error:5:24-29:fixed-width type required
+;;error:5:30-35:incompatible length multiplier
 (defcolumns X Y)
 (definterleaved Z (X Y))
 (defpermutation (A B) ((+ Z) (+ Y)))

--- a/testdata/interleave_invalid_09.lisp
+++ b/testdata/interleave_invalid_09.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 (definterleaved Z (X Y))
 (defpermutation (A B) ((+ Z) (+ Y)))

--- a/testdata/interleave_invalid_10.lisp
+++ b/testdata/interleave_invalid_10.lisp
@@ -1,4 +1,5 @@
-;;error:2:1-2:blah
+;;error:5:24-29:fixed-width type required
+;;error:5:30-35:incompatible length multiplier
 (defcolumns X Y)
 (definterleaved Z (X Y))
 (defpermutation (A B) ((+ X) (+ Z)))

--- a/testdata/interleave_invalid_10.lisp
+++ b/testdata/interleave_invalid_10.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 (definterleaved Z (X Y))
 (defpermutation (A B) ((+ X) (+ Z)))

--- a/testdata/interleave_invalid_11.lisp
+++ b/testdata/interleave_invalid_11.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X)
 (defconst Y 1)
 (definterleaved Z (X Y))

--- a/testdata/interleave_invalid_11.lisp
+++ b/testdata/interleave_invalid_11.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:4:22-23:unknown symbol
 (defcolumns X)
 (defconst Y 1)
 (definterleaved Z (X Y))

--- a/testdata/interleave_invalid_12.lisp
+++ b/testdata/interleave_invalid_12.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:4:20-21:unknown symbol
 (defcolumns Y)
 (defconst X 1)
 (definterleaved Z (X Y))

--- a/testdata/interleave_invalid_12.lisp
+++ b/testdata/interleave_invalid_12.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns Y)
 (defconst X 1)
 (definterleaved Z (X Y))

--- a/testdata/lookup_invalid_01.lisp
+++ b/testdata/lookup_invalid_01.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 (deflookup test (Y) (X X))

--- a/testdata/lookup_invalid_01.lisp
+++ b/testdata/lookup_invalid_01.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:21-26:incorrect number of columns
 (defcolumns X Y)
 (deflookup test (Y) (X X))

--- a/testdata/lookup_invalid_02.lisp
+++ b/testdata/lookup_invalid_02.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:23-26:incorrect number of columns
 (defcolumns X Y)
 (deflookup test (Y Y) (X))

--- a/testdata/lookup_invalid_02.lisp
+++ b/testdata/lookup_invalid_02.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 (deflookup test (Y Y) (X))

--- a/testdata/lookup_invalid_03.lisp
+++ b/testdata/lookup_invalid_03.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 (deflookup () (Y) (X))

--- a/testdata/lookup_invalid_03.lisp
+++ b/testdata/lookup_invalid_03.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:12-14:malformed handle
 (defcolumns X Y)
 (deflookup () (Y) (X))

--- a/testdata/lookup_invalid_04.lisp
+++ b/testdata/lookup_invalid_04.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X)
 (deflookup test (X) (Y))
 

--- a/testdata/lookup_invalid_04.lisp
+++ b/testdata/lookup_invalid_04.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:3:22-23:unknown symbol
 (defcolumns X)
 (deflookup test (X) (Y))
 

--- a/testdata/lookup_invalid_05.lisp
+++ b/testdata/lookup_invalid_05.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:3:18-19:unknown symbol
 (defcolumns X)
 (deflookup test (Y) (X))
 

--- a/testdata/lookup_invalid_05.lisp
+++ b/testdata/lookup_invalid_05.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X)
 (deflookup test (Y) (X))
 

--- a/testdata/lookup_invalid_06.lisp
+++ b/testdata/lookup_invalid_06.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 (deflookup test (m1.A m2.B) (X Y))
 

--- a/testdata/lookup_invalid_06.lisp
+++ b/testdata/lookup_invalid_06.lisp
@@ -1,4 +1,5 @@
-;;error:2:1-2:blah
+;;error:4:18-22:unknown symbol
+;;error:4:23-27:unknown symbol
 (defcolumns X Y)
 (deflookup test (m1.A m2.B) (X Y))
 

--- a/testdata/lookup_invalid_07.lisp
+++ b/testdata/lookup_invalid_07.lisp
@@ -1,4 +1,5 @@
-;;error:2:1-2:blah
+;;error:4:21-25:unknown symbol
+;;error:4:26-30:unknown symbol
 (defcolumns X)
 (deflookup test ((+ m1.A m2.B)) (X))
 

--- a/testdata/lookup_invalid_07.lisp
+++ b/testdata/lookup_invalid_07.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X)
 (deflookup test ((+ m1.A m2.B)) (X))
 

--- a/testdata/lookup_invalid_08.lisp
+++ b/testdata/lookup_invalid_08.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X)
 (deflookup test ((+ m2.A 1)) (X))
 

--- a/testdata/lookup_invalid_08.lisp
+++ b/testdata/lookup_invalid_08.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:3:21-25:unknown symbol
 (defcolumns X)
 (deflookup test ((+ m2.A 1)) (X))
 

--- a/testdata/lookup_invalid_09.lisp
+++ b/testdata/lookup_invalid_09.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:3:25-29:unknown symbol
 (defcolumns X)
 (deflookup test (X) ((+ m2.A 1)))
 

--- a/testdata/lookup_invalid_09.lisp
+++ b/testdata/lookup_invalid_09.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X)
 (deflookup test (X) ((+ m2.A 1)))
 

--- a/testdata/module_invalid_01.lisp
+++ b/testdata/module_invalid_01.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:6:13-14:unknown symbol
 (module m1)
 (defcolumns X)
 

--- a/testdata/module_invalid_01.lisp
+++ b/testdata/module_invalid_01.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (module m1)
 (defcolumns X)
 

--- a/testdata/norm_invalid_01.lisp
+++ b/testdata/norm_invalid_01.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns ST A)
 (defconstraint c1 () (* ST (- 1 (~ A 0))))

--- a/testdata/norm_invalid_01.lisp
+++ b/testdata/norm_invalid_01.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:33-40:incorrect number of arguments
 (defcolumns ST A)
 (defconstraint c1 () (* ST (- 1 (~ A 0))))

--- a/testdata/permute_invalid_01.lisp
+++ b/testdata/permute_invalid_01.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:17-20:too many target columns
 (defcolumns (X :i16@prove))
 (defpermutation (Z) ())

--- a/testdata/permute_invalid_01.lisp
+++ b/testdata/permute_invalid_01.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns (X :i16@prove))
 (defpermutation (Z) ())

--- a/testdata/permute_invalid_02.lisp
+++ b/testdata/permute_invalid_02.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns (X :i16@prove))
 (defpermutation (Z) (X X))

--- a/testdata/permute_invalid_02.lisp
+++ b/testdata/permute_invalid_02.lisp
@@ -1,3 +1,4 @@
-;;error:2:1-2:blah
+;;error:4:17-20:too few target columns
+;;error:4:22-23:missing sort direction
 (defcolumns (X :i16@prove))
 (defpermutation (Z) (X X))

--- a/testdata/permute_invalid_03.lisp
+++ b/testdata/permute_invalid_03.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:22-25:malformed permutation column
 (defcolumns (X :i16@prove))
 (defpermutation (Z) ((X)))

--- a/testdata/permute_invalid_03.lisp
+++ b/testdata/permute_invalid_03.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns (X :i16@prove))
 (defpermutation (Z) ((X)))

--- a/testdata/permute_invalid_04.lisp
+++ b/testdata/permute_invalid_04.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:23-24:malformed sort direction
 (defcolumns (X :i16@prove))
 (defpermutation (Z) ((? X)))

--- a/testdata/permute_invalid_04.lisp
+++ b/testdata/permute_invalid_04.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns (X :i16@prove))
 (defpermutation (Z) ((? X)))

--- a/testdata/permute_invalid_05.lisp
+++ b/testdata/permute_invalid_05.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:4:22-30:unknown symbol
 (module m1)
 (defcolumns (X :i16@prove))
 (defpermutation (Z) ((+ m1.X)))

--- a/testdata/permute_invalid_05.lisp
+++ b/testdata/permute_invalid_05.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (module m1)
 (defcolumns (X :i16@prove))
 (defpermutation (Z) ((+ m1.X)))

--- a/testdata/permute_invalid_06.lisp
+++ b/testdata/permute_invalid_06.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns X)
 (defpermutation (Z) ((+ X)))

--- a/testdata/permute_invalid_06.lisp
+++ b/testdata/permute_invalid_06.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:22-27:fixed-width type required
 (defcolumns X)
 (defpermutation (Z) ((+ X)))

--- a/testdata/permute_invalid_07.lisp
+++ b/testdata/permute_invalid_07.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:4:22-23:missing sort direction
 (module m1)
 (defcolumns (X :i16))
 (defpermutation (Z) (X))

--- a/testdata/permute_invalid_07.lisp
+++ b/testdata/permute_invalid_07.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (module m1)
 (defcolumns (X :i16))
 (defpermutation (Z) (X))

--- a/testdata/permute_invalid_08.lisp
+++ b/testdata/permute_invalid_08.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:22-27:unknown symbol
 (defconst X 100)
 (defpermutation (Y) ((+ X)))

--- a/testdata/permute_invalid_08.lisp
+++ b/testdata/permute_invalid_08.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defconst X 100)
 (defpermutation (Y) ((+ X)))

--- a/testdata/property_invalid_01.lisp
+++ b/testdata/property_invalid_01.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns X)
 (defproperty (c) X)

--- a/testdata/property_invalid_01.lisp
+++ b/testdata/property_invalid_01.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:14-17:expected constraint handle
 (defcolumns X)
 (defproperty (c) X)

--- a/testdata/property_invalid_02.lisp
+++ b/testdata/property_invalid_02.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:1-21:malformed declaration
 (defcolumns X)
 (defproperty p1 X X)

--- a/testdata/property_invalid_02.lisp
+++ b/testdata/property_invalid_02.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns X)
 (defproperty p1 X X)

--- a/testdata/purefun_invalid_01.lisp
+++ b/testdata/purefun_invalid_01.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:4:25-27:unknown symbol
 (defcolumns A)
 ;;(defpurefun (id x) x)
 (defconstraint test () (id A))

--- a/testdata/purefun_invalid_01.lisp
+++ b/testdata/purefun_invalid_01.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns A)
 ;;(defpurefun (id x) x)
 (defconstraint test () (id A))

--- a/testdata/purefun_invalid_02.lisp
+++ b/testdata/purefun_invalid_02.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:4:27-29:unknown symbol
 (defcolumns A)
 (defpurefun (id x) x)
 (defconstraint test () (+ id A))

--- a/testdata/purefun_invalid_02.lisp
+++ b/testdata/purefun_invalid_02.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns A)
 (defpurefun (id x) x)
 (defconstraint test () (+ id A))

--- a/testdata/purefun_invalid_03.lisp
+++ b/testdata/purefun_invalid_03.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns A)
 (defpurefun (id x) x)
 (defconstraint test () (id A A))

--- a/testdata/purefun_invalid_03.lisp
+++ b/testdata/purefun_invalid_03.lisp
@@ -1,4 +1,5 @@
-;;error:2:1-2:blah
+;;error:5:24-32:incorrect number of arguments (found 2)
+;;error:5:24-32:ambiguous invocation
 (defcolumns A)
 (defpurefun (id x) x)
 (defconstraint test () (id A A))

--- a/testdata/purefun_invalid_04.lisp
+++ b/testdata/purefun_invalid_04.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:4:25-26:not permitted in pure context
 (defcolumns A)
 ;; not pure!
 (defpurefun (id x) (+ x A))

--- a/testdata/purefun_invalid_04.lisp
+++ b/testdata/purefun_invalid_04.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns A)
 ;; not pure!
 (defpurefun (id x) (+ x A))

--- a/testdata/purefun_invalid_05.lisp
+++ b/testdata/purefun_invalid_05.lisp
@@ -1,2 +1,2 @@
-;;error:2:1-2:blah
+;;error:2:25-26:unknown symbol
 (defpurefun (id x) (+ x y))

--- a/testdata/purefun_invalid_05.lisp
+++ b/testdata/purefun_invalid_05.lisp
@@ -1,1 +1,2 @@
+;;error:2:1-2:blah
 (defpurefun (id x) (+ x y))

--- a/testdata/purefun_invalid_06.lisp
+++ b/testdata/purefun_invalid_06.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X)
 ;; recursive :)
 (defpurefun (id x) (+ x (id x)))

--- a/testdata/purefun_invalid_07.lisp
+++ b/testdata/purefun_invalid_07.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns A)
 (defun (getA) A)
 ;; not pure!

--- a/testdata/purefun_invalid_07.lisp
+++ b/testdata/purefun_invalid_07.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:5:25-31:not permitted in pure context
 (defcolumns A)
 (defun (getA) A)
 ;; not pure!

--- a/testdata/purefun_invalid_08.lisp
+++ b/testdata/purefun_invalid_08.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:6:22-28:expected loobean constraint (found 𝔽)
 (defcolumns (X :@loob) Y)
 (defpurefun (id x) x)
 

--- a/testdata/purefun_invalid_08.lisp
+++ b/testdata/purefun_invalid_08.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns (X :@loob) Y)
 (defpurefun (id x) x)
 

--- a/testdata/purefun_invalid_09.lisp
+++ b/testdata/purefun_invalid_09.lisp
@@ -1,3 +1,5 @@
+;;error:6:39-40:expected type u1 (found 𝔽)
+;;error:7:39-40:expected type u1 (found u16)
 (defpurefun ((eq :binary@loob :force) (x :binary) (y :binary)) (^ (- x y) 2))
 ;;
 (defcolumns (X :binary@loob) Y (Z :i16))

--- a/testdata/purefun_invalid_10.lisp
+++ b/testdata/purefun_invalid_10.lisp
@@ -1,2 +1,3 @@
+;;error:3:1-29:symbol * already declared
 ;; Attempt to overload intrinsic.
 (defpurefun (* x y) (* x y))

--- a/testdata/purefun_invalid_11.lisp
+++ b/testdata/purefun_invalid_11.lisp
@@ -1,3 +1,4 @@
+;;error:4:1-50:symbol eq already declared
 ;; Duplicate overload is always a syntax error.
 (defpurefun (eq (x :binary) (y :binary)) (- x y))
 (defpurefun (eq (x :binary) (y :binary)) (+ x y))

--- a/testdata/purefun_invalid_12.lisp
+++ b/testdata/purefun_invalid_12.lisp
@@ -1,3 +1,4 @@
+;;error:4:1-25:symbol eq already declared
 ;; Cannot overload pure with impure, and vice versa.
 (defpurefun (eq (x :binary) (y :binary)) (- x y))
 (defun (eq x y) (+ x y))

--- a/testdata/purefun_invalid_13.lisp
+++ b/testdata/purefun_invalid_13.lisp
@@ -1,3 +1,4 @@
+;;error:8:22-30:ambiguous invocation
 (defpurefun (fn (x :binary) y) (- x y))
 (defpurefun (fn x (y :binary)) (+ x y))
 (defpurefun (fn x y) (* x y))

--- a/testdata/range_invalid_01.lisp
+++ b/testdata/range_invalid_01.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 
 (definrange X)

--- a/testdata/range_invalid_01.lisp
+++ b/testdata/range_invalid_01.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:4:1-15:malformed declaration
 (defcolumns X Y)
 
 (definrange X)

--- a/testdata/range_invalid_02.lisp
+++ b/testdata/range_invalid_02.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 (definrange X Y)

--- a/testdata/range_invalid_02.lisp
+++ b/testdata/range_invalid_02.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:15-16:malformed bound
 (defcolumns X Y)
 (definrange X Y)

--- a/testdata/range_invalid_03.lisp
+++ b/testdata/range_invalid_03.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:1-19:malformed declaration
 (defcolumns X Y)
 (definrange X 2 Y)

--- a/testdata/range_invalid_03.lisp
+++ b/testdata/range_invalid_03.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns X Y)
 (definrange X 2 Y)

--- a/testdata/range_invalid_04.lisp
+++ b/testdata/range_invalid_04.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns X)
 (definrange Y 2)

--- a/testdata/range_invalid_04.lisp
+++ b/testdata/range_invalid_04.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:13-14:unknown symbol
 (defcolumns X)
 (definrange Y 2)

--- a/testdata/reduce_invalid_01.lisp
+++ b/testdata/reduce_invalid_01.lisp
@@ -1,2 +1,3 @@
+;;error:3:33-34:unknown symbol
 (defcolumns (X :@loob) (Y :@loob))
 (defconstraint c1 () (reduce + (X Y)))

--- a/testdata/reduce_invalid_02.lisp
+++ b/testdata/reduce_invalid_02.lisp
@@ -1,1 +1,2 @@
+;;error:2:22-32:expected 2 arguments, found 1
 (defconstraint c1 () (reduce +))

--- a/testdata/reduce_invalid_03.lisp
+++ b/testdata/reduce_invalid_03.lisp
@@ -1,2 +1,3 @@
+;;error:3:22-44:expected loobean constraint (found 𝔽)
 (defcolumns X Y)
 (defconstraint c1 () (reduce + (begin X Y)))

--- a/testdata/reduce_invalid_04.lisp
+++ b/testdata/reduce_invalid_04.lisp
@@ -1,3 +1,4 @@
+;;error:4:22-45:incorrect number of arguments (expected 2)
 (defcolumns (X :@loob) (Y :@loob))
 (defpurefun (op x y z) (+ x y z))
 (defconstraint c1 () (reduce op (begin X Y)))

--- a/testdata/reduce_invalid_05.lisp
+++ b/testdata/reduce_invalid_05.lisp
@@ -1,3 +1,4 @@
+;;error:4:22-45:incorrect number of arguments (expected 2)
 (defcolumns (X :@loob) (Y :@loob))
 (defpurefun (op x) (+ x 1))
 (defconstraint c1 () (reduce op (begin X Y)))

--- a/testdata/shift_invalid_01.lisp
+++ b/testdata/shift_invalid_01.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
-(defcolumns X ST)
+;;error:3:37-38:not permitted in pure context
+(defcolumns (X :@loob) (ST :@loob))
 (defconstraint c1 () (* ST (shift X X)))

--- a/testdata/shift_invalid_01.lisp
+++ b/testdata/shift_invalid_01.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns X ST)
 (defconstraint c1 () (* ST (shift X X)))

--- a/testdata/shift_invalid_02.lisp
+++ b/testdata/shift_invalid_02.lisp
@@ -1,2 +1,3 @@
+;;error:2:1-2:blah
 (defcolumns X ST)
 (defconstraint c1 () (* ST (shift X)))

--- a/testdata/shift_invalid_02.lisp
+++ b/testdata/shift_invalid_02.lisp
@@ -1,3 +1,3 @@
-;;error:2:1-2:blah
+;;error:3:28-37:incorrect number of arguments
 (defcolumns X ST)
 (defconstraint c1 () (* ST (shift X)))

--- a/testdata/type_invalid_01.lisp
+++ b/testdata/type_invalid_01.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:6:22-32:expected loobean constraint (found u8)
 (defcolumns
     (BIT :binary@loob)
     (X :i8))

--- a/testdata/type_invalid_01.lisp
+++ b/testdata/type_invalid_01.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns
     (BIT :binary@loob)
     (X :i8))

--- a/testdata/type_invalid_02.lisp
+++ b/testdata/type_invalid_02.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns
     (BIT :binary)
     (X :i8@loob))

--- a/testdata/type_invalid_02.lisp
+++ b/testdata/type_invalid_02.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:6:26-29:invalid condition (neither loobean nor boolean)
 (defcolumns
     (BIT :binary)
     (X :i8@loob))

--- a/testdata/type_invalid_03.lisp
+++ b/testdata/type_invalid_03.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:6:26-29:invalid condition (neither loobean nor boolean)
 (defcolumns
     (BIT :i8)
     (X :i8@loob))

--- a/testdata/type_invalid_03.lisp
+++ b/testdata/type_invalid_03.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns
     (BIT :i8)
     (X :i8@loob))

--- a/testdata/type_invalid_04.lisp
+++ b/testdata/type_invalid_04.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns
     (BIT :binary@loob)
     (X :binary@bool))

--- a/testdata/type_invalid_04.lisp
+++ b/testdata/type_invalid_04.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:6:22-32:expected loobean constraint (found u1@bool)
 (defcolumns
     (BIT :binary@loob)
     (X :binary@bool))

--- a/testdata/type_invalid_05.lisp
+++ b/testdata/type_invalid_05.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns
     (BIT :binary)
     (X :binary@loob))

--- a/testdata/type_invalid_05.lisp
+++ b/testdata/type_invalid_05.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:6:26-35:invalid condition (neither loobean nor boolean)
 (defcolumns
     (BIT :binary)
     (X :binary@loob))

--- a/testdata/type_invalid_06.lisp
+++ b/testdata/type_invalid_06.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:4:27-30:unexpected loobean guard
 (defcolumns (BIT :i1@loob) (X :i1@loob))
 
 (defconstraint c1 (:guard BIT) X)

--- a/testdata/type_invalid_06.lisp
+++ b/testdata/type_invalid_06.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns (BIT :i1@loob) (X :i1@loob))
 
 (defconstraint c1 (:guard BIT) X)

--- a/testdata/type_invalid_07.lisp
+++ b/testdata/type_invalid_07.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:6:26-27:invalid condition (neither loobean nor boolean)
 (defcolumns (X :i1) (Y :i1) (A :i4@loob) (B :i4@loob))
 (definterleaved Z (X Y))
 (definterleaved C (A B))

--- a/testdata/type_invalid_07.lisp
+++ b/testdata/type_invalid_07.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns (X :i1) (Y :i1) (A :i4@loob) (B :i4@loob))
 (definterleaved Z (X Y))
 (definterleaved C (A B))

--- a/testdata/type_invalid_08.lisp
+++ b/testdata/type_invalid_08.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns (X :i1@loob) (Y :i1@loob) (A :i4) (B :i4))
 (definterleaved Z (X Y))
 (definterleaved C (A B))

--- a/testdata/type_invalid_08.lisp
+++ b/testdata/type_invalid_08.lisp
@@ -1,4 +1,4 @@
-;;error:2:1-2:blah
+;;error:6:22-30:expected loobean constraint (found u4)
 (defcolumns (X :i1@loob) (Y :i1@loob) (A :i4) (B :i4))
 (definterleaved Z (X Y))
 (definterleaved C (A B))

--- a/testdata/type_invalid_09.lisp
+++ b/testdata/type_invalid_09.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns (X :i1) (Y :i1) (A :i4@loob) (B :i4@loob))
 (definterleaved Z (X Y))
 (definterleaved C (A B))

--- a/testdata/type_invalid_10.lisp
+++ b/testdata/type_invalid_10.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns (X :i1@loob) (Y :i1) (A :i4@loob) (B :i4@loob))
 (definterleaved Z (X Y))
 (definterleaved C (A B))

--- a/testdata/type_invalid_11.lisp
+++ b/testdata/type_invalid_11.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns (X :i1) (Y :i1@loob) (A :i4@loob) (B :i4@loob))
 (definterleaved Z (X Y))
 (definterleaved C (A B))

--- a/testdata/type_invalid_12.lisp
+++ b/testdata/type_invalid_12.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns (X :i1@bool) (Y :i1) (A :i4@loob) (B :i4@loob))
 (definterleaved Z (X Y))
 (definterleaved C (A B))

--- a/testdata/type_invalid_13.lisp
+++ b/testdata/type_invalid_13.lisp
@@ -1,3 +1,4 @@
+;;error:2:1-2:blah
 (defcolumns (X :i1) (Y :i1@bool) (A :i4@loob) (B :i4@loob))
 (definterleaved Z (X Y))
 (definterleaved C (A B))


### PR DESCRIPTION
This adds a requirement that all invalid tests (i.e. tests which should fail with an error) have the exact error specified as part of the test.  A new comment syntax is supported for this purpose.