### PR TITLE
fix: incorrect splitting with skip instructions

### DIFF
--- a/pkg/test/assembly_test.go
+++ b/pkg/test/assembly_test.go
@@ -44,7 +44,7 @@ func Test_Asm_FastPow(t *testing.T) {
 }
 
 func Test_Asm_Max(t *testing.T) {
-	test_util.Check(t, false, "asm/max")
+	test_util.CheckWithFields(t, false, "asm/max", ag.BLS12_377, ag.GF_8209)
 }
 
 // func Test_Asm_Max256(t *testing.T) {


### PR DESCRIPTION
Skip instructions were being incorrectly handled during register splitting, as their skip destinations were not updated.  That meant, when some instruction in between the skip and its target was split into more than one instruction, the original skip jumped to the wrong place.