### PR TITLE
feat: increase resolution cycle limit

### DIFF
--- a/pkg/corset/resolver.go
+++ b/pkg/corset/resolver.go
@@ -191,7 +191,7 @@ func (r *resolver) finaliseDeclarationsInModule(scope *ModuleScope, decls []Decl
 	// error reporting).
 	var (
 		incomplete Node = nil
-		counter    uint = 4
+		counter    uint = 32
 	)
 	//
 	for changed && !complete && counter > 0 {


### PR DESCRIPTION
This increases the limit from 4 to 32.  Its not clear what the right limit is, but if the limit is too high then that could cause a long delay in certain situations.