### PR TITLE
feat: fix for union of all traces

### DIFF
--- a/pkg/cmd/generate/union.go
+++ b/pkg/cmd/generate/union.go
@@ -56,7 +56,7 @@ func unionSubmodules(left []corset.SourceModule, right []corset.SourceModule) []
 		leftModule := left[l]
 		rightModule := right[r]
 		c := strings.Compare(leftModule.Name, rightModule.Name)
-
+		//
 		switch {
 		case c < 0:
 			// Only in left
@@ -76,6 +76,10 @@ func unionSubmodules(left []corset.SourceModule, right []corset.SourceModule) []
 			r++
 		}
 	}
+	// Including any remaining left modules
+	modules = append(modules, left[l:]...)
+	// Including any remaining right modules
+	modules = append(modules, right[r:]...)
 	//
 	return modules
 }


### PR DESCRIPTION
This puts in place a very simple fix for unioning traces which resulted in some modules being left out by mistake.