### PR TITLE
fix: remove debug print statement from CountUnique function

### DIFF
--- a/pkg/util/collection/array/util.go
+++ b/pkg/util/collection/array/util.go
@@ -96,8 +96,6 @@ func CountUnique[T cmp.Ordered](items []T) uint {
 	// First sort them
 	slices.Sort(items)
 	//
-	fmt.Printf("got %v\n", items)
-	//
 	count := uint(0)
 	//
 	for i, v := range items {


### PR DESCRIPTION
Remove unnecessary debug print statement from CountUnique function in array/util.go that was accidentally left in production code