### PR TITLE
fix: column union

### DIFF
--- a/pkg/cmd/generate/union.go
+++ b/pkg/cmd/generate/union.go
@@ -120,6 +120,10 @@ func unionColumns(left []corset.SourceColumn, right []corset.SourceColumn) []cor
 			r++
 		}
 	}
+	// Including any remaining left columns
+	columns = append(columns, left[l:]...)
+	// Including any remaining right columns
+	columns = append(columns, right[r:]...)
 	//
 	return columns
 }


### PR DESCRIPTION
The algorithm for unioning columns was broken when there were different numbers of columns in total.