### PR TITLE
tweak testing parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,8 @@ lint:
 
 .PHONY: test
 test:
-	@echo ">>> Running Unit Tests..."
-	go test --timeout 0 -v ./...
-
-.PHONY: qtest
-qtest:
-	@echo ">>> Running (Quick) Tests..."
-	go test -v -race --run Test_ ./...
+	@echo ">>> Running All Tests..."
+	go test -cpu=1 --timeout 0 -v ./...
 
 .PHONY: test-no-cache
 test-no-cache:

--- a/pkg/test/invalid_corset_test.go
+++ b/pkg/test/invalid_corset_test.go
@@ -791,11 +791,11 @@ func Test_Invalid_Compute_07(t *testing.T) {
 // nolint
 func CheckInvalid(t *testing.T, test string) {
 	var corsetConfig corset.CompilationConfig
+	// Enable testing each trace in parallel
+	t.Parallel()
 	//
 	corsetConfig.Legacy = true
 	filename := fmt.Sprintf("%s/%s.lisp", InvalidTestDir, test)
-	// Enable testing each trace in parallel
-	t.Parallel()
 	// Read constraints file
 	bytes, err := os.ReadFile(filename)
 	// Check test file read ok

--- a/pkg/test/util/framework.go
+++ b/pkg/test/util/framework.go
@@ -52,6 +52,9 @@ func Check(t *testing.T, stdlib bool, test string) {
 // accepted by a given set of constraints, and all traces that we expect to be
 // rejected are rejected.  All fields provided are tested against.
 func CheckWithFields(t *testing.T, stdlib bool, test string, fields ...schema.FieldConfig) {
+	// Enable testing each trace in parallel
+	t.Parallel()
+	//
 	var (
 		filenames = matchSourceFiles(test)
 		// Configure the stack
@@ -61,8 +64,6 @@ func CheckWithFields(t *testing.T, stdlib bool, test string, fields ...schema.Fi
 	if len(fields) == 0 {
 		panic("no field configurations")
 	}
-	// Enable testing each trace in parallel
-	t.Parallel()
 	// Record how many tests executed.
 	nTests := 0
 	// Iterate possible testfile extensions


### PR DESCRIPTION
It seems that using `-cpu=1` provides the optimal experience at this time.