### PR TITLE
feat: support writing coverage data

### DIFF
--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -13,6 +13,7 @@
 package cmd
 
 import (
+	enc_json "encoding/json"
 	"fmt"
 	"os"
 	"path"
@@ -23,6 +24,7 @@ import (
 	legacy_binfile "github.com/consensys/go-corset/pkg/binfile/legacy"
 	"github.com/consensys/go-corset/pkg/corset"
 	"github.com/consensys/go-corset/pkg/hir"
+	sc "github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/trace/json"
 	"github.com/consensys/go-corset/pkg/trace/lt"
@@ -85,6 +87,32 @@ func GetStringArray(cmd *cobra.Command, flag string) []string {
 	}
 
 	return r
+}
+
+func writeCoverageReport(filename string, air sc.CoverageMap, mir sc.CoverageMap, hir sc.CoverageMap) {
+	var data map[string]any = make(map[string]any)
+	// Add AIR data (if applicable)
+	if !air.IsEmpty() {
+		data["air"] = air.ToJson()
+	}
+	// Add MIR data (if applicable)
+	if !mir.IsEmpty() {
+		data["mir"] = mir.ToJson()
+	}
+	// Add HIR data (if applicable)
+	if !hir.IsEmpty() {
+		data["hir"] = hir.ToJson()
+	}
+	// write to disk
+	jsonString, err := enc_json.Marshal(data)
+	//
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(5)
+	} else if err := os.WriteFile(filename, jsonString, 0644); err != nil {
+		fmt.Println(err)
+		os.Exit(6)
+	}
 }
 
 // Write a given trace file to disk

--- a/pkg/schema/coverage.go
+++ b/pkg/schema/coverage.go
@@ -59,6 +59,11 @@ func NewBranchCoverage() CoverageMap {
 	return CoverageMap{items}
 }
 
+// IsEmpty checks whether or not this map is empty.
+func (p *CoverageMap) IsEmpty() bool {
+	return len(p.items) == 0
+}
+
 // CoverageOf returns, for a given constraint, the recorded coverage data.
 func (p *CoverageMap) CoverageOf(name string) Coverage {
 	return p.items[name]
@@ -99,6 +104,22 @@ func (p *CoverageMap) Keys() *set.SortedSet[string] {
 	}
 	//
 	return keys
+}
+
+// ToJson returns a representation of this coverage map suitable for being
+// converted into JSON.
+func (p *CoverageMap) ToJson() map[string]any {
+	var json map[string]any = make(map[string]any)
+	//
+	keys := p.Keys()
+	// Print out the data
+	for iter := keys.Iter(); iter.HasNext(); {
+		ith := iter.Next()
+		cov := p.CoverageOf(ith)
+		json[ith] = cov.Covered.Iter().Collect()
+	}
+	//
+	return json
 }
 
 // ============================================================================

