### PR TITLE
fix: improve errors for substituted for variables

### DIFF
--- a/pkg/sexp/translator.go
+++ b/pkg/sexp/translator.go
@@ -336,7 +336,7 @@ func translateSExpArray[T comparable](p *Translator[T], l *Array) (T, []SyntaxEr
 	// Check whether we found one.
 	if t != nil {
 		node, errors = (t)(l)
-	} else if p.list_default != nil {
+	} else if p.array_default != nil {
 		node, err := (p.array_default)(l)
 		// Update source mapping
 		if err == nil {

--- a/pkg/test/invalid_corset_test.go
+++ b/pkg/test/invalid_corset_test.go
@@ -576,6 +576,10 @@ func Test_Invalid_Array_05(t *testing.T) {
 	CheckInvalid(t, "array_invalid_05")
 }
 
+func Test_Invalid_Array_06(t *testing.T) {
+	CheckInvalid(t, "array_invalid_06")
+}
+
 // ===================================================================
 // Reduce
 // ===================================================================

--- a/testdata/array_invalid_06.lisp
+++ b/testdata/array_invalid_06.lisp
@@ -1,0 +1,10 @@
+;;error:10:36-37:array index out-of-bounds
+;;error:10:31-38:void expression not permitted here
+(defcolumns
+    (BIT :binary@prove :array [4])
+    (ARG :i16@loob))
+
+(defconstraint bits ()
+  (- ARG
+     (reduce +
+      (for i [0:3] (* (^ 2 i) [BIT i])))))


### PR DESCRIPTION
This improves the error reporting for substituted index variables. For example, when the index variable is actually out-of-range then its nice to report a sensible error about this.