### PR TITLE
feat: support defensive padding

### DIFF
--- a/pkg/schema/assertion.go
+++ b/pkg/schema/assertion.go
@@ -60,6 +60,12 @@ func NewPropertyAssertion[T Testable](handle string, ctx tr.Context, property T)
 	return &PropertyAssertion[T]{handle, ctx, property}
 }
 
+// Bounds is not required for a property assertion since these are not real
+// constraints.
+func (p *PropertyAssertion[T]) Bounds(module uint) util.Bounds {
+	return util.EMPTY_BOUND
+}
+
 // Accepts checks whether a vanishing constraint evaluates to zero on every row
 // of a table. If so, return nil otherwise return an error.
 //

--- a/pkg/schema/assignment/byte_decomposition.go
+++ b/pkg/schema/assignment/byte_decomposition.go
@@ -94,10 +94,13 @@ func (p *ByteDecomposition) ComputeColumns(tr trace.Trace) ([]trace.ArrayColumn,
 	return cols, nil
 }
 
-// RequiredSpillage returns the minimum amount of spillage required to ensure
-// valid traces are accepted in the presence of arbitrary padding.
-func (p *ByteDecomposition) RequiredSpillage() uint {
-	return uint(0)
+// Bounds determines the well-definedness bounds for this assignment for both
+// the negative (left) or positive (right) directions.  For example, consider an
+// expression such as "(shift X -1)".  This is technically undefined for the
+// first row of any trace and, by association, any constraint evaluating this
+// expression on that first row is also undefined (and hence must pass).
+func (p *ByteDecomposition) Bounds() util.Bounds {
+	return util.EMPTY_BOUND
 }
 
 // Dependencies returns the set of columns that this assignment depends upon.

--- a/pkg/schema/assignment/computation.go
+++ b/pkg/schema/assignment/computation.go
@@ -67,10 +67,13 @@ func (p *Computation) IsComputed() bool {
 // Assignment Interface
 // ============================================================================
 
-// RequiredSpillage returns the minimum amount of spillage required to ensure
-// valid traces are accepted in the presence of arbitrary padding.
-func (p *Computation) RequiredSpillage() uint {
-	return uint(0)
+// Bounds determines the well-definedness bounds for this assignment for both
+// the negative (left) or positive (right) directions.  For example, consider an
+// expression such as "(shift X -1)".  This is technically undefined for the
+// first row of any trace and, by association, any constraint evaluating this
+// expression on that first row is also undefined (and hence must pass).
+func (p *Computation) Bounds() util.Bounds {
+	return util.EMPTY_BOUND
 }
 
 // ComputeColumns computes the values of columns defined by this assignment.

--- a/pkg/schema/assignment/computed_column.go
+++ b/pkg/schema/assignment/computed_column.go
@@ -63,15 +63,13 @@ func (p *ComputedColumn[E]) IsComputed() bool {
 // Assignment Interface
 // ============================================================================
 
-// RequiredSpillage returns the minimum amount of spillage required to ensure
-// this column can be correctly computed in the presence of arbitrary (front)
-// padding.
-func (p *ComputedColumn[E]) RequiredSpillage() uint {
-	// NOTE: Spillage is only currently considered to be necessary at the front
-	// (i.e. start) of a trace.  This is because padding is always inserted at
-	// the front, never the back.  As such, it is the maximum positive shift
-	// which determines how much spillage is required for this comptuation.
-	return p.expr.Bounds().End
+// Bounds determines the well-definedness bounds for this assignment for both
+// the negative (left) or positive (right) directions.  For example, consider an
+// expression such as "(shift X -1)".  This is technically undefined for the
+// first row of any trace and, by association, any constraint evaluating this
+// expression on that first row is also undefined (and hence must pass).
+func (p *ComputedColumn[E]) Bounds() util.Bounds {
+	return p.expr.Bounds()
 }
 
 // ComputeColumns computes the values of columns defined by this assignment.

--- a/pkg/schema/assignment/interleave.go
+++ b/pkg/schema/assignment/interleave.go
@@ -64,10 +64,13 @@ func (p *Interleaving) IsComputed() bool {
 // Assignment Interface
 // ============================================================================
 
-// RequiredSpillage returns the minimum amount of spillage required to ensure
-// valid traces are accepted in the presence of arbitrary padding.
-func (p *Interleaving) RequiredSpillage() uint {
-	return uint(0)
+// Bounds determines the well-definedness bounds for this assignment for both
+// the negative (left) or positive (right) directions.  For example, consider an
+// expression such as "(shift X -1)".  This is technically undefined for the
+// first row of any trace and, by association, any constraint evaluating this
+// expression on that first row is also undefined (and hence must pass).
+func (p *Interleaving) Bounds() util.Bounds {
+	return util.EMPTY_BOUND
 }
 
 // ComputeColumns computes the values of columns defined by this assignment.

--- a/pkg/schema/assignment/lexicographic_sort.go
+++ b/pkg/schema/assignment/lexicographic_sort.go
@@ -68,10 +68,13 @@ func (p *LexicographicSort) IsComputed() bool {
 // Assignment Interface
 // ============================================================================
 
-// RequiredSpillage returns the minimum amount of spillage required to ensure
-// valid traces are accepted in the presence of arbitrary padding.
-func (p *LexicographicSort) RequiredSpillage() uint {
-	return uint(0)
+// Bounds determines the well-definedness bounds for this assignment for both
+// the negative (left) or positive (right) directions.  For example, consider an
+// expression such as "(shift X -1)".  This is technically undefined for the
+// first row of any trace and, by association, any constraint evaluating this
+// expression on that first row is also undefined (and hence must pass).
+func (p *LexicographicSort) Bounds() util.Bounds {
+	return util.EMPTY_BOUND
 }
 
 // ComputeColumns computes the values of columns defined as needed to support

--- a/pkg/schema/assignment/sorted_permutation.go
+++ b/pkg/schema/assignment/sorted_permutation.go
@@ -70,10 +70,13 @@ func (p *SortedPermutation) IsComputed() bool {
 // Assignment Interface
 // ============================================================================
 
-// RequiredSpillage returns the minimum amount of spillage required to ensure
-// valid traces are accepted in the presence of arbitrary padding.
-func (p *SortedPermutation) RequiredSpillage() uint {
-	return uint(0)
+// Bounds determines the well-definedness bounds for this assignment for both
+// the negative (left) or positive (right) directions.  For example, consider an
+// expression such as "(shift X -1)".  This is technically undefined for the
+// first row of any trace and, by association, any constraint evaluating this
+// expression on that first row is also undefined (and hence must pass).
+func (p *SortedPermutation) Bounds() util.Bounds {
+	return util.EMPTY_BOUND
 }
 
 // ComputeColumns computes the values of columns defined by this assignment.

--- a/pkg/schema/constraint/lookup.go
+++ b/pkg/schema/constraint/lookup.go
@@ -66,6 +66,31 @@ func NewLookupConstraint[E schema.Evaluable](handle string, source trace.Context
 	return &LookupConstraint[E]{handle, source, target, sources, targets}
 }
 
+// Bounds determines the well-definedness bounds for this constraint for both
+// the negative (left) or positive (right) directions.  For example, consider an
+// expression such as "(shift X -1)".  This is technically undefined for the
+// first row of any trace and, by association, any constraint evaluating this
+// expression on that first row is also undefined (and hence must pass).
+//
+//nolint:revive
+func (p *LookupConstraint[E]) Bounds(module uint) util.Bounds {
+	var bound util.Bounds
+	//
+	if module == p.SourceContext.Module() {
+		for _, e := range p.Sources {
+			eth := e.Bounds()
+			bound.Union(&eth)
+		}
+	} else if module == p.TargetContext.Module() {
+		for _, e := range p.Targets {
+			eth := e.Bounds()
+			bound.Union(&eth)
+		}
+	}
+	//
+	return bound
+}
+
 // Accepts checks whether a lookup constraint into the target columns holds for
 // all rows of the source columns.
 //

--- a/pkg/schema/constraint/permutation.go
+++ b/pkg/schema/constraint/permutation.go
@@ -44,10 +44,13 @@ func NewPermutationConstraint(targets []uint, sources []uint) *PermutationConstr
 	return &PermutationConstraint{targets, sources}
 }
 
-// RequiredSpillage returns the minimum amount of spillage required to ensure
-// valid traces are accepted in the presence of arbitrary padding.
-func (p *PermutationConstraint) RequiredSpillage() uint {
-	return uint(0)
+// Bounds determines the well-definedness bounds for this constraint for both
+// the negative (left) or positive (right) directions.  For example, consider an
+// expression such as "(shift X -1)".  This is technically undefined for the
+// first row of any trace and, by association, any constraint evaluating this
+// expression on that first row is also undefined (and hence must pass).
+func (p *PermutationConstraint) Bounds(module uint) util.Bounds {
+	return util.EMPTY_BOUND
 }
 
 // Accepts checks whether a permutation holds between the source and

--- a/pkg/schema/constraint/range.go
+++ b/pkg/schema/constraint/range.go
@@ -7,6 +7,7 @@ import (
 	"github.com/consensys/go-corset/pkg/schema"
 	sc "github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
+	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/sexp"
 )
 
@@ -60,6 +61,21 @@ func NewRangeConstraint[E sc.Evaluable](handle string, context trace.Context,
 func (p *RangeConstraint[E]) BoundedAtMost(bound uint) bool {
 	var n fr.Element = fr.NewElement(uint64(bound))
 	return p.Bound.Cmp(&n) <= 0
+}
+
+// Bounds determines the well-definedness bounds for this constraint for both
+// the negative (left) or positive (right) directions.  For example, consider an
+// expression such as "(shift X -1)".  This is technically undefined for the
+// first row of any trace and, by association, any constraint evaluating this
+// expression on that first row is also undefined (and hence must pass).
+//
+//nolint:revive
+func (p *RangeConstraint[E]) Bounds(module uint) util.Bounds {
+	if p.Context.Module() == module {
+		return p.Expr.Bounds()
+	}
+	//
+	return util.EMPTY_BOUND
 }
 
 // Accepts checks whether a range constraint holds on every row of a table. If so, return

--- a/pkg/schema/constraint/vanishing.go
+++ b/pkg/schema/constraint/vanishing.go
@@ -113,6 +113,21 @@ func NewVanishingConstraint[T sc.Testable](handle string, context tr.Context,
 	return &VanishingConstraint[T]{handle, context, domain, constraint}
 }
 
+// Bounds determines the well-definedness bounds for this constraint for both
+// the negative (left) or positive (right) directions.  For example, consider an
+// expression such as "(shift X -1)".  This is technically undefined for the
+// first row of any trace and, by association, any constraint evaluating this
+// expression on that first row is also undefined (and hence must pass).
+//
+//nolint:revive
+func (p *VanishingConstraint[E]) Bounds(module uint) util.Bounds {
+	if p.Context.Module() == module {
+		return p.Constraint.Bounds()
+	}
+	//
+	return util.EMPTY_BOUND
+}
+
 // Accepts checks whether a vanishing constraint evaluates to zero on every row
 // of a table.  If so, return nil otherwise return an error.
 //

--- a/pkg/trace/array_trace.go
+++ b/pkg/trace/array_trace.go
@@ -73,14 +73,15 @@ func (p *ArrayTrace) FillColumn(cid uint, data field.FrArray, padding fr.Element
 	col.fill(data, padding)
 }
 
-// Pad pads a given module with a given number of padding rows.
-func (p *ArrayTrace) Pad(module uint, n uint) {
-	p.modules[module].height += n
+// Pad prepends (front) and appends (back) a given module with a given number of
+// padding rows.
+func (p *ArrayTrace) Pad(module uint, front uint, back uint) {
+	p.modules[module].height += front + back
 	// Padd each column contained within this module.
 	for i := 0; i < len(p.columns); i++ {
 		c := &p.columns[i]
 		if c.context.ModuleId == module {
-			c.pad(n)
+			c.pad(front, back)
 		}
 	}
 }
@@ -234,14 +235,12 @@ func (p *ArrayColumn) fill(data field.FrArray, padding fr.Element) {
 	p.padding = padding
 }
 
-func (p *ArrayColumn) pad(n uint) {
-	// FIXME: have to avoid attempting to pad a computed column which has not
-	// yet neen computed (i.e. because we are applying spillage).  Somehow, this
-	// special casing does not feel right to me.
+func (p *ArrayColumn) pad(front uint, back uint) {
 	if p.data != nil {
 		// Apply the length multiplier
-		n = n * p.context.LengthMultiplier()
+		front = front * p.context.LengthMultiplier()
+		back = back * p.context.LengthMultiplier()
 		// Pad front of array
-		p.data = p.data.PadFront(n, p.padding)
+		p.data = p.data.Pad(front, back, p.padding)
 	}
 }

--- a/pkg/util/arrays.go
+++ b/pkg/util/arrays.go
@@ -23,9 +23,9 @@ type Array[T comparable] interface {
 	Slice(uint, uint) Array[T]
 	// Return the number of bits required to store an element of this array.
 	BitWidth() uint
-	// Insert a given number of copies of T at start of array producing an
-	// updated array.
-	PadFront(uint, T) Array[T]
+	// Insert n copies of T at start of the array and m copies at the back
+	// producing an updated array.
+	Pad(uint, uint, T) Array[T]
 	// Write out the contents of this array, assuming a minimal unit of 1 byte
 	// per element.
 	Write(w io.Writer) error

--- a/pkg/util/field/field_array.go
+++ b/pkg/util/field/field_array.go
@@ -101,14 +101,20 @@ func (p *FrElementArray) Slice(start uint, end uint) util.Array[fr.Element] {
 	return &FrElementArray{p.elements[start:end], p.bitwidth}
 }
 
-// PadFront (i.e. insert at the beginning) this array with n copies of the given padding value.
-func (p *FrElementArray) PadFront(n uint, padding fr.Element) util.Array[fr.Element] {
+// Pad prepend array with n copies and append with m copies of the given padding
+// value.
+func (p *FrElementArray) Pad(n uint, m uint, padding fr.Element) util.Array[fr.Element] {
+	l := uint(len(p.elements))
 	// Allocate sufficient memory
-	ndata := make([]fr.Element, uint(len(p.elements))+n)
+	ndata := make([]fr.Element, l+n+m)
 	// Copy over the data
 	copy(ndata[n:], p.elements)
-	// Go padding!
+	// Front padding!
 	for i := uint(0); i < n; i++ {
+		ndata[i] = padding
+	}
+	// Back padding!
+	for i := n + l; i < n+l+m; i++ {
 		ndata[i] = padding
 	}
 	// Copy over

--- a/pkg/util/field/field_index_array.go
+++ b/pkg/util/field/field_index_array.go
@@ -101,10 +101,12 @@ func (p *FrIndexArray) Slice(start uint, end uint) util.Array[fr.Element] {
 	return &FrIndexArray{elements[start:end], heap, pool, p.bitwidth}
 }
 
-// PadFront (i.e. insert at the beginning) this array with n copies of the given padding value.
-func (p *FrIndexArray) PadFront(n uint, padding fr.Element) util.Array[fr.Element] {
+// Pad prepend array with n copies and append with m copies of the given padding
+// value.
+func (p *FrIndexArray) Pad(n uint, m uint, padding fr.Element) util.Array[fr.Element] {
+	l := uint(len(p.elements))
 	// Allocate sufficient memory
-	elements := make([]uint32, uint(len(p.elements))+n)
+	elements := make([]uint32, l+n+m)
 	heap := make([]fr.Element, len(p.heap))
 	pool := make(map[[4]uint64]uint32, len(p.pool))
 	// Copy over the data
@@ -116,8 +118,12 @@ func (p *FrIndexArray) PadFront(n uint, padding fr.Element) util.Array[fr.Elemen
 	}
 	//
 	narr := &FrIndexArray{elements, heap, pool, p.bitwidth}
-	// Go padding!
+	// Front padding!
 	for i := uint(0); i < n; i++ {
+		narr.Set(i, padding)
+	}
+	// Back padding!
+	for i := n + l; i < l+n+m; i++ {
 		narr.Set(i, padding)
 	}
 	// Copy over

--- a/pkg/util/field/field_pool_array.go
+++ b/pkg/util/field/field_pool_array.go
@@ -69,15 +69,22 @@ func (p *FrPoolArray[K, P]) Slice(start uint, end uint) util.Array[fr.Element] {
 	return &FrPoolArray[K, P]{p.pool, p.elements[start:end], p.bitwidth}
 }
 
-// PadFront (i.e. insert at the beginning) this array with n copies of the given padding value.
-func (p *FrPoolArray[K, P]) PadFront(n uint, padding fr.Element) util.Array[fr.Element] {
+// Pad prepend array with n copies and append with m copies of the given padding
+// value.
+func (p *FrPoolArray[K, P]) Pad(n uint, m uint, padding fr.Element) util.Array[fr.Element] {
+	l := uint(len(p.elements))
+	// Ensure padding in pool
 	key := p.pool.Put(padding)
 	// Allocate sufficient memory
-	nelements := make([]K, uint(len(p.elements))+n)
+	nelements := make([]K, l+n+m)
 	// Copy over the data
 	copy(nelements[n:], p.elements)
-	// Go padding!
+	// Front padding!
 	for i := uint(0); i < n; i++ {
+		nelements[i] = key
+	}
+	// Back padding!
+	for i := l + n; i < l+n+m; i++ {
 		nelements[i] = key
 	}
 	// Copy over

--- a/testdata/basic_09.lisp
+++ b/testdata/basic_09.lisp
@@ -2,4 +2,5 @@
 
 (defcolumns CT)
 (defconstraint c1 () (vanishes!
+                      ;; CT(i) == CT(i+1) || CT(i) + 1 == CT(i+1)
                       (* (- CT (shift CT 1)) (- (+ CT 1) (shift CT 1)))))


### PR DESCRIPTION
This adds support for defensive padding, and enables it by default. Defensive padding is the conversative prepending of padding rows to ensure that constraints in the active region are not clipped.  This reflects the fact that such constraints may be subject to padding by the prover anyway and, hence, we simply get ahead of the curve by doing adding it automatically.

This also adds support to the trace command to expand the trace prior to filtering, etc and also to allow defensive padding and/or spillage to be applied.