### PR TITLE
feat: improve error reporting around functions

### DIFF
--- a/pkg/corset/resolver.go
+++ b/pkg/corset/resolver.go
@@ -455,7 +455,7 @@ func (r *resolver) finaliseDefFunInModule(enclosing Scope, decl *DefFun) []Synta
 	datatype, errors := r.finaliseExpressionInModule(scope, decl.Body())
 	// Finalise declaration
 	if len(errors) == 0 {
-		decl.binding.Finalise(datatype)
+		decl.symbol.binding.Finalise(datatype)
 	}
 	// Done
 	return errors

--- a/pkg/corset/symbol.go
+++ b/pkg/corset/symbol.go
@@ -65,6 +65,15 @@ func NewColumnName(name string) *ColumnName {
 	return &ColumnName{name, false, nil, false}
 }
 
+// FunctionName represents a name used in a position where it can only be
+// resolved as a function.
+type FunctionName = Name[*DefunBinding]
+
+// NewFunctionName construct a new column name which is (initially) unresolved.
+func NewFunctionName(name string, binding *DefunBinding) *FunctionName {
+	return &FunctionName{name, true, binding, true}
+}
+
 // Name represents a name within some syntactic item.  Essentially this wraps a
 // string and provides a mechanism for it to be associated with source line
 // information.

--- a/testdata/purefun_invalid_10.lisp
+++ b/testdata/purefun_invalid_10.lisp
@@ -1,3 +1,3 @@
-;;error:3:1-29:symbol * already declared
+;;error:3:14-15:symbol * already declared
 ;; Attempt to overload intrinsic.
 (defpurefun (* x y) (* x y))

--- a/testdata/purefun_invalid_11.lisp
+++ b/testdata/purefun_invalid_11.lisp
@@ -1,4 +1,4 @@
-;;error:4:1-50:symbol eq already declared
+;;error:4:14-16:symbol eq already declared
 ;; Duplicate overload is always a syntax error.
 (defpurefun (eq (x :binary) (y :binary)) (- x y))
 (defpurefun (eq (x :binary) (y :binary)) (+ x y))

--- a/testdata/purefun_invalid_12.lisp
+++ b/testdata/purefun_invalid_12.lisp
@@ -1,4 +1,4 @@
-;;error:4:1-25:symbol eq already declared
+;;error:4:9-11:symbol eq already declared
 ;; Cannot overload pure with impure, and vice versa.
 (defpurefun (eq (x :binary) (y :binary)) (- x y))
 (defun (eq x y) (+ x y))


### PR DESCRIPTION
This improves the error reporting around functions, such as arising from defun and defpurefun.  Specifically, it highlights only the function name when there is a general error related to the function (e.g. its redeclared, etc).