### PR TITLE
feat: sanity checks for lookup vectors

### DIFF
--- a/pkg/test/invalid_corset_test.go
+++ b/pkg/test/invalid_corset_test.go
@@ -480,6 +480,19 @@ func Test_Invalid_Lookup_10(t *testing.T) {
 	CheckInvalid(t, "invalid/lookup_invalid_10")
 }
 
+func Test_Invalid_Lookup_11(t *testing.T) {
+	CheckInvalid(t, "invalid/lookup_invalid_11")
+}
+func Test_Invalid_Lookup_12(t *testing.T) {
+	CheckInvalid(t, "invalid/lookup_invalid_12")
+}
+func Test_Invalid_Lookup_13(t *testing.T) {
+	CheckInvalid(t, "invalid/lookup_invalid_13")
+}
+func Test_Invalid_Lookup_14(t *testing.T) {
+	CheckInvalid(t, "invalid/lookup_invalid_14")
+}
+
 // ===================================================================
 // Interleavings
 // ===================================================================

--- a/testdata/invalid/lookup_invalid_11.lisp
+++ b/testdata/invalid/lookup_invalid_11.lisp
@@ -1,0 +1,3 @@
+;;error:3:16-23:signed term encountered
+(defcolumns (X :u16) (Y :u16))
+(deflookup l1 ((- 1 X)) (Y))

--- a/testdata/invalid/lookup_invalid_12.lisp
+++ b/testdata/invalid/lookup_invalid_12.lisp
@@ -1,0 +1,3 @@
+;;error:3:20-27:signed term encountered
+(defcolumns (X :u16) (Y :u16))
+(deflookup l1 (X) ((- 1 Y)))

--- a/testdata/invalid/lookup_invalid_13.lisp
+++ b/testdata/invalid/lookup_invalid_13.lisp
@@ -1,0 +1,3 @@
+;;error:3:20-27:signed selector encountered
+(defcolumns (P :u1) (X :u16) (Y :u16))
+(defclookup l1 (X) (- 0 P) (Y))

--- a/testdata/invalid/lookup_invalid_14.lisp
+++ b/testdata/invalid/lookup_invalid_14.lisp
@@ -1,0 +1,3 @@
+;;error:3:20-21:non-binary selector encountered
+(defcolumns (P :u2) (X :u16) (Y :u16))
+(defclookup l1 (X) P (Y))


### PR DESCRIPTION
This puts in place some sanity checks for lookup vectors, such as looking for potentially negative coordinates.