### PR TITLE
feat: enable MIR optimisation levels

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -39,4 +39,5 @@ func init() {
 	rootCmd.PersistentFlags().Bool("legacy", false, "use legacy binary format")
 	rootCmd.PersistentFlags().Bool("no-stdlib", false, "prevent standard library from being included")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "increase logging verbosity")
+	rootCmd.PersistentFlags().UintP("opt", "O", 1, "set optimisation level")
 }

--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -26,6 +26,7 @@ import (
 	legacy_binfile "github.com/consensys/go-corset/pkg/binfile/legacy"
 	"github.com/consensys/go-corset/pkg/corset"
 	"github.com/consensys/go-corset/pkg/hir"
+	"github.com/consensys/go-corset/pkg/mir"
 	sc "github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/trace/json"
@@ -92,7 +93,9 @@ func GetStringArray(cmd *cobra.Command, flag string) []string {
 	return r
 }
 
-func writeCoverageReport(filename string, binfile *binfile.BinaryFile, coverage [3]sc.CoverageMap) {
+func writeCoverageReport(filename string, binfile *binfile.BinaryFile, coverage [3]sc.CoverageMap,
+	config mir.OptimisationConfig) {
+	//
 	var (
 		air                 = coverage[0]
 		mir                 = coverage[1]
@@ -102,7 +105,7 @@ func writeCoverageReport(filename string, binfile *binfile.BinaryFile, coverage 
 	// Lower schemas
 	hirSchema := &binfile.Schema
 	mirSchema := hirSchema.LowerToMir()
-	airSchema := mirSchema.LowerToAir()
+	airSchema := mirSchema.LowerToAir(config)
 	// Add AIR data (if applicable)
 	if !air.IsEmpty() {
 		data["air"] = air.ToJson(airSchema)
@@ -127,7 +130,7 @@ func writeCoverageReport(filename string, binfile *binfile.BinaryFile, coverage 
 	}
 }
 
-func readCoverageReport(filename string, binfile *binfile.BinaryFile) [3]sc.CoverageMap {
+func readCoverageReport(filename string, binfile *binfile.BinaryFile, config mir.OptimisationConfig) [3]sc.CoverageMap {
 	var (
 		report map[string]map[string][]uint
 		air    sc.CoverageMap
@@ -139,7 +142,7 @@ func readCoverageReport(filename string, binfile *binfile.BinaryFile) [3]sc.Cove
 	// Lower schemas
 	hirSchema := &binfile.Schema
 	mirSchema := hirSchema.LowerToMir()
-	airSchema := mirSchema.LowerToAir()
+	airSchema := mirSchema.LowerToAir(config)
 	// Check success
 	if err == nil {
 		if err = enc_json.Unmarshal(bytes, &report); err == nil {

--- a/pkg/test/valid_corset_test.go
+++ b/pkg/test/valid_corset_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/consensys/go-corset/pkg/corset"
 	"github.com/consensys/go-corset/pkg/hir"
+	"github.com/consensys/go-corset/pkg/mir"
 	sc "github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/trace/json"
@@ -1264,7 +1265,7 @@ func CheckTraces(t *testing.T, test string, maxPadding uint, cfg TestConfig, tra
 			// Lower HIR => MIR
 			mirSchema := hirSchema.LowerToMir()
 			// Lower MIR => AIR
-			airSchema := mirSchema.LowerToAir()
+			airSchema := mirSchema.LowerToAir(mir.DEFAULT_OPTIMISATION_LEVEL)
 			// Align trace with schema, and check whether expanded or not.
 			for padding := uint(0); padding <= maxPadding; padding++ {
 				// Construct trace identifiers


### PR DESCRIPTION
This puts in place some relatively simplistic optimisation levels which can, in principle, be used for investigating the cost of different optimisations.