### PR TITLE
feat: support identifiers involving @

### DIFF
--- a/pkg/corset/parser.go
+++ b/pkg/corset/parser.go
@@ -1273,7 +1273,7 @@ func isIdentifierStart(c rune) bool {
 }
 
 func isIdentifierMiddle(c rune) bool {
-	return unicode.IsDigit(c) || isIdentifierStart(c) || c == '-' || c == '!'
+	return unicode.IsDigit(c) || isIdentifierStart(c) || c == '-' || c == '!' || c == '@'
 }
 
 func isFunctionIdentifierStart(c rune) bool {

--- a/testdata/purefun_06.lisp
+++ b/testdata/purefun_06.lisp
@@ -1,6 +1,6 @@
 (defcolumns X Y)
-(defun (double x) (+ x x))
+(defun (double@d x) (+ x x))
 (defpurefun ((~eq :@loob) x y) (~ (- x y)))
 
 ;; Y == 2 * X
-(defconstraint c1 () (~eq Y (double X)))
+(defconstraint c1 () (~eq Y (double@d X)))


### PR DESCRIPTION
This symbol is supported by the existing corset tool.  Therefore, to maintain backwards compatibility ... it must also be supported.