### PR TITLE
refactor: `Trace` -> `Trace[field]`

### DIFF
--- a/pkg/asm/compiler/stamp.go
+++ b/pkg/asm/compiler/stamp.go
@@ -19,6 +19,7 @@ import (
 	tr "github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/field"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -34,7 +35,7 @@ func (p StampAssignment) Bounds(module uint) util.Bounds {
 }
 
 // Compute implementation for schema.Assignment interface.
-func (p StampAssignment) Compute(trace tr.Trace, schema sc.AnySchema) ([]tr.ArrayColumn, error) {
+func (p StampAssignment) Compute(trace tr.Trace[bls12_377.Element], schema sc.AnySchema) ([]tr.ArrayColumn, error) {
 	var (
 		zero     = fr.NewElement(0)
 		one      = fr.One()

--- a/pkg/asm/io/assignment.go
+++ b/pkg/asm/io/assignment.go
@@ -21,6 +21,7 @@ import (
 	tr "github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/field"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -34,7 +35,7 @@ func (p Assignment[T]) Bounds(module uint) util.Bounds {
 }
 
 // Compute implementation for schema.Assignment interface.
-func (p Assignment[T]) Compute(trace tr.Trace, schema sc.AnySchema) ([]tr.ArrayColumn, error) {
+func (p Assignment[T]) Compute(trace tr.Trace[bls12_377.Element], schema sc.AnySchema) ([]tr.ArrayColumn, error) {
 	var (
 		trModule = trace.Module(p.id)
 		states   []State

--- a/pkg/asm/io/constraint.go
+++ b/pkg/asm/io/constraint.go
@@ -24,6 +24,7 @@ import (
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/bit"
 	"github.com/consensys/go-corset/pkg/util/collection/set"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -44,7 +45,7 @@ func (p *ConstraintFailure) Message() string {
 }
 
 // RequiredCells identifies the cells required to evaluate the failing constraint at the failing row.
-func (p *ConstraintFailure) RequiredCells(tr trace.Trace) *set.AnySortedSet[trace.CellRef] {
+func (p *ConstraintFailure) RequiredCells(tr trace.Trace[bls12_377.Element]) *set.AnySortedSet[trace.CellRef] {
 	return set.NewAnySortedSet[trace.CellRef]()
 }
 
@@ -57,7 +58,7 @@ func (p *ConstraintFailure) String() string {
 type Constraint[T Instruction[T]] Function[T]
 
 // Accepts implementation for schema.Constraint interface.
-func (p Constraint[T]) Accepts(trace tr.Trace, _ sc.AnySchema) (bit.Set, sc.Failure) {
+func (p Constraint[T]) Accepts(trace tr.Trace[bls12_377.Element], _ sc.AnySchema) (bit.Set, sc.Failure) {
 	// Extract relevant part of the trace
 	var (
 		coverage bit.Set

--- a/pkg/cmd/check.go
+++ b/pkg/cmd/check.go
@@ -33,6 +33,7 @@ import (
 	tr "github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/set"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/word"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -207,7 +208,7 @@ func checkTrace(ir string, traces [][]tr.RawColumn[word.BigEndian], schema sc.An
 }
 
 // Report constraint failures, whilst providing contextual information (when requested).
-func reportFailures(ir string, failures []sc.Failure, trace tr.Trace, cfg checkConfig) {
+func reportFailures(ir string, failures []sc.Failure, trace tr.Trace[bls12_377.Element], cfg checkConfig) {
 	errs := make([]error, len(failures))
 	for i, f := range failures {
 		errs[i] = errors.New(f.Message())
@@ -223,7 +224,7 @@ func reportFailures(ir string, failures []sc.Failure, trace tr.Trace, cfg checkC
 }
 
 // Print a human-readable report detailing the given failure
-func reportFailure(failure sc.Failure, trace tr.Trace, cfg checkConfig) {
+func reportFailure(failure sc.Failure, trace tr.Trace[bls12_377.Element], cfg checkConfig) {
 	if f, ok := failure.(*vanishing.Failure); ok {
 		cells := f.RequiredCells(trace)
 		fmt.Printf("failing constraint %s:\n", f.Handle)
@@ -248,7 +249,7 @@ func reportFailure(failure sc.Failure, trace tr.Trace, cfg checkConfig) {
 }
 
 // Print a human-readable report detailing the given failure with a vanishing constraint.
-func reportRelevantCells(cells *set.AnySortedSet[tr.CellRef], trace tr.Trace, cfg checkConfig) {
+func reportRelevantCells(cells *set.AnySortedSet[tr.CellRef], trace tr.Trace[bls12_377.Element], cfg checkConfig) {
 	// Construct trace window
 	window := check.NewTraceWindow(cells, trace, cfg.reportPadding, cfg.corsetSourceMap)
 	// Construct & configure printer

--- a/pkg/cmd/inspect.go
+++ b/pkg/cmd/inspect.go
@@ -22,6 +22,7 @@ import (
 	sc "github.com/consensys/go-corset/pkg/schema"
 	tr "github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/termio"
 	"github.com/spf13/cobra"
 )
@@ -75,7 +76,7 @@ var inspectCmd = &cobra.Command{
 }
 
 // Inspect a given trace using a given schema.
-func inspect(schema sc.AnySchema, srcmap *corset.SourceMap, trace tr.Trace) []error {
+func inspect(schema sc.AnySchema, srcmap *corset.SourceMap, trace tr.Trace[bls12_377.Element]) []error {
 	// Construct inspector window
 	inspector := construct(schema, trace, srcmap)
 	// Render inspector
@@ -86,7 +87,7 @@ func inspect(schema sc.AnySchema, srcmap *corset.SourceMap, trace tr.Trace) []er
 	return inspector.Start()
 }
 
-func construct(schema sc.AnySchema, trace tr.Trace, srcmap *corset.SourceMap) *inspector.Inspector {
+func construct(schema sc.AnySchema, trace tr.Trace[bls12_377.Element], srcmap *corset.SourceMap) *inspector.Inspector {
 	term, err := termio.NewTerminal()
 	// Check whether successful
 	if err == nil {

--- a/pkg/cmd/inspector/inspect.go
+++ b/pkg/cmd/inspector/inspect.go
@@ -20,6 +20,7 @@ import (
 	"github.com/consensys/go-corset/pkg/corset"
 	sc "github.com/consensys/go-corset/pkg/schema"
 	tr "github.com/consensys/go-corset/pkg/trace"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/termio"
 	"github.com/consensys/go-corset/pkg/util/termio/widget"
 )
@@ -50,7 +51,7 @@ type Inspector struct {
 	height uint
 	//
 	term  *termio.Terminal
-	trace tr.Trace
+	trace tr.Trace[bls12_377.Element]
 	// Module states
 	modules []ModuleState
 	// Widgets
@@ -81,7 +82,12 @@ type Mode interface {
 }
 
 // NewInspector constructs a new inspector on given terminal.
-func NewInspector(term *termio.Terminal, schema sc.AnySchema, trace tr.Trace, srcmap *corset.SourceMap) *Inspector {
+func NewInspector(
+	term *termio.Terminal,
+	schema sc.AnySchema,
+	trace tr.Trace[bls12_377.Element],
+	srcmap *corset.SourceMap,
+) *Inspector {
 	states := make([]ModuleState, 0)
 	//
 	for _, module := range srcmap.Flattern(concreteModules) {

--- a/pkg/cmd/inspector/module_state.go
+++ b/pkg/cmd/inspector/module_state.go
@@ -23,6 +23,7 @@ import (
 	tr "github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/array"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/termio"
 )
 
@@ -30,7 +31,7 @@ import (
 // module, including related aspects like filter histories, etc.
 type ModuleState struct {
 	// Corresponding trace
-	trace tr.Trace
+	trace tr.Trace[bls12_377.Element]
 	// Name of the source-level module
 	name string
 	// Identifies trace columns in this module.
@@ -88,7 +89,7 @@ func (p *SourceColumnFilter) Match(col SourceColumn) bool {
 	return false
 }
 
-func newModuleState(module *corset.SourceModule, trace tr.Trace, enums []corset.Enumeration,
+func newModuleState(module *corset.SourceModule, trace tr.Trace[bls12_377.Element], enums []corset.Enumeration,
 	recurse bool) ModuleState {
 	//
 	var (

--- a/pkg/cmd/inspector/module_view.go
+++ b/pkg/cmd/inspector/module_view.go
@@ -20,6 +20,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	"github.com/consensys/go-corset/pkg/corset"
 	tr "github.com/consensys/go-corset/pkg/trace"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/termio"
 )
 
@@ -62,7 +63,7 @@ func (p *ModuleView) SetRow(row uint) uint {
 
 // SetActiveColumns sets the currently active set of columns.  This updates the
 // current column title width, as as well as the maximum width for every row.
-func (p *ModuleView) SetActiveColumns(trace tr.Trace, columns []SourceColumn) {
+func (p *ModuleView) SetActiveColumns(trace tr.Trace[bls12_377.Element], columns []SourceColumn) {
 	p.columns = columns
 	p.height = 0
 	// Recalculate module height
@@ -94,7 +95,7 @@ func (p *ModuleView) RowWidth(row uint) uint {
 // CellAt returns a textual representation of the data at a given column and row
 // in the module's view.  Observe that the first row and column typically show
 // titles.
-func (p *ModuleView) CellAt(trace tr.Trace, col, row uint) termio.FormattedText {
+func (p *ModuleView) CellAt(trace tr.Trace[bls12_377.Element], col, row uint) termio.FormattedText {
 	if row == 0 && col == 0 {
 		return termio.NewText("")
 	}
@@ -132,7 +133,7 @@ func (p *ModuleView) CellAt(trace tr.Trace, col, row uint) termio.FormattedText 
 }
 
 // ValueAt extracts the data point at a given rol and column in the trace.
-func (p *ModuleView) ValueAt(trace tr.Trace, trCol, trRow uint) fr.Element {
+func (p *ModuleView) ValueAt(trace tr.Trace[bls12_377.Element], trCol, trRow uint) fr.Element {
 	// Determine underlying register for the given column.
 	ref := p.columns[trCol].Register
 	// Extract cell value from register
@@ -141,7 +142,7 @@ func (p *ModuleView) ValueAt(trace tr.Trace, trCol, trRow uint) fr.Element {
 
 // IsActive determines whether a given cell is active, or not.  A cell can be
 // inactive, for example, if its part of a perspective which is not active.
-func (p *ModuleView) IsActive(trace tr.Trace, trCol, trRow uint) bool {
+func (p *ModuleView) IsActive(trace tr.Trace[bls12_377.Element], trCol, trRow uint) bool {
 	// Determine enclosing module
 	module := trace.Module(p.columns[trCol].Register.Module())
 	// Extract relevant selector
@@ -195,7 +196,7 @@ func (p *ModuleView) recalculateColumnTitleWidth() uint {
 	return uint(maxWidth)
 }
 
-func (p *ModuleView) recalculateRowWidths(module tr.Trace) []uint {
+func (p *ModuleView) recalculateRowWidths(module tr.Trace[bls12_377.Element]) []uint {
 	widths := make([]uint, p.height)
 	//
 	for row := uint(0); row < uint(len(widths)); row++ {

--- a/pkg/ir/air/constraint.go
+++ b/pkg/ir/air/constraint.go
@@ -25,6 +25,7 @@ import (
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/bit"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -105,7 +106,7 @@ func (p Air[C]) Air() {
 // Accepts determines whether a given constraint accepts a given trace or
 // not.  If not, a failure is produced.  Otherwise, a bitset indicating
 // branch coverage is returned.
-func (p Air[C]) Accepts(trace trace.Trace, schema schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Air[C]) Accepts(trace trace.Trace[bls12_377.Element], schema schema.AnySchema) (bit.Set, schema.Failure) {
 	return p.constraint.Accepts(trace, schema)
 }
 

--- a/pkg/ir/air/gadgets/bitwidth.go
+++ b/pkg/ir/air/gadgets/bitwidth.go
@@ -26,6 +26,7 @@ import (
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/field"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -249,7 +250,10 @@ func (p *typeDecomposition) AddSource(source sc.RegisterRef) {
 
 // Compute computes the values of columns defined by this assignment.
 // This requires computing the value of each byte column in the decomposition.
-func (p *typeDecomposition) Compute(tr trace.Trace, schema sc.AnySchema) ([]trace.ArrayColumn, error) {
+func (p *typeDecomposition) Compute(
+	tr trace.Trace[bls12_377.Element],
+	schema sc.AnySchema,
+) ([]trace.ArrayColumn, error) {
 	// Read inputs
 	sources := assignment.ReadRegisters(tr, p.sources...)
 	// Combine all sources
@@ -344,7 +348,10 @@ type byteDecomposition struct {
 
 // Compute computes the values of columns defined by this assignment.
 // This requires computing the value of each byte column in the decomposition.
-func (p *byteDecomposition) Compute(tr trace.Trace, schema sc.AnySchema) ([]trace.ArrayColumn, error) {
+func (p *byteDecomposition) Compute(
+	tr trace.Trace[bls12_377.Element],
+	schema sc.AnySchema,
+) ([]trace.ArrayColumn, error) {
 	var n = uint(len(p.targets))
 	// Read inputs
 	sources := assignment.ReadRegisters(tr, p.source)

--- a/pkg/ir/assignment/computation.go
+++ b/pkg/ir/assignment/computation.go
@@ -26,6 +26,7 @@ import (
 	"github.com/consensys/go-corset/pkg/util/collection/array"
 	"github.com/consensys/go-corset/pkg/util/collection/hash"
 	"github.com/consensys/go-corset/pkg/util/field"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -64,7 +65,7 @@ func (p *Computation) Bounds(_ sc.ModuleId) util.Bounds {
 // Compute computes the values of columns defined by this assignment. This
 // requires copying the data in the source columns, and sorting that data
 // according to the permutation criteria.
-func (p *Computation) Compute(trace tr.Trace, schema sc.AnySchema) ([]tr.ArrayColumn, error) {
+func (p *Computation) Compute(trace tr.Trace[bls12_377.Element], schema sc.AnySchema) ([]tr.ArrayColumn, error) {
 	var (
 		fn func([]field.FrArray) []field.FrArray
 		ok bool
@@ -152,7 +153,7 @@ func (p *Computation) Lisp(schema sc.AnySchema) sexp.SExp {
 type NativeComputation func([]field.FrArray) []field.FrArray
 
 func computeNative(sources []sc.RegisterRef, targets []sc.RegisterRef, fn NativeComputation,
-	trace tr.Trace, schema sc.AnySchema) []tr.ArrayColumn {
+	trace tr.Trace[bls12_377.Element], schema sc.AnySchema) []tr.ArrayColumn {
 	// Read inputs
 	inputs := ReadRegisters(trace, sources...)
 	// Read inputs

--- a/pkg/ir/assignment/computed_register.go
+++ b/pkg/ir/assignment/computed_register.go
@@ -23,6 +23,7 @@ import (
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/field"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -63,7 +64,10 @@ func (p *ComputedRegister) Bounds(mid sc.ModuleId) util.Bounds {
 // Compute the values of columns defined by this assignment. Specifically, this
 // creates a new column which contains the result of evaluating a given
 // expression on each row.
-func (p *ComputedRegister) Compute(tr trace.Trace, schema schema.AnySchema) ([]trace.ArrayColumn, error) {
+func (p *ComputedRegister) Compute(
+	tr trace.Trace[bls12_377.Element],
+	schema schema.AnySchema,
+) ([]trace.ArrayColumn, error) {
 	var (
 		trModule = tr.Module(p.Target.Module())
 		scModule = schema.Module(p.Target.Module())

--- a/pkg/ir/assignment/lexicographic_sort.go
+++ b/pkg/ir/assignment/lexicographic_sort.go
@@ -20,6 +20,7 @@ import (
 	tr "github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/field"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -76,7 +77,7 @@ func (p *LexicographicSort) Bounds(_ sc.ModuleId) util.Bounds {
 // Compute computes the values of columns defined as needed to support the
 // LexicographicSortingGadget. That includes the delta column, and the bit
 // selectors.
-func (p *LexicographicSort) Compute(trace tr.Trace, schema sc.AnySchema) ([]tr.ArrayColumn, error) {
+func (p *LexicographicSort) Compute(trace tr.Trace[bls12_377.Element], schema sc.AnySchema) ([]tr.ArrayColumn, error) {
 	var (
 		// Exact number of (signed) columns involved in the sort
 		nbits = len(p.signs)

--- a/pkg/ir/assignment/sorted_permutation.go
+++ b/pkg/ir/assignment/sorted_permutation.go
@@ -21,6 +21,7 @@ import (
 	tr "github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/field"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -65,7 +66,7 @@ func (p *SortedPermutation) Bounds(_ sc.ModuleId) util.Bounds {
 // Compute computes the values of columns defined by this assignment. This
 // requires copying the data in the source columns, and sorting that data
 // according to the permutation criteria.
-func (p *SortedPermutation) Compute(trace tr.Trace, schema sc.AnySchema) ([]tr.ArrayColumn, error) {
+func (p *SortedPermutation) Compute(trace tr.Trace[bls12_377.Element], schema sc.AnySchema) ([]tr.ArrayColumn, error) {
 	// Read inputs
 	sources := ReadRegisters(trace, p.Sources...)
 	// Apply native function

--- a/pkg/ir/assignment/util.go
+++ b/pkg/ir/assignment/util.go
@@ -17,10 +17,11 @@ import (
 	sc "github.com/consensys/go-corset/pkg/schema"
 	tr "github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/field"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 )
 
 // ReadRegisters a given set of registers from a trace.
-func ReadRegisters(trace tr.Trace, regs ...sc.RegisterRef) []field.FrArray {
+func ReadRegisters(trace tr.Trace[bls12_377.Element], regs ...sc.RegisterRef) []field.FrArray {
 	var (
 		targets = make([]field.FrArray, len(regs))
 	)

--- a/pkg/ir/builder/validation.go
+++ b/pkg/ir/builder/validation.go
@@ -22,12 +22,13 @@ import (
 	tr "github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/field"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 )
 
 // TraceValidation validates that values held in trace columns match the
 // expected type.  This is really a sanity check that the trace is not
 // malformed.
-func TraceValidation(parallel bool, schema sc.AnySchema, tr tr.Trace) []error {
+func TraceValidation(parallel bool, schema sc.AnySchema, tr tr.Trace[bls12_377.Element]) []error {
 	var (
 		errors []error
 		// Start timer
@@ -50,7 +51,7 @@ func TraceValidation(parallel bool, schema sc.AnySchema, tr tr.Trace) []error {
 // SequentialTraceValidation validates that values held in trace columns match
 // the expected type.  This is really a sanity check that the trace is not
 // malformed.
-func SequentialTraceValidation(schema sc.AnySchema, tr trace.Trace) []error {
+func SequentialTraceValidation(schema sc.AnySchema, tr trace.Trace[bls12_377.Element]) []error {
 	var errors []error
 	//
 	for i := uint(0); i < max(schema.Width(), tr.Width()); i++ {
@@ -77,7 +78,7 @@ func SequentialTraceValidation(schema sc.AnySchema, tr trace.Trace) []error {
 // ParallelTraceValidation validates that values held in trace columns match the
 // expected type.  This is really a sanity check that the trace is not
 // malformed.
-func ParallelTraceValidation(schema sc.AnySchema, trace tr.Trace) []error {
+func ParallelTraceValidation(schema sc.AnySchema, trace tr.Trace[bls12_377.Element]) []error {
 	var (
 		errors []error
 		// Construct a communication channel for errors.

--- a/pkg/ir/mir/constraint.go
+++ b/pkg/ir/mir/constraint.go
@@ -25,6 +25,7 @@ import (
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/bit"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -81,7 +82,7 @@ func NewSortedConstraint(handle string, context schema.ModuleId, bitwidth uint, 
 // Accepts determines whether a given constraint accepts a given trace or
 // not.  If not, a failure is produced.  Otherwise, a bitset indicating
 // branch coverage is returned.
-func (p Constraint) Accepts(trace trace.Trace, schema schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Constraint) Accepts(trace trace.Trace[bls12_377.Element], schema schema.AnySchema) (bit.Set, schema.Failure) {
 	return p.constraint.Accepts(trace, schema)
 }
 

--- a/pkg/ir/trace_builder.go
+++ b/pkg/ir/trace_builder.go
@@ -21,6 +21,7 @@ import (
 	sc "github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/field"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 )
 
 // TraceBuilder provides a mechanical means of constructing a trace from a given
@@ -167,7 +168,10 @@ func (tb TraceBuilder) BatchSize() uint {
 
 // Build attempts to construct a trace for a given schema, producing errors if
 // there are inconsistencies (e.g. missing columns, duplicate columns, etc).
-func (tb TraceBuilder) Build(schema sc.AnySchema, rawCols []trace.BigEndianColumn) (trace.Trace, []error) {
+func (tb TraceBuilder) Build(
+	schema sc.AnySchema,
+	rawCols []trace.BigEndianColumn,
+) (trace.Trace[bls12_377.Element], []error) {
 	var (
 		cols   []trace.RawFrColumn
 		errors []error

--- a/pkg/schema/assignment.go
+++ b/pkg/schema/assignment.go
@@ -15,6 +15,7 @@ package schema
 import (
 	tr "github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -37,7 +38,7 @@ type Assignment interface {
 	// assignment depends must exist (e.g. are either inputs or have been
 	// computed already).  Computed columns do not exist in the original trace,
 	// but are added during trace expansion to form the final trace.
-	Compute(tr.Trace, Schema[Constraint]) ([]tr.ArrayColumn, error)
+	Compute(tr.Trace[bls12_377.Element], Schema[Constraint]) ([]tr.ArrayColumn, error)
 	// Consistent applies a number of internal consistency checks.  Whilst not
 	// strictly necessary, these can highlight otherwise hidden problems as an aid
 	// to debugging.

--- a/pkg/schema/constraint.go
+++ b/pkg/schema/constraint.go
@@ -17,6 +17,7 @@ import (
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/bit"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -26,7 +27,7 @@ type Constraint interface {
 	// Accepts determines whether a given constraint accepts a given trace or
 	// not.  If not, a failure is produced.  Otherwise, a bitset indicating
 	// branch coverage is returned.
-	Accepts(trace.Trace, AnySchema) (bit.Set, Failure)
+	Accepts(trace.Trace[bls12_377.Element], AnySchema) (bit.Set, Failure)
 	// Determine the well-definedness bounds for this constraint in both the
 	// negative (left) or positive (right) directions.  For example, consider an
 	// expression such as "(shift X -1)".  This is technically undefined for the

--- a/pkg/schema/constraint/assertion.go
+++ b/pkg/schema/constraint/assertion.go
@@ -22,6 +22,7 @@ import (
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/bit"
 	"github.com/consensys/go-corset/pkg/util/collection/set"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -44,7 +45,7 @@ func (p *AssertionFailure) Message() string {
 }
 
 // RequiredCells identifies the cells required to evaluate the failing constraint at the failing row.
-func (p *AssertionFailure) RequiredCells(tr trace.Trace) *set.AnySortedSet[trace.CellRef] {
+func (p *AssertionFailure) RequiredCells(tr trace.Trace[bls12_377.Element]) *set.AnySortedSet[trace.CellRef] {
 	return p.Constraint.RequiredCells(int(p.Row), p.Context)
 }
 
@@ -112,7 +113,7 @@ func (p Assertion[T]) Bounds(module uint) util.Bounds {
 // of a table. If so, return nil otherwise return an error.
 //
 //nolint:revive
-func (p Assertion[T]) Accepts(tr trace.Trace, sc schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Assertion[T]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnySchema) (bit.Set, schema.Failure) {
 	var (
 		coverage bit.Set
 		trModule trace.Module  = tr.Module(p.Context)

--- a/pkg/schema/constraint/failure.go
+++ b/pkg/schema/constraint/failure.go
@@ -17,6 +17,7 @@ import (
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/collection/set"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 )
 
 // InternalFailure is a generic mechanism for reporting failures, particularly
@@ -40,7 +41,7 @@ func (p *InternalFailure) Message() string {
 }
 
 // RequiredCells identifies the cells required to evaluate the failing constraint at the failing row.
-func (p *InternalFailure) RequiredCells(tr trace.Trace) *set.AnySortedSet[trace.CellRef] {
+func (p *InternalFailure) RequiredCells(tr trace.Trace[bls12_377.Element]) *set.AnySortedSet[trace.CellRef] {
 	if p.Term != nil {
 		return p.Term.RequiredCells(int(p.Row), p.Context)
 	}

--- a/pkg/schema/constraint/interleaving/constraint.go
+++ b/pkg/schema/constraint/interleaving/constraint.go
@@ -20,6 +20,7 @@ import (
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/bit"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -79,7 +80,7 @@ func (p Constraint[E]) Bounds(module uint) util.Bounds {
 
 // Accepts checks whether a Interleave holds between the source and
 // target columns.
-func (p Constraint[E]) Accepts(tr trace.Trace, sc schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Constraint[E]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnySchema) (bit.Set, schema.Failure) {
 	var (
 		coverage bit.Set
 		srcTrMod = tr.Module(p.SourceContext)

--- a/pkg/schema/constraint/interleaving/failure.go
+++ b/pkg/schema/constraint/interleaving/failure.go
@@ -19,6 +19,7 @@ import (
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/collection/set"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 )
 
 // Failure provides structural information about a failing lookup constraint.
@@ -47,7 +48,7 @@ func (p *Failure) String() string {
 }
 
 // RequiredCells identifies the cells required to evaluate the failing constraint at the failing row.
-func (p *Failure) RequiredCells(tr trace.Trace) *set.AnySortedSet[trace.CellRef] {
+func (p *Failure) RequiredCells(tr trace.Trace[bls12_377.Element]) *set.AnySortedSet[trace.CellRef] {
 	var res = set.NewAnySortedSet[trace.CellRef]()
 	//
 	res.InsertSorted(p.Source.RequiredCells(int(p.Row), p.SourceContext))

--- a/pkg/schema/constraint/lookup/constraint.go
+++ b/pkg/schema/constraint/lookup/constraint.go
@@ -23,6 +23,7 @@ import (
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/bit"
 	"github.com/consensys/go-corset/pkg/util/collection/hash"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -139,7 +140,7 @@ func (p Constraint[E]) Bounds(module uint) util.Bounds {
 // all rows of the source columns.
 //
 //nolint:revive
-func (p Constraint[E]) Accepts(tr trace.Trace, sc schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Constraint[E]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnySchema) (bit.Set, schema.Failure) {
 	var (
 		coverage bit.Set
 		// Determine width (in columns) of this lookup
@@ -162,7 +163,7 @@ func (p Constraint[E]) Accepts(tr trace.Trace, sc schema.AnySchema) (bit.Set, sc
 	return coverage, nil
 }
 
-func (p *Constraint[E]) insertTargetVectors(tr trace.Trace, sc schema.AnySchema,
+func (p *Constraint[E]) insertTargetVectors(tr trace.Trace[bls12_377.Element], sc schema.AnySchema,
 	bytes []byte) (*hash.Set[hash.BytesKey], schema.Failure) {
 	//
 	var (
@@ -196,8 +197,12 @@ func (p *Constraint[E]) insertTargetVectors(tr trace.Trace, sc schema.AnySchema,
 	return rows, nil
 }
 
-func (p *Constraint[E]) checkSourceVectors(rows *hash.Set[hash.BytesKey], tr trace.Trace, sc schema.AnySchema,
-	bytes []byte) schema.Failure {
+func (p *Constraint[E]) checkSourceVectors(
+	rows *hash.Set[hash.BytesKey],
+	tr trace.Trace[bls12_377.Element],
+	sc schema.AnySchema,
+	bytes []byte,
+) schema.Failure {
 	// Choose optimised loop
 	for _, source := range p.Sources {
 		var (

--- a/pkg/schema/constraint/lookup/failure.go
+++ b/pkg/schema/constraint/lookup/failure.go
@@ -19,6 +19,7 @@ import (
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/collection/set"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 )
 
 // Failure provides structural information about a failing lookup constraint.
@@ -43,7 +44,7 @@ func (p *Failure) String() string {
 }
 
 // RequiredCells identifies the cells required to evaluate the failing constraint at the failing row.
-func (p *Failure) RequiredCells(_ trace.Trace) *set.AnySortedSet[trace.CellRef] {
+func (p *Failure) RequiredCells(_ trace.Trace[bls12_377.Element]) *set.AnySortedSet[trace.CellRef] {
 	res := set.NewAnySortedSet[trace.CellRef]()
 	// Handle terms
 	for _, e := range p.Sources {

--- a/pkg/schema/constraint/permutation/constraint.go
+++ b/pkg/schema/constraint/permutation/constraint.go
@@ -22,6 +22,7 @@ import (
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/bit"
 	"github.com/consensys/go-corset/pkg/util/field"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -84,7 +85,7 @@ func (p Constraint) Bounds(module uint) util.Bounds {
 
 // Accepts checks whether a permutation holds between the source and
 // target columns.
-func (p Constraint) Accepts(tr trace.Trace, _ schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Constraint) Accepts(tr trace.Trace[bls12_377.Element], _ schema.AnySchema) (bit.Set, schema.Failure) {
 	var (
 		// Coverage currently always empty for permutation constraints.
 		coverage bit.Set

--- a/pkg/schema/constraint/ranged/constraint.go
+++ b/pkg/schema/constraint/ranged/constraint.go
@@ -23,6 +23,7 @@ import (
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/bit"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -91,7 +92,7 @@ func (p Constraint[E]) Bounds(module uint) util.Bounds {
 // nil otherwise return an error.
 //
 //nolint:revive
-func (p Constraint[E]) Accepts(tr trace.Trace, sc schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Constraint[E]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnySchema) (bit.Set, schema.Failure) {
 	var (
 		coverage bit.Set
 		trModule = tr.Module(p.Context)

--- a/pkg/schema/constraint/ranged/failure.go
+++ b/pkg/schema/constraint/ranged/failure.go
@@ -19,6 +19,7 @@ import (
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/collection/set"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 )
 
 // Failure provides structural information about a failing type constraint.
@@ -46,6 +47,6 @@ func (p *Failure) String() string {
 }
 
 // RequiredCells identifies the cells required to evaluate the failing constraint at the failing row.
-func (p *Failure) RequiredCells(tr trace.Trace) *set.AnySortedSet[trace.CellRef] {
+func (p *Failure) RequiredCells(tr trace.Trace[bls12_377.Element]) *set.AnySortedSet[trace.CellRef] {
 	return p.Expr.RequiredCells(int(p.Row), p.Context)
 }

--- a/pkg/schema/constraint/sorted/constraint.go
+++ b/pkg/schema/constraint/sorted/constraint.go
@@ -23,6 +23,7 @@ import (
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/bit"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -98,7 +99,7 @@ func (p Constraint[E]) Bounds(module uint) util.Bounds {
 
 // Accepts checks whether a Sorted holds between the source and
 // target columns.
-func (p Constraint[E]) Accepts(tr trace.Trace, sc schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Constraint[E]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnySchema) (bit.Set, schema.Failure) {
 	var (
 		coverage bit.Set
 		// Determine enclosing module

--- a/pkg/schema/constraint/util.go
+++ b/pkg/schema/constraint/util.go
@@ -18,6 +18,7 @@ import (
 	"github.com/consensys/go-corset/pkg/ir"
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 )
 
 // CheckConsistent performs a simple consistency check for terms in a given
@@ -49,7 +50,7 @@ func CheckConsistent[E ir.Contextual](module uint, schema schema.AnySchema, term
 
 // DetermineHandle is a very simple helper which determines a suitable qualified
 // name for the given constraint handle.
-func DetermineHandle(handle string, ctx schema.ModuleId, tr trace.Trace) string {
+func DetermineHandle(handle string, ctx schema.ModuleId, tr trace.Trace[bls12_377.Element]) string {
 	modName := tr.Module(ctx).Name()
 	//
 	return trace.QualifiedColumnName(modName, handle)

--- a/pkg/schema/constraint/vanishing/constraint.go
+++ b/pkg/schema/constraint/vanishing/constraint.go
@@ -22,6 +22,7 @@ import (
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/bit"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -94,7 +95,7 @@ func (p Constraint[T]) Bounds(module uint) util.Bounds {
 // of a table.  If so, return nil otherwise return an error.
 //
 //nolint:revive
-func (p Constraint[T]) Accepts(tr trace.Trace, sc schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Constraint[T]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnySchema) (bit.Set, schema.Failure) {
 	var (
 		// Handle is used for error reporting.
 		handle = constraint.DetermineHandle(p.Handle, p.Context, tr)

--- a/pkg/schema/constraint/vanishing/failure.go
+++ b/pkg/schema/constraint/vanishing/failure.go
@@ -19,6 +19,7 @@ import (
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/collection/set"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 )
 
 // Failure provides structural information about a failing vanishing constraint.
@@ -40,7 +41,7 @@ func (p *Failure) Message() string {
 }
 
 // RequiredCells identifies the cells required to evaluate the failing constraint at the failing row.
-func (p *Failure) RequiredCells(tr trace.Trace) *set.AnySortedSet[trace.CellRef] {
+func (p *Failure) RequiredCells(tr trace.Trace[bls12_377.Element]) *set.AnySortedSet[trace.CellRef] {
 	return p.Constraint.RequiredCells(int(p.Row), p.Context)
 }
 

--- a/pkg/schema/mixed_schema.go
+++ b/pkg/schema/mixed_schema.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/collection/iter"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 )
 
 // MixedSchema represents a schema comprised of exactly two kinds of concrete
@@ -79,7 +80,7 @@ func (p MixedSchema[M1, M2]) Constraints() iter.Iterator[Constraint] {
 
 // Expand a given trace according to this schema by determining appropriate
 // values for all computed columns within the schema.
-func (p MixedSchema[M1, M2]) Expand(trace.Trace) (trace.Trace, []error) {
+func (p MixedSchema[M1, M2]) Expand(trace.Trace[bls12_377.Element]) (trace.Trace[bls12_377.Element], []error) {
 	panic("todo")
 }
 

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -15,6 +15,7 @@ package schema
 import (
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/collection/iter"
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 )
 
 // Any converts a concrete schema into a generic view of the schema.
@@ -30,7 +31,7 @@ type AnySchema = Schema[Constraint]
 
 // Expander functions are responsible for "filling" traces according to a given
 // schema.  More specifically, the determine values for all computed columns.
-type Expander[M any, C any] func(Schema[C], trace.Trace) trace.Trace
+type Expander[M any, C any] func(Schema[C], trace.Trace[bls12_377.Element]) trace.Trace[bls12_377.Element]
 
 // ============================================================================
 

--- a/pkg/trace/trace.go
+++ b/pkg/trace/trace.go
@@ -22,7 +22,7 @@ import (
 
 // Trace describes a set of named columns.  Columns are not required to have the
 // same height and can be either "data" columns or "computed" columns.
-type Trace interface {
+type Trace[F field.Element[F]] interface {
 	// Access a given column directly via a reference.
 	Column(ColumnRef) Column
 	// Access a given module in this trace.

--- a/pkg/trace/util.go
+++ b/pkg/trace/util.go
@@ -14,6 +14,8 @@ package trace
 
 import (
 	"fmt"
+
+	bls12_377 "github.com/consensys/go-corset/pkg/util/field/bls12-377"
 )
 
 // QualifiedColumnName returns the fully qualified name of a given column.
@@ -26,7 +28,7 @@ func QualifiedColumnName(module string, column string) string {
 }
 
 // NumberOfColumns returns the total number of all columns in the given trace.
-func NumberOfColumns(tr Trace) uint {
+func NumberOfColumns(tr Trace[bls12_377.Element]) uint {
 	var count = uint(0)
 	//
 	for i := range tr.Width() {


### PR DESCRIPTION
This PR generifies the `Trace` interface, but keeps all its instantiations to `bls12_377` as before, to facilitate further refactoring and an eventual migration to other fields.