### PR TITLE
fix: translation of perspective selectors

### DIFF
--- a/pkg/corset/compiler/translator.go
+++ b/pkg/corset/compiler/translator.go
@@ -305,7 +305,7 @@ func (t *translator) translateDefConstraint(decl *ast.DefConstraint, module util
 		// NOTE: using an ifnot (as above) would be preferable here.  However,
 		// this is currently done just to ensure constraints identical to the
 		// original are generated.
-		constraint = hir.Product(selector, constraint)
+		constraint = hir.If(selector, hir.VOID, constraint)
 	}
 	//
 	if len(errors) == 0 {


### PR DESCRIPTION
These were being translated directly as a product, rather than as an if. This was not desirable.