--- a/pkg/util/collection/bit/bit_test.go
+++ b/pkg/util/collection/bit/bit_test.go
@@ -13,6 +13,7 @@
 package bit
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/consensys/go-corset/pkg/util"
@@ -47,6 +48,10 @@ func TestSlow_BitSet_05(t *testing.T) {
 
 func TestSlow_BitSet_06(t *testing.T) {
 	check_BitSet_Insert(t, 100000, 16384)
+}
+
+func TestSlow_BitSet_07(t *testing.T) {
+	check_BitSet_Insert(t, 100000, 65536)
 }
 
 // ===================================================================
@@ -87,6 +92,9 @@ func check_BitSet_Insert(t *testing.T, n uint, m uint) {
 	//
 	if bset.Count() != count {
 		t.Errorf("unexpected number of items (%d vs %d) (insert)", bset.Count(), count)
+	} else if c := bset.Iter().Count(); c != count {
+		fmt.Printf("%v\n", items)
+		t.Errorf("unexpected number of items (%d vs %d) (iterator)", c, count)
 	}
 	//
 	if iset.Count() != count {
@@ -108,6 +116,13 @@ func check_BitSet_Insert(t *testing.T, n uint, m uint) {
 			t.Errorf("unexpected item %d (insert all)", i)
 		} else if l && !s {
 			t.Errorf("missing item %d (insert all)", i)
+		}
+	}
+	//
+	for iter := bset.Iter(); iter.HasNext(); {
+		ith := iter.Next()
+		if !array_contains(items, ith) {
+			t.Errorf("unexpected item %d (iterator)", ith)
 		}
 	}
 }

--- a/pkg/util/collection/iter/append.go
+++ b/pkg/util/collection/iter/append.go
@@ -80,7 +80,7 @@ func (p *appendIterator[T]) Count() uint {
 //
 //nolint:revive
 func (p *appendIterator[T]) Find(predicate Predicate[T]) (uint, bool) {
-	return baseFind(p, predicate)
+	return Find(p, predicate)
 }
 
 // Nth returns the nth item in this iterator
@@ -88,5 +88,5 @@ func (p *appendIterator[T]) Find(predicate Predicate[T]) (uint, bool) {
 //nolint:revive
 func (p *appendIterator[T]) Nth(n uint) T {
 	// TODO: improve performance.
-	return baseNth(p, n)
+	return Nth(p, n)
 }

--- a/pkg/util/collection/iter/array.go
+++ b/pkg/util/collection/iter/array.go
@@ -80,7 +80,7 @@ func (p *arrayIterator[T]) Count() uint {
 //
 //nolint:revive
 func (p *arrayIterator[T]) Find(predicate Predicate[T]) (uint, bool) {
-	return baseFind(p, predicate)
+	return Find(p, predicate)
 }
 
 // Nth returns the nth item in this iterator

--- a/pkg/util/collection/iter/flatten.go
+++ b/pkg/util/collection/iter/flatten.go
@@ -113,7 +113,7 @@ func (p *flattenIterator[S, T]) Count() uint {
 //
 //nolint:revive
 func (p *flattenIterator[S, T]) Find(predicate Predicate[T]) (uint, bool) {
-	return baseFind(p, predicate)
+	return Find(p, predicate)
 }
 
 // Nth returns the nth item in this iterator

--- a/pkg/util/collection/iter/iterator.go
+++ b/pkg/util/collection/iter/iterator.go
@@ -48,11 +48,15 @@ type Iterator[T any] interface {
 // Base Iterator
 // ===============================================================
 
-func baseFind[T any, S Enumerator[T]](iter S, predicate Predicate[T]) (uint, bool) {
+// Find provides a default implementation of Iterator.Find which can be used by
+// other iterator implementations.
+//
+//nolint:revive
+func Find[T any, S Enumerator[T]](iter S, predicate Predicate[T]) (uint, bool) {
 	index := uint(0)
 
-	for i := iter; i.HasNext(); {
-		if predicate(i.Next()) {
+	for iter.HasNext() {
+		if predicate(iter.Next()) {
 			return index, true
 		}
 
@@ -62,11 +66,15 @@ func baseFind[T any, S Enumerator[T]](iter S, predicate Predicate[T]) (uint, boo
 	return 0, false
 }
 
-func baseNth[T any, S Enumerator[T]](iter S, n uint) T {
+// Nth provides a default implementation of Iterator.Nth which can be used by
+// other iterator implementations.
+//
+//nolint:revive
+func Nth[T any, S Enumerator[T]](iter S, n uint) T {
 	index := uint(0)
 
-	for i := iter; i.HasNext(); {
-		ith := i.Next()
+	for iter.HasNext() {
+		ith := iter.Next()
 		if index == n {
 			return ith
 		}
@@ -75,4 +83,34 @@ func baseNth[T any, S Enumerator[T]](iter S, n uint) T {
 	}
 	// Issue!
 	panic("iterator out-of-bounds")
+}
+
+// Count provides a default implementation of Iterator.Count which can be used by
+// other iterator implementations.
+//
+//nolint:revive
+func Count[T any, S Enumerator[T]](iter S) uint {
+	count := uint(0)
+
+	for iter.HasNext() {
+		iter.Next()
+		//
+		count++
+	}
+	// Issue!
+	return count
+}
+
+// Collect provides a default implementation of Iterator.Collect which can be used by
+// other iterator implementations.
+//
+//nolint:revive
+func Collect[T any, S Enumerator[T]](iter S) []T {
+	var items []T = make([]T, 0)
+	//
+	for iter.HasNext() {
+		items = append(items, iter.Next())
+	}
+	//
+	return items
 }


### PR DESCRIPTION
The coverage cli command now accepts a filename which identifies where coverage data is going to be written.  The intention is that an additional command will be added ("coverage") which can be used to query coverage data, or to aggregate it, etc.