### PR TITLE
fix: support for constant constraints

### DIFF
--- a/pkg/corset/compiler/translator.go
+++ b/pkg/corset/compiler/translator.go
@@ -310,11 +310,8 @@ func (t *translator) translateDefConstraint(decl *ast.DefConstraint, module util
 	//
 	if len(errors) == 0 {
 		context := constraint.Context(t.schema)
-		//
-		if !context.IsVoid() {
-			// Add translated constraint
-			t.schema.AddVanishingConstraint(decl.Handle, context, decl.Domain, constraint)
-		}
+		// Add translated constraint
+		t.schema.AddVanishingConstraint(decl.Handle, context, decl.Domain, constraint)
 	}
 	// Done
 	return errors

--- a/pkg/hir/schema.go
+++ b/pkg/hir/schema.go
@@ -141,7 +141,7 @@ func (p *Schema) AddLookupConstraint(handle string, source trace.Context, target
 
 // AddVanishingConstraint appends a new vanishing constraint.
 func (p *Schema) AddVanishingConstraint(handle string, context trace.Context, domain util.Option[int], expr Expr) {
-	if context.Module() >= uint(len(p.modules)) {
+	if !context.IsVoid() && context.Module() >= uint(len(p.modules)) {
 		panic(fmt.Sprintf("invalid module index (%d)", context.Module()))
 	}
 

--- a/pkg/mir/schema.go
+++ b/pkg/mir/schema.go
@@ -140,7 +140,7 @@ func (p *Schema) AddLookupConstraint(handle string, source trace.Context, target
 func (p *Schema) AddVanishingConstraint(handle string, num uint, context trace.Context,
 	domain util.Option[int], c Constraint) {
 	//
-	if context.Module() >= uint(len(p.modules)) {
+	if !context.IsVoid() && context.Module() >= uint(len(p.modules)) {
 		panic(fmt.Sprintf("invalid module index (%d)", context.Module()))
 	}
 


### PR DESCRIPTION
This improves the support for constraints which evaluate to known constants.  This can happen in various situations, such as when a guard exists to only enable a constraint for specific builds.