### PR TITLE
fix: constant datatypes in trace generation

### DIFF
--- a/pkg/corset/compiler.go
+++ b/pkg/corset/compiler.go
@@ -21,6 +21,7 @@ import (
 	"github.com/consensys/go-corset/pkg/corset/ast"
 	"github.com/consensys/go-corset/pkg/corset/compiler"
 	"github.com/consensys/go-corset/pkg/hir"
+	sc "github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/util/source"
 )
 
@@ -195,15 +196,18 @@ func constructSourceModule(scope *compiler.ModuleScope, env compiler.GlobalEnvir
 	}
 	// Map source-level constants
 	for _, binding := range scope.DestructuredConstants() {
+		var datatype sc.Type
 		// Convert data type
-		if datatype, ok := binding.DataType.(*ast.IntType); ok {
-			constants = append(constants, SourceConstant{
-				binding.Path.Tail(),
-				*binding.Value.AsConstant(),
-				datatype.AsUnderlying(),
-				binding.Extern,
-			})
+		if dt, ok := binding.DataType.(*ast.IntType); ok {
+			datatype = dt.AsUnderlying()
 		}
+		//
+		constants = append(constants, SourceConstant{
+			binding.Path.Tail(),
+			*binding.Value.AsConstant(),
+			datatype,
+			binding.Extern,
+		})
 	}
 	//
 	for _, child := range scope.Children() {


### PR DESCRIPTION
The issue was around constants which have no explicit datatype given. They end up with a nil type in the compiled binary constraints file and, in such case, the constant value is used to determine the bitwidth.