### PR TITLE
feat: relax syntax for defclookup

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -14,7 +14,6 @@ package cmd
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"runtime/debug"
 
@@ -177,7 +176,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("sequential", false, "perform sequential trace expansion")
 	rootCmd.PersistentFlags().Bool("defensive", true, "defensively pad modules")
 	rootCmd.PersistentFlags().Bool("validate", true, "apply trace validation")
-	rootCmd.PersistentFlags().UintP("batch", "b", math.MaxUint, "specify batch size for constraint checking")
+	rootCmd.PersistentFlags().UintP("batch", "b", 1024, "specify batch size for constraint checking")
 	// Misc
 	rootCmd.PersistentFlags().StringArrayP("set", "S", []string{}, "set value of externalised constant.")
 }

--- a/pkg/corset/compiler/parser.go
+++ b/pkg/corset/compiler/parser.go
@@ -823,7 +823,6 @@ func (p *Parser) parseDefConditionalLookup(elements []sexp.SExp) (ast.Declaratio
 		handle                         = elements[1]
 		targets, sources               []ast.Expr
 		targetSelector, sourceSelector ast.Expr
-		hasTargetSelector              = elements[2].AsList() == nil
 		errs1, errs2, errs3, errs4     []SyntaxError
 	)
 	//
@@ -832,12 +831,8 @@ func (p *Parser) parseDefConditionalLookup(elements []sexp.SExp) (ast.Declaratio
 		targets, errs2 = p.parseDefLookupSources("target", elements[3])
 		sourceSelector, errs3 = p.translator.Translate(elements[4])
 		sources, errs4 = p.parseDefLookupSources("source", elements[5])
-	} else if hasTargetSelector {
-		targetSelector, errs1 = p.translator.Translate(elements[2])
-		targets, errs2 = p.parseDefLookupSources("target", elements[3])
-		sources, errs3 = p.parseDefLookupSources("source", elements[4])
 	} else {
-		// Must have source selector
+		// Assume source selector
 		targets, errs1 = p.parseDefLookupSources("target", elements[2])
 		sourceSelector, errs2 = p.translator.Translate(elements[3])
 		sources, errs3 = p.parseDefLookupSources("source", elements[4])

--- a/pkg/ir/assignment/lexicographic_sort.go
+++ b/pkg/ir/assignment/lexicographic_sort.go
@@ -166,7 +166,7 @@ func (p *LexicographicSort) Lisp(schema sc.AnySchema) sexp.SExp {
 
 	for i := range p.sources {
 		ith := schema.Register(p.sources[i])
-		ith_module := schema.Module(p.targets[i].Module())
+		ith_module := schema.Module(p.sources[i].Module())
 		ith_name := ith.QualifiedName(ith_module)
 		//
 		if i >= len(p.signs) {

--- a/testdata/basic/lookup_23.lisp
+++ b/testdata/basic/lookup_23.lisp
@@ -1,3 +1,3 @@
 (defcolumns (X :i16) (P :binary) (Y :i16))
 ;; use of selector
-(defclookup test P (Y) (X))
+(defclookup test P (Y) 1 (X))


### PR DESCRIPTION
This relaxes the syntax to choose source selector when only 5 arguments are given.  Therefore, its not possible to specify a target selector on its own.