### PR TITLE
fix: for unsafe casts

### DIFF
--- a/pkg/corset/compiler/preprocessor.go
+++ b/pkg/corset/compiler/preprocessor.go
@@ -292,7 +292,7 @@ func (p *preprocessor) preprocessExpressionInModule(expr ast.Expr) (ast.Expr, []
 		nexpr, errors = &ast.Add{Args: args}, errs
 	case *ast.Cast:
 		arg, errs := p.preprocessExpressionInModule(e.Arg)
-		nexpr, errors = &ast.Cast{Arg: arg, Type: e.Type}, errs
+		nexpr, errors = &ast.Cast{Arg: arg, Type: e.Type, Unsafe: e.Unsafe}, errs
 	case *ast.Constant:
 		return e, nil
 	case *ast.Debug:


### PR DESCRIPTION
There was a problem whereby the notion of an unsafe cast was being lost during preprocessing.  This meant the benefit of such a cast was also lost.