### PR TITLE
fix: for preprocessing concat expressions

### DIFF
--- a/pkg/corset/compiler/preprocessor.go
+++ b/pkg/corset/compiler/preprocessor.go
@@ -376,7 +376,8 @@ func (p *preprocessor) preprocessExpressionInModule(expr ast.Expr) (ast.Expr, []
 	case *ast.VariableAccess:
 		return e, nil
 	case *ast.Concat:
-		return e, nil
+		args, errs := p.preprocessExpressionsInModule(e.Args)
+		nexpr, errors = &ast.Concat{Args: args}, errs
 	default:
 		return nil, p.srcmap.SyntaxErrors(expr, "unknown expression encountered during preprocessing")
 	}


### PR DESCRIPTION
This simply updates them to be properly preprocessed.