### PR TITLE
fix: missing case in hir.substituteTerm

### DIFF
--- a/pkg/hir/substitute.go
+++ b/pkg/hir/substitute.go
@@ -65,6 +65,9 @@ func substituteTerm(mapping map[string]fr.Element, e Term) {
 		// do nout
 	case *Exp:
 		substituteTerm(mapping, e.Arg)
+	case *Equation:
+		substituteTerm(mapping, e.Lhs)
+		substituteTerm(mapping, e.Rhs)
 	case *IfZero:
 		substituteTerm(mapping, e.Condition)
 		// Subsitute true branch (if applicable)


### PR DESCRIPTION
Perhaps predictibly, the missing case was for Equation.