### PR TITLE
feat: update shf test

### DIFF
--- a/pkg/test/valid_corset_test.go
+++ b/pkg/test/valid_corset_test.go
@@ -805,11 +805,10 @@ func TestSlow_Mxp(t *testing.T) {
 	Check(t, true, "mxp")
 }
 
-/*
-	 func TestSlow_Shf(t *testing.T) {
-		Check(t, true, "shf")
-	}
-*/
+func TestSlow_Shf(t *testing.T) {
+	Check(t, true, "shf")
+}
+
 func TestSlow_Euc(t *testing.T) {
 	Check(t, true, "euc")
 }

--- a/testdata/shf.lisp
+++ b/testdata/shf.lisp
@@ -266,7 +266,7 @@
 ;;    2.5 shifting constraints   ;;
 ;;                               ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(defun (left-shift-by k ct bit_b bit_n B1_init B2_init B1_shft B2_shft)
+(defun (left-shift-by k ct bit_b (bit_n :binary) B1_init B2_init B1_shft B2_shft)
   (begin (plateau-constraint ct bit_n (- LLARGE k))
          (if-zero bit_b
                   (begin (= B1_shft B1_init)
@@ -278,7 +278,7 @@
                                      (shift B2_init (- k LLARGE)))
                                   (vanishes! B2_shft))))))
 
-(defun (right-shift-by k ct neg inst bit_b bit_n B1_init B2_init B1_shft B2_shft)
+(defun (right-shift-by k ct neg inst bit_b (bit_n :binary) B1_init B2_init B1_shft B2_shft)
   (begin (plateau-constraint ct bit_n k)
          (if-zero bit_b
                   (begin (= B1_shft B1_init)


### PR DESCRIPTION
This updates the shf test itself, rather than changing the go-corset implementation.  This is because, at this time, it seems like the more sensible option.  However, we may need to revisit this in the future if it ends up forcing lots of changes in the full constraint set.