### PR TITLE
feat: remove deprecated stdlib functions

### DIFF
--- a/pkg/corset/stdlib.lisp
+++ b/pkg/corset/stdlib.lisp
@@ -27,9 +27,6 @@
 (defpurefun (if-not-eq A B then else) (if (!= A B) then else))
 (defpurefun (if-not (cond :bool) then) (if (not! cond) then))
 (defpurefun (if-not (cond :bool) then else) (if (not! cond) then else))
-;; DEPRECATED: will be removed in near future
-(defpurefun (is-zero e0) (if (== e0 0) 1 0))
-(defpurefun (is-not-zero e0) (~ e0))
 
 ;; =============================================================================
 ;; Boolean connectives

--- a/testdata/mxp.lisp
+++ b/testdata/mxp.lisp
@@ -155,10 +155,13 @@
            (begin (if-not-zero (+ [MXP_TYPE 1] [MXP_TYPE 2] [MXP_TYPE 3])
                                (eq! NOOP [MXP_TYPE 1]))
                   (if-eq [MXP_TYPE 4] 1
-                         (eq! NOOP (is-zero SIZE_1_LO)))
+                         (if (eq! SIZE_1_LO 0)
+                                  (eq! NOOP 1)
+                                  (eq! NOOP 0)))
                   (if-eq [MXP_TYPE 5] 1
-                         (eq! NOOP
-                              (* (is-zero SIZE_1_LO) (is-zero SIZE_2_LO)))))))
+                         (if (and! (eq! SIZE_1_LO 0) (eq! SIZE_2_LO 0))
+                             (eq! NOOP 1)
+                             (eq! NOOP 0))))))
 
 (defconstraint noop-consequences (:guard NOOP)
   (begin (vanishes! QUAD_COST)
@@ -338,8 +341,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun (offsets-are-in-bounds)
-  (* (is-zero (- CT CT_MAX_NON_TRIVIAL))
-     (- 1 MXPX)))
+  (if (eq! CT CT_MAX_NON_TRIVIAL)
+      (- 1 MXPX) 0))
 
 (defconstraint size-in-evm-words (:guard (* (standing-hypothesis) (offsets-are-in-bounds)))
   (if-eq [MXP_TYPE 4] 1


### PR DESCRIPTION
This removes two functions from the standard library, namely `is-zero` and `is-not-zero`.  These were the only remaining functions which use the boolean interpretation (which no longer exists).  A key challenge here was to the update the MXP module with alternative translations which did not use these methods.