### PR TITLE
fix: update binfile format version

### DIFF
--- a/pkg/binfile/binfile.go
+++ b/pkg/binfile/binfile.go
@@ -200,12 +200,12 @@ func (p *Header) IsCompatible() bool {
 // matter what version, we should always have the ZKBINARY identifier first,
 // followed by a GOB encoding of the header.  What follows after that, however,
 // is determined by the major version.
-const BINFILE_MAJOR_VERSION uint16 = 4
+const BINFILE_MAJOR_VERSION uint16 = 5
 
 // BINFILE_MINOR_VERSION gives the minor version of the binary file format.  The
 // expected interpretation is that older versions are compatible with newer
 // ones, but not vice-versa.
-const BINFILE_MINOR_VERSION uint16 = 1
+const BINFILE_MINOR_VERSION uint16 = 0
 
 // ZKBINARY is used as the file identifier for binary file types.  This just
 // helps us identify actual binary files from corrupted files.


### PR DESCRIPTION
Since the changes made to accomodate conditional and multi lookups, the binfile format has changed in an incompatible fashion.  However, the format version number was not increased.  Therefore, this increases it.