### PR TITLE
feat: make assignments generic

### DIFF
--- a/pkg/asm/compiler/builder.go
+++ b/pkg/asm/compiler/builder.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/util"
+	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 )
 
 // Module provides an abstraction for modules in the underlying constraint
@@ -26,7 +27,7 @@ type Module[T any, E Expr[T, E], M any] interface {
 	Initialise(fn MicroFunction, mid uint) M
 
 	// NewAssignment adds a new assignment to this module.
-	NewAssignment(assignment schema.Assignment)
+	NewAssignment(assignment schema.Assignment[bls12_377.Element])
 
 	// NewColumn constructs a new column of the given name and bitwidth within
 	// this module.

--- a/pkg/asm/compiler/mir.go
+++ b/pkg/asm/compiler/mir.go
@@ -50,7 +50,7 @@ func (p MirModule) Initialise(fn MicroFunction, mid uint) MirModule {
 }
 
 // NewAssignment adds a new assignment to this module.
-func (p MirModule) NewAssignment(assignment schema.Assignment) {
+func (p MirModule) NewAssignment(assignment schema.Assignment[bls12_377.Element]) {
 	p.Module.AddAssignment(assignment)
 }
 

--- a/pkg/asm/io/function.go
+++ b/pkg/asm/io/function.go
@@ -20,6 +20,7 @@ import (
 
 	sc "github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/util/collection/iter"
+	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 )
 
 const (
@@ -76,10 +77,10 @@ func NewFunction[T Instruction[T]](id sc.ModuleId, name string, registers []Regi
 // Assignments returns an iterator over the assignments of this schema.
 // These are the computations used to assign values to all computed columns
 // in this module.
-func (p *Function[T]) Assignments() iter.Iterator[sc.Assignment] {
-	var assignment Assignment[T] = Assignment[T]{p.id, p.name, p.registers, p.code}
+func (p *Function[T]) Assignments() iter.Iterator[sc.Assignment[bls12_377.Element]] {
+	var assignment = Assignment[bls12_377.Element, T]{p.id, p.name, p.registers, p.code}
 	//
-	return iter.NewUnitIterator[sc.Assignment](assignment)
+	return iter.NewUnitIterator[sc.Assignment[bls12_377.Element]](assignment)
 }
 
 // CodeAt returns the ith instruction making up the body of this function.

--- a/pkg/cmd/debug/stats.go
+++ b/pkg/cmd/debug/stats.go
@@ -22,6 +22,7 @@ import (
 	"github.com/consensys/go-corset/pkg/ir/mir"
 	"github.com/consensys/go-corset/pkg/schema"
 	sc "github.com/consensys/go-corset/pkg/schema"
+	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 	"github.com/consensys/go-corset/pkg/util/termio"
 )
 
@@ -68,10 +69,10 @@ var schemaSummarisers []schemaSummariser = []schemaSummariser{
 	constraintCounter("Permutations", isPermutationConstraint),
 	constraintCounter("Range", isRangeConstraint),
 	// Assignments
-	assignmentCounter("Computed Columns", reflect.TypeOf((*assignment.ComputedRegister)(nil))),
-	assignmentCounter("Computation Columns", reflect.TypeOf((*assignment.Computation)(nil))),
-	assignmentCounter("Lexicographic Orderings", reflect.TypeOf((*assignment.LexicographicSort)(nil))),
-	assignmentCounter("Sorted Permutations", reflect.TypeOf((*assignment.SortedPermutation)(nil))),
+	assignmentCounter("Computed Columns", reflect.TypeOf((*assignment.ComputedRegister[bls12_377.Element])(nil))),
+	assignmentCounter("Computation Columns", reflect.TypeOf((*assignment.Computation[bls12_377.Element])(nil))),
+	assignmentCounter("Lexicographic Orderings", reflect.TypeOf((*assignment.LexicographicSort[bls12_377.Element])(nil))),
+	assignmentCounter("Sorted Permutations", reflect.TypeOf((*assignment.SortedPermutation[bls12_377.Element])(nil))),
 	// Columns
 	columnCounter(),
 	columnWidthSummariser(1, 1),

--- a/pkg/corset/compiler/translator.go
+++ b/pkg/corset/compiler/translator.go
@@ -326,7 +326,7 @@ func (t *translator) translateDefComputed(decl *ast.DefComputed, path util.Path)
 	// Determine enclosing module
 	module := t.moduleOf(context)
 	// Add the assignment and check the first identifier.
-	module.AddAssignment(assignment.NewComputation(binding.name, targets, sources))
+	module.AddAssignment(assignment.NewComputation[bls12_377.Element](binding.name, targets, sources))
 	//
 	return nil
 }
@@ -554,7 +554,7 @@ func (t *translator) translateDefInterleaved(decl *ast.DefInterleaved, path util
 	)
 	// Register assignment
 	tgtModule.AddAssignment(
-		assignment.NewComputation("interleave", targets, sources))
+		assignment.NewComputation[bls12_377.Element]("interleave", targets, sources))
 
 	// Done
 	return errors
@@ -602,7 +602,7 @@ func (t *translator) translateDefPermutation(decl *ast.DefPermutation, path util
 	signs := slices.Clone(decl.Signs)
 	bitwidth := determineMaxBitwidth(module, targetTerms[:len(signs)])
 	// Add assignment for computing the sorted permutation
-	module.AddAssignment(assignment.NewSortedPermutation(module.Id(), targets, signs, sources))
+	module.AddAssignment(assignment.NewSortedPermutation[bls12_377.Element](module.Id(), targets, signs, sources))
 	// Add Permutation Constraint
 	module.AddConstraint(mir.NewPermutationConstraint(handle.String(), module.Id(), targets, sources))
 	// Add Sorting Constraint

--- a/pkg/ir/air/gadgets/lexicographic_sort.go
+++ b/pkg/ir/air/gadgets/lexicographic_sort.go
@@ -145,7 +145,7 @@ func (p *LexicographicSortingGadget) Apply(mid sc.ModuleId, schema *air.SchemaBu
 		deltaIndex = targets[0].Register()
 		//
 		module.AddAssignment(
-			assignment.NewLexicographicSort(targets, p.signs, sources, p.bitwidth))
+			assignment.NewLexicographicSort[bls12_377.Element](targets, p.signs, sources, p.bitwidth))
 		// Construct selector bits.
 		p.addLexicographicSelectorBits(deltaIndex, mid, schema)
 		// Add necessary bitwidth constraints.  Note, we don't need to consider

--- a/pkg/ir/assignment/util.go
+++ b/pkg/ir/assignment/util.go
@@ -17,12 +17,7 @@ import (
 	tr "github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/collection/array"
 	"github.com/consensys/go-corset/pkg/util/field"
-	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
-	"github.com/consensys/go-corset/pkg/util/word"
 )
-
-// WordPool offsets a convenient alias
-type WordPool = word.Pool[uint, bls12_377.Element]
 
 // ReadRegisters a given set of registers from a trace.
 func ReadRegisters[F field.Element[F]](trace tr.Trace[F], regs ...sc.RegisterRef) []array.Array[F] {

--- a/pkg/ir/builder/splitting.go
+++ b/pkg/ir/builder/splitting.go
@@ -27,9 +27,6 @@ import (
 	"github.com/consensys/go-corset/pkg/util/word"
 )
 
-// WordPool offsets a convenient alias
-type WordPool = word.Pool[uint, word.BigEndian]
-
 // TraceSplitting splits a given set of raw columns according to a given
 // register mapping or, otherwise, simply lowers them.
 func TraceSplitting[F field.Element[F]](parallel bool, tf lt.TraceFile, mapping schema.LimbsMap) (word.Pool[uint, F],

--- a/pkg/ir/schema_builder.go
+++ b/pkg/ir/schema_builder.go
@@ -18,6 +18,7 @@ import (
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/util/collection/iter"
 	"github.com/consensys/go-corset/pkg/util/field"
+	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 )
 
 // SchemaBuilder is a mechanism for constructing mixed schemas which attempts to
@@ -131,7 +132,7 @@ type ModuleBuilder[F field.Element[F], C schema.Constraint, T Term[F, T]] struct
 	// Constraints for this module
 	constraints []C
 	// Assignments for computed registers
-	assignments []schema.Assignment
+	assignments []schema.Assignment[bls12_377.Element]
 }
 
 // NewModuleBuilder constructs a new builder for a module with the given name.
@@ -158,7 +159,7 @@ func NewExternModuleBuilder[F field.Element[F], C schema.Constraint, T Term[F, T
 
 // AddAssignment adds a new assignment to this module.  Assignments are
 // responsible for computing the values of computed columns.
-func (p *ModuleBuilder[F, C, T]) AddAssignment(assignment schema.Assignment) {
+func (p *ModuleBuilder[F, C, T]) AddAssignment(assignment schema.Assignment[bls12_377.Element]) {
 	if p.extern {
 		panic("cannot add assignment to external module")
 	}
@@ -178,7 +179,7 @@ func (p *ModuleBuilder[F, C, T]) AddConstraint(constraint C) {
 // Assignments returns an iterator over the assignments of this schema.
 // These are the computations used to assign values to all computed columns
 // in this module.
-func (p *ModuleBuilder[F, C, T]) Assignments() iter.Iterator[schema.Assignment] {
+func (p *ModuleBuilder[F, C, T]) Assignments() iter.Iterator[schema.Assignment[bls12_377.Element]] {
 	return iter.NewArrayIterator(p.assignments)
 }
 

--- a/pkg/schema/assignment.go
+++ b/pkg/schema/assignment.go
@@ -16,7 +16,6 @@ import (
 	tr "github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/array"
-	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -26,7 +25,7 @@ import (
 // have an associated assignment.  A good example of an assignment is computed
 // the multiplicative inverse of a column in order to implement a non-zero
 // check.
-type Assignment interface {
+type Assignment[F any] interface {
 	// For the given module, determine any well-definedness bounds implied by
 	// this assignment in  both the negative (left) or positive (right)
 	// directions.  For example, consider an expression such as "(shift X -1)".
@@ -39,7 +38,7 @@ type Assignment interface {
 	// assignment depends must exist (e.g. are either inputs or have been
 	// computed already).  Computed columns do not exist in the original trace,
 	// but are added during trace expansion to form the final trace.
-	Compute(tr.Trace[bls12_377.Element], Schema[Constraint]) ([]array.MutArray[bls12_377.Element], error)
+	Compute(tr.Trace[F], Schema[Constraint]) ([]array.MutArray[F], error)
 	// Consistent applies a number of internal consistency checks.  Whilst not
 	// strictly necessary, these can highlight otherwise hidden problems as an aid
 	// to debugging.

--- a/pkg/schema/mixed_schema.go
+++ b/pkg/schema/mixed_schema.go
@@ -45,7 +45,7 @@ func NewMixedSchema[M1 Module, M2 Module](leftModules []M1, rightModules []M2) M
 // Assignments returns an iterator over the assignments of this schema
 // These are the computations used to assign values to all computed columns
 // in this schema.
-func (p MixedSchema[M1, M2]) Assignments() iter.Iterator[Assignment] {
+func (p MixedSchema[M1, M2]) Assignments() iter.Iterator[Assignment[bls12_377.Element]] {
 	leftIter := assignmentsOf(p.left)
 	rightIter := assignmentsOf(p.right)
 	//

--- a/pkg/schema/module.go
+++ b/pkg/schema/module.go
@@ -19,6 +19,7 @@ import (
 	"reflect"
 
 	"github.com/consensys/go-corset/pkg/util/collection/iter"
+	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 )
 
 // ModuleMap provides a mapping from module identifiers (or names) to register
@@ -45,7 +46,7 @@ type Module interface {
 	// Assignments returns an iterator over the assignments of this module.
 	// These are the computations used to assign values to all computed columns
 	// in this module.
-	Assignments() iter.Iterator[Assignment]
+	Assignments() iter.Iterator[Assignment[bls12_377.Element]]
 	// Constraints provides access to those constraints associated with this
 	// module.
 	Constraints() iter.Iterator[Constraint]
@@ -89,7 +90,7 @@ type Table[C Constraint] struct {
 	padding     bool
 	registers   []Register
 	constraints []C
-	assignments []Assignment
+	assignments []Assignment[bls12_377.Element]
 }
 
 // NewTable constructs a table module with the given registers and constraints.
@@ -99,7 +100,7 @@ func NewTable[C Constraint](name string, multiplier uint, padding bool) *Table[C
 
 // Assignments provides access to those assignments defined as part of this
 // table.
-func (p *Table[C]) Assignments() iter.Iterator[Assignment] {
+func (p *Table[C]) Assignments() iter.Iterator[Assignment[bls12_377.Element]] {
 	return iter.NewArrayIterator(p.assignments)
 }
 
@@ -175,7 +176,7 @@ func (p *Table[C]) Subdivide(mapping LimbsMap) *Table[C] {
 		modmap      = mapping.ModuleOf(p.name)
 		registers   []Register
 		constraints []C
-		assignments []Assignment
+		assignments []Assignment[bls12_377.Element]
 	)
 	// Append mapping registers
 	for i := range p.registers {
@@ -189,7 +190,7 @@ func (p *Table[C]) Subdivide(mapping LimbsMap) *Table[C] {
 	for _, c := range p.assignments {
 		var a any = c
 		//nolint
-		if fc, ok := a.(FieldAgnostic[Assignment]); ok {
+		if fc, ok := a.(FieldAgnostic[Assignment[bls12_377.Element]]); ok {
 			assignments = append(assignments, fc.Subdivide(mapping))
 		} else {
 			panic(fmt.Sprintf("non-field agnostic assignment (%s)", reflect.TypeOf(a).String()))
@@ -219,7 +220,7 @@ func (p *Table[C]) Width() uint {
 // ============================================================================
 
 // AddAssignments adds a new assignments to this table.
-func (p *Table[C]) AddAssignments(assignments ...Assignment) {
+func (p *Table[C]) AddAssignments(assignments ...Assignment[bls12_377.Element]) {
 	p.assignments = append(p.assignments, assignments...)
 }
 

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -46,7 +46,7 @@ type Schema[C any] interface {
 	// Assignments returns an iterator over the assignments of this schema.
 	// That is, the set of computations used to determine values for all
 	// computed columns.
-	Assignments() iter.Iterator[Assignment]
+	Assignments() iter.Iterator[Assignment[bls12_377.Element]]
 	// Consistent applies a number of internal consistency checks.  Whilst not
 	// strictly necessary, these can highlight otherwise hidden problems as an aid
 	// to debugging.

--- a/pkg/schema/uniform_schema.go
+++ b/pkg/schema/uniform_schema.go
@@ -18,6 +18,7 @@ import (
 	"math"
 
 	"github.com/consensys/go-corset/pkg/util/collection/iter"
+	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 )
 
 // UniformSchema represents the simplest kind of schema which contains only
@@ -37,7 +38,7 @@ func NewUniformSchema[M Module](modules []M) UniformSchema[M] {
 // Assignments returns an iterator over the assignments of this schema
 // These are the computations used to assign values to all computed columns
 // in this schema.
-func (p UniformSchema[M]) Assignments() iter.Iterator[Assignment] {
+func (p UniformSchema[M]) Assignments() iter.Iterator[Assignment[bls12_377.Element]] {
 	return assignmentsOf(p.modules)
 }
 
@@ -101,10 +102,10 @@ func (p UniformSchema[M]) Width() uint {
 
 // Extract an iterator over all the constraints in a given array using a
 // projecting iterator.
-func assignmentsOf[M Module](modules []M) iter.Iterator[Assignment] {
+func assignmentsOf[M Module](modules []M) iter.Iterator[Assignment[bls12_377.Element]] {
 	arrIter := iter.NewArrayIterator(modules)
 	//
-	return iter.NewFlattenIterator(arrIter, func(m M) iter.Iterator[Assignment] {
+	return iter.NewFlattenIterator(arrIter, func(m M) iter.Iterator[Assignment[bls12_377.Element]] {
 		return m.Assignments()
 	})
 }


### PR DESCRIPTION
This makes the Assignment interface generic, as well as all the non-assembly assignment implementations.  In most cases, this was very straightforward as most of the plumbing had already been done.