### PR TITLE
feat: make constraints generic

### DIFF
--- a/pkg/asm/io/assignment.go
+++ b/pkg/asm/io/assignment.go
@@ -22,6 +22,7 @@ import (
 	"github.com/consensys/go-corset/pkg/util/collection/array"
 	"github.com/consensys/go-corset/pkg/util/collection/bit"
 	"github.com/consensys/go-corset/pkg/util/field"
+	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 	"github.com/consensys/go-corset/pkg/util/word"
 )
@@ -36,7 +37,7 @@ func (p Assignment[F, T]) Bounds(module uint) util.Bounds {
 }
 
 // Compute implementation for schema.Assignment interface.
-func (p Assignment[F, T]) Compute(trace tr.Trace[F], schema sc.AnySchema) ([]array.MutArray[F], error) {
+func (p Assignment[F, T]) Compute(trace tr.Trace[F], schema sc.AnySchema[F]) ([]array.MutArray[F], error) {
 	//
 	var (
 		trModule = trace.Module(p.id)
@@ -52,12 +53,12 @@ func (p Assignment[F, T]) Compute(trace tr.Trace[F], schema sc.AnySchema) ([]arr
 }
 
 // Consistent implementation for schema.Assignment interface.
-func (p Assignment[F, T]) Consistent(sc.AnySchema) []error {
+func (p Assignment[F, T]) Consistent(sc.AnySchema[bls12_377.Element]) []error {
 	return nil
 }
 
 // Lisp implementation for schema.Assignment interface.
-func (p Assignment[F, T]) Lisp(schema sc.AnySchema) sexp.SExp {
+func (p Assignment[F, T]) Lisp(schema sc.AnySchema[bls12_377.Element]) sexp.SExp {
 	//
 	return sexp.NewList([]sexp.SExp{
 		sexp.NewSymbol("compute"),

--- a/pkg/asm/io/constraint.go
+++ b/pkg/asm/io/constraint.go
@@ -57,7 +57,8 @@ func (p *ConstraintFailure) String() string {
 type Constraint[T Instruction[T]] Function[T]
 
 // Accepts implementation for schema.Constraint interface.
-func (p Constraint[T]) Accepts(trace tr.Trace[bls12_377.Element], _ sc.AnySchema) (bit.Set, sc.Failure) {
+func (p Constraint[T]) Accepts(trace tr.Trace[bls12_377.Element], _ sc.AnySchema[bls12_377.Element],
+) (bit.Set, sc.Failure) {
 	// Extract relevant part of the trace
 	var (
 		coverage bit.Set
@@ -97,7 +98,7 @@ func (p Constraint[T]) Bounds(module uint) util.Bounds {
 }
 
 // Consistent implementation for schema.Constraint interface.
-func (p Constraint[T]) Consistent(sc.AnySchema) []error {
+func (p Constraint[T]) Consistent(sc.AnySchema[bls12_377.Element]) []error {
 	return nil
 }
 
@@ -112,7 +113,7 @@ func (p Constraint[T]) Name() string {
 }
 
 // Lisp implementation for schema.Constraint interface.
-func (p Constraint[T]) Lisp(schema sc.AnySchema) sexp.SExp {
+func (p Constraint[T]) Lisp(schema sc.AnySchema[bls12_377.Element]) sexp.SExp {
 	//
 	return sexp.NewList([]sexp.SExp{
 		sexp.NewSymbol("function"),

--- a/pkg/asm/io/function.go
+++ b/pkg/asm/io/function.go
@@ -95,16 +95,16 @@ func (p *Function[T]) Code() []T {
 
 // Constraints provides access to those constraints associated with this
 // function.
-func (p *Function[T]) Constraints() iter.Iterator[sc.Constraint] {
+func (p *Function[T]) Constraints() iter.Iterator[sc.Constraint[bls12_377.Element]] {
 	var constraint Constraint[T] = Constraint[T]{p.id, p.name, p.registers, p.code}
 	//
-	return iter.NewUnitIterator[sc.Constraint](constraint)
+	return iter.NewUnitIterator[sc.Constraint[bls12_377.Element]](constraint)
 }
 
 // Consistent applies a number of internal consistency checks.  Whilst not
 // strictly necessary, these can highlight otherwise hidden problems as an aid
 // to debugging.
-func (p *Function[T]) Consistent(sc.Schema[sc.Constraint]) []error {
+func (p *Function[T]) Consistent(sc.AnySchema[bls12_377.Element]) []error {
 	// TODO: add checks?
 	return nil
 }

--- a/pkg/binfile/binfile.go
+++ b/pkg/binfile/binfile.go
@@ -205,7 +205,7 @@ const BINFILE_MAJOR_VERSION uint16 = 6
 // BINFILE_MINOR_VERSION gives the minor version of the binary file format.  The
 // expected interpretation is that older versions are compatible with newer
 // ones, but not vice-versa.
-const BINFILE_MINOR_VERSION uint16 = 2
+const BINFILE_MINOR_VERSION uint16 = 3
 
 // ZKBINARY is used as the file identifier for binary file types.  This just
 // helps us identify actual binary files from corrupted files.

--- a/pkg/cmd/check.go
+++ b/pkg/cmd/check.go
@@ -33,6 +33,7 @@ import (
 	"github.com/consensys/go-corset/pkg/trace/lt"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/set"
+	"github.com/consensys/go-corset/pkg/util/field"
 	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -222,24 +223,24 @@ func reportFailures(ir string, failures []sc.Failure, trace tr.Trace[bls12_377.E
 }
 
 // Print a human-readable report detailing the given failure
-func reportFailure(failure sc.Failure, trace tr.Trace[bls12_377.Element], cfg checkConfig) {
-	if f, ok := failure.(*vanishing.Failure); ok {
+func reportFailure[F field.Element[F]](failure sc.Failure, trace tr.Trace[F], cfg checkConfig) {
+	if f, ok := failure.(*vanishing.Failure[F]); ok {
 		cells := f.RequiredCells(trace)
 		fmt.Printf("failing constraint %s:\n", f.Handle)
 		reportRelevantCells(cells, trace, cfg)
-	} else if f, ok := failure.(*ranged.Failure); ok {
+	} else if f, ok := failure.(*ranged.Failure[F]); ok {
 		cells := f.RequiredCells(trace)
 		fmt.Printf("failing range constraint %s:\n", f.Handle)
 		reportRelevantCells(cells, trace, cfg)
-	} else if f, ok := failure.(*lookup.Failure); ok {
+	} else if f, ok := failure.(*lookup.Failure[F]); ok {
 		cells := f.RequiredCells(trace)
 		fmt.Printf("failing lookup constraint %s:\n", f.Handle)
 		reportRelevantCells(cells, trace, cfg)
-	} else if f, ok := failure.(*constraint.AssertionFailure); ok {
+	} else if f, ok := failure.(*constraint.AssertionFailure[F]); ok {
 		cells := f.RequiredCells(trace)
 		fmt.Printf("failing assertion %s:\n", f.Handle)
 		reportRelevantCells(cells, trace, cfg)
-	} else if f, ok := failure.(*constraint.InternalFailure); ok {
+	} else if f, ok := failure.(*constraint.InternalFailure[F]); ok {
 		cells := f.RequiredCells(trace)
 		fmt.Printf("%s in %s:\n", f.Error, f.Handle)
 		reportRelevantCells(cells, trace, cfg)
@@ -247,7 +248,7 @@ func reportFailure(failure sc.Failure, trace tr.Trace[bls12_377.Element], cfg ch
 }
 
 // Print a human-readable report detailing the given failure with a vanishing constraint.
-func reportRelevantCells(cells *set.AnySortedSet[tr.CellRef], trace tr.Trace[bls12_377.Element], cfg checkConfig) {
+func reportRelevantCells[F field.Element[F]](cells *set.AnySortedSet[tr.CellRef], trace tr.Trace[F], cfg checkConfig) {
 	// Construct trace window
 	window := check.NewTraceWindow(cells, trace, cfg.reportPadding, cfg.corsetSourceMap)
 	// Construct & configure printer

--- a/pkg/cmd/check.go
+++ b/pkg/cmd/check.go
@@ -175,7 +175,7 @@ func checkWithLegacyPipeline(cfg checkConfig, batched bool, tracefile string, sc
 	}
 }
 
-func checkTrace(ir string, traces []lt.TraceFile, schema sc.AnySchema,
+func checkTrace(ir string, traces []lt.TraceFile, schema sc.AnySchema[bls12_377.Element],
 	builder ir.TraceBuilder, cfg checkConfig) bool {
 	//
 	for _, tf := range traces {

--- a/pkg/cmd/debug/schema.go
+++ b/pkg/cmd/debug/schema.go
@@ -21,6 +21,7 @@ import (
 	cmd_util "github.com/consensys/go-corset/pkg/cmd/util"
 	"github.com/consensys/go-corset/pkg/ir/mir"
 	"github.com/consensys/go-corset/pkg/schema"
+	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -34,7 +35,7 @@ func PrintSchemas(stack cmd_util.SchemaStack, textwidth uint) {
 }
 
 // Print out all declarations included in a given
-func printSchema(schema schema.AnySchema, width uint) {
+func printSchema(schema schema.AnySchema[bls12_377.Element], width uint) {
 	first := true
 	// Print out each module, one by one.
 	for i := schema.Modules(); i.HasNext(); {
@@ -65,7 +66,7 @@ func printSchema(schema schema.AnySchema, width uint) {
 // Legacy module
 // ==================================================================
 
-func printModule(module schema.Module, sc schema.AnySchema, width uint) {
+func printModule(module schema.Module, sc schema.AnySchema[bls12_377.Element], width uint) {
 	formatter := sexp.NewFormatter(width)
 	formatter.Add(&sexp.SFormatter{Head: "if", Priority: 0})
 	formatter.Add(&sexp.SFormatter{Head: "ifnot", Priority: 0})
@@ -147,7 +148,7 @@ func countRegisters(module schema.Module, filter func(schema.Register) bool) uin
 	return count
 }
 
-func requiresSpacing(c schema.Constraint) bool {
+func requiresSpacing(c schema.Constraint[bls12_377.Element]) bool {
 	if c, ok := c.(mir.Constraint); ok {
 		if _, ok := c.Unwrap().(mir.VanishingConstraint); ok {
 			return ok

--- a/pkg/cmd/debug/stats.go
+++ b/pkg/cmd/debug/stats.go
@@ -58,12 +58,12 @@ func PrintStats(stack cmd_util.SchemaStack) {
 
 type schemaSummariser struct {
 	name    string
-	summary func(sc.AnySchema) int
+	summary func(sc.AnySchema[bls12_377.Element]) int
 }
 
 var schemaSummarisers []schemaSummariser = []schemaSummariser{
 	// Constraints
-	constraintCounter("Constraints", func(schema.Constraint) bool { return true }),
+	constraintCounter("Constraints", func(schema.Constraint[bls12_377.Element]) bool { return true }),
 	constraintCounter("Vanishing", isVanishingConstraint),
 	constraintCounter("Lookups", isLookupConstraint),
 	constraintCounter("Permutations", isPermutationConstraint),
@@ -85,7 +85,7 @@ var schemaSummarisers []schemaSummariser = []schemaSummariser{
 	columnWidthSummariser(129, 256),
 }
 
-func isVanishingConstraint(c schema.Constraint) bool {
+func isVanishingConstraint(c schema.Constraint[bls12_377.Element]) bool {
 	switch c := c.(type) {
 	case air.VanishingConstraint:
 		return true
@@ -97,7 +97,7 @@ func isVanishingConstraint(c schema.Constraint) bool {
 	return false
 }
 
-func isLookupConstraint(c schema.Constraint) bool {
+func isLookupConstraint(c schema.Constraint[bls12_377.Element]) bool {
 	switch c := c.(type) {
 	case air.LookupConstraint:
 		return true
@@ -109,7 +109,7 @@ func isLookupConstraint(c schema.Constraint) bool {
 	return false
 }
 
-func isPermutationConstraint(c schema.Constraint) bool {
+func isPermutationConstraint(c schema.Constraint[bls12_377.Element]) bool {
 	switch c := c.(type) {
 	case air.PermutationConstraint:
 		return true
@@ -121,7 +121,7 @@ func isPermutationConstraint(c schema.Constraint) bool {
 	return false
 }
 
-func isRangeConstraint(c schema.Constraint) bool {
+func isRangeConstraint(c schema.Constraint[bls12_377.Element]) bool {
 	switch c := c.(type) {
 	case air.RangeConstraint:
 		return true
@@ -133,10 +133,10 @@ func isRangeConstraint(c schema.Constraint) bool {
 	return false
 }
 
-func constraintCounter(title string, includes func(schema.Constraint) bool) schemaSummariser {
+func constraintCounter(title string, includes func(schema.Constraint[bls12_377.Element]) bool) schemaSummariser {
 	return schemaSummariser{
 		name: title,
-		summary: func(schema sc.AnySchema) int {
+		summary: func(schema sc.AnySchema[bls12_377.Element]) int {
 			sum := 0
 			for iter := schema.Constraints(); iter.HasNext(); {
 				if includes(iter.Next()) {
@@ -151,7 +151,7 @@ func constraintCounter(title string, includes func(schema.Constraint) bool) sche
 func assignmentCounter(title string, types ...reflect.Type) schemaSummariser {
 	return schemaSummariser{
 		name: title,
-		summary: func(schema sc.AnySchema) int {
+		summary: func(schema sc.AnySchema[bls12_377.Element]) int {
 			sum := 0
 			for _, t := range types {
 				sum += typeOfCounter(schema, t)
@@ -161,7 +161,7 @@ func assignmentCounter(title string, types ...reflect.Type) schemaSummariser {
 	}
 }
 
-func typeOfCounter(schema sc.AnySchema, dyntype reflect.Type) int {
+func typeOfCounter(schema sc.AnySchema[bls12_377.Element], dyntype reflect.Type) int {
 	count := 0
 
 	for m := range schema.Width() {
@@ -179,7 +179,7 @@ func typeOfCounter(schema sc.AnySchema, dyntype reflect.Type) int {
 func columnCounter() schemaSummariser {
 	return schemaSummariser{
 		name: "Columns (all)",
-		summary: func(schema sc.AnySchema) int {
+		summary: func(schema sc.AnySchema[bls12_377.Element]) int {
 			count := 0
 			for m := range schema.Width() {
 				count += int(schema.Module(m).Width())
@@ -192,7 +192,7 @@ func columnCounter() schemaSummariser {
 func columnWidthSummariser(lowWidth uint, highWidth uint) schemaSummariser {
 	return schemaSummariser{
 		name: fmt.Sprintf("Columns (%d..%d bits)", lowWidth, highWidth),
-		summary: func(schema sc.AnySchema) int {
+		summary: func(schema sc.AnySchema[bls12_377.Element]) int {
 			count := 0
 			for i := schema.Modules(); i.HasNext(); {
 				m := i.Next()

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/consensys/go-corset/pkg/cmd/generate"
 	cmd_util "github.com/consensys/go-corset/pkg/cmd/util"
 	sc "github.com/consensys/go-corset/pkg/schema"
+	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
@@ -128,7 +129,7 @@ func splitConstraintSets(filenames []string) [][]string {
 
 // Determine spillage required for a given schema and optimisation configuration
 // with (or without) defensive padding.
-func determineSpillage(schema sc.AnySchema, defensive bool) []uint {
+func determineSpillage(schema sc.AnySchema[bls12_377.Element], defensive bool) []uint {
 	nModules := schema.Width()
 	//
 	spillage := make([]uint, nModules)

--- a/pkg/cmd/generate/util.go
+++ b/pkg/cmd/generate/util.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/consensys/go-corset/pkg/schema"
 	sc "github.com/consensys/go-corset/pkg/schema"
+	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 )
 
 // Get a string representing the bound of all values in a given bitwidth.  For
@@ -58,7 +59,7 @@ func normaliseBitwidth(bitwidth uint) uint {
 
 // Determine total number of registers, including those for computed columns, in
 // this schema.
-func getMaxRegisterIndex(schema sc.AnySchema) uint {
+func getMaxRegisterIndex(schema sc.AnySchema[bls12_377.Element]) uint {
 	mx := uint(0)
 	// Write register initialisers
 	for mid := range schema.Width() {

--- a/pkg/cmd/inspect.go
+++ b/pkg/cmd/inspect.go
@@ -22,7 +22,7 @@ import (
 	sc "github.com/consensys/go-corset/pkg/schema"
 	tr "github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
-	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
+	"github.com/consensys/go-corset/pkg/util/field"
 	"github.com/consensys/go-corset/pkg/util/termio"
 	"github.com/spf13/cobra"
 )
@@ -76,7 +76,7 @@ var inspectCmd = &cobra.Command{
 }
 
 // Inspect a given trace using a given schema.
-func inspect(schema sc.AnySchema, srcmap *corset.SourceMap, trace tr.Trace[bls12_377.Element]) []error {
+func inspect[F field.Element[F]](schema sc.AnySchema[F], srcmap *corset.SourceMap, trace tr.Trace[F]) []error {
 	// Construct inspector window
 	inspector := construct(schema, trace, srcmap)
 	// Render inspector
@@ -87,7 +87,9 @@ func inspect(schema sc.AnySchema, srcmap *corset.SourceMap, trace tr.Trace[bls12
 	return inspector.Start()
 }
 
-func construct(schema sc.AnySchema, trace tr.Trace[bls12_377.Element], srcmap *corset.SourceMap) *inspector.Inspector {
+func construct[F field.Element[F]](schema sc.AnySchema[F], trace tr.Trace[F], srcmap *corset.SourceMap,
+) *inspector.Inspector[F] {
+	//
 	term, err := termio.NewTerminal()
 	// Check whether successful
 	if err == nil {

--- a/pkg/cmd/inspector/input_mode.go
+++ b/pkg/cmd/inspector/input_mode.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/consensys/go-corset/pkg/util/collection/array"
+	"github.com/consensys/go-corset/pkg/util/field"
 	"github.com/consensys/go-corset/pkg/util/source"
 	"github.com/consensys/go-corset/pkg/util/source/bexp"
 	"github.com/consensys/go-corset/pkg/util/termio"
@@ -26,7 +27,7 @@ import (
 
 // InputMode is where the user is entering some information (e.g. row for
 // executing a goto command).
-type InputMode[T any] struct {
+type InputMode[F field.Element[F], T any] struct {
 	// prompt to show user
 	prompt termio.FormattedText
 	// input text being accumulated whilst in input mode.
@@ -50,8 +51,8 @@ type InputHandler[T any] interface {
 	Apply(T) termio.FormattedText
 }
 
-func newInputMode[T any](prompt termio.FormattedText, index uint, history []string,
-	handler InputHandler[T]) *InputMode[T] {
+func newInputMode[F field.Element[F], T any](prompt termio.FormattedText, index uint, history []string,
+	handler InputHandler[T]) *InputMode[F, T] {
 	var input []byte
 	// Determine whether to show item from history
 	if index >= uint(len(history)) {
@@ -60,12 +61,12 @@ func newInputMode[T any](prompt termio.FormattedText, index uint, history []stri
 		input = []byte(history[index])
 	}
 	// Done
-	return &InputMode[T]{prompt, input, 0, history, index, handler}
+	return &InputMode[F, T]{prompt, input, 0, history, index, handler}
 }
 
 // Activate navigation mode by setting the command bar to show the navigation
 // commands.
-func (p *InputMode[T]) Activate(parent *Inspector) {
+func (p *InputMode[F, T]) Activate(parent *Inspector[F]) {
 	parent.cmdBar.Clear()
 	parent.cmdBar.AddLeft(p.prompt)
 	// Add current filter
@@ -96,13 +97,13 @@ func (p *InputMode[T]) Activate(parent *Inspector) {
 }
 
 // Clock navitation mode, which does nothing at this time.
-func (p *InputMode[T]) Clock(parent *Inspector) {
+func (p *InputMode[F, T]) Clock(parent *Inspector[F]) {
 	// Nothing to do.
 }
 
 // KeyPressed in input mode simply updates the input, or exits the mode if
 // either "ESC" or enter are pressed.
-func (p *InputMode[T]) KeyPressed(parent *Inspector, key uint16) bool {
+func (p *InputMode[F, T]) KeyPressed(parent *Inspector[F], key uint16) bool {
 	switch {
 	case key == termio.ESC:
 		return true
@@ -155,7 +156,7 @@ func (p *InputMode[T]) KeyPressed(parent *Inspector, key uint16) bool {
 }
 
 // Delete character at cursor position
-func (p *InputMode[T]) deleteCharacterAtCursor() {
+func (p *InputMode[F, T]) deleteCharacterAtCursor() {
 	if p.cursor > 0 {
 		p.cursor--
 		p.input = array.RemoveAt(p.input, p.cursor)
@@ -163,7 +164,7 @@ func (p *InputMode[T]) deleteCharacterAtCursor() {
 }
 
 // Insert character at cursor position
-func (p *InputMode[T]) insertCharacterAtCursor(char byte) {
+func (p *InputMode[F, T]) insertCharacterAtCursor(char byte) {
 	p.input = array.InsertAt(p.input, char, p.cursor)
 	// advance cursor
 	p.cursor++
@@ -219,19 +220,20 @@ func (p *regexHandler) Apply(regex *regexp.Regexp) termio.FormattedText {
 // Proposition (i.e. Boolean Expression) Handler
 // ==================================================================
 
-type queryHandler struct {
+type queryHandler[F field.Element[F]] struct {
 	// environment determines which variables are permitted
 	env func(string) bool
 	//
-	callback func(*Query) termio.FormattedText
+	callback func(*Query[F]) termio.FormattedText
 }
 
-func newQueryHandler(env func(string) bool, callback func(*Query) termio.FormattedText) InputHandler[*Query] {
-	return &queryHandler{env, callback}
+func newQueryHandler[F field.Element[F]](env func(string) bool, callback func(*Query[F]) termio.FormattedText,
+) InputHandler[*Query[F]] {
+	return &queryHandler[F]{env, callback}
 }
 
-func (p *queryHandler) Convert(input string) (*Query, error) {
-	prop, errs := bexp.Parse[*Query](input, p.env)
+func (p *queryHandler[F]) Convert(input string) (*Query[F], error) {
+	prop, errs := bexp.Parse[*Query[F]](input, p.env)
 	// Check whether any errors reported
 	if len(errs) == 0 {
 		return prop, nil
@@ -240,7 +242,7 @@ func (p *queryHandler) Convert(input string) (*Query, error) {
 	return nil, errors.New(query_error(errs[0]))
 }
 
-func (p *queryHandler) Apply(query *Query) termio.FormattedText {
+func (p *queryHandler[F]) Apply(query *Query[F]) termio.FormattedText {
 	return p.callback(query)
 }
 

--- a/pkg/cmd/inspector/module_view.go
+++ b/pkg/cmd/inspector/module_view.go
@@ -13,8 +13,8 @@
 package inspector
 
 import (
-	"encoding/binary"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/consensys/go-corset/pkg/corset"
@@ -238,10 +238,15 @@ func (p *ModuleView[F]) display(col uint, val F) string {
 			enumID := int(disp - corset.DISPLAY_CUSTOM)
 			// Check whether valid enumeration.
 			if enumID < len(p.enumerations) {
-				index := binary.BigEndian.Uint64(val.Bytes())
-				// Check whether value covered by enumeration.
-				if lab, ok := p.enumerations[enumID][index]; ok {
-					return lab
+				var index big.Int
+				//
+				index.SetBytes(val.Bytes())
+				//
+				if index.IsUint64() {
+					// Check whether value covered by enumeration.
+					if lab, ok := p.enumerations[enumID][index.Uint64()]; ok {
+						return lab
+					}
 				}
 			}
 		}

--- a/pkg/cmd/inspector/nav_mode.go
+++ b/pkg/cmd/inspector/nav_mode.go
@@ -14,17 +14,18 @@ package inspector
 
 import (
 	"github.com/consensys/go-corset/pkg/util/collection/set"
+	"github.com/consensys/go-corset/pkg/util/field"
 	"github.com/consensys/go-corset/pkg/util/termio"
 )
 
 // NavigationMode is the default mode of the inspector.  In this mode, the user
 // is navigating the trace in the normal fashion.
-type NavigationMode struct {
+type NavigationMode[F field.Element[F]] struct {
 }
 
 // Activate navigation mode by setting the command bar to show the navigation
 // commands.
-func (p *NavigationMode) Activate(parent *Inspector) {
+func (p *NavigationMode[F]) Activate(parent *Inspector[F]) {
 	parent.cmdBar.Clear()
 	parent.cmdBar.AddLeft(termio.NewColouredText("[g]", termio.TERM_YELLOW))
 	parent.cmdBar.AddLeft(termio.NewText("oto :: "))
@@ -47,13 +48,13 @@ func (p *NavigationMode) Activate(parent *Inspector) {
 }
 
 // Clock navitation mode, which does nothing at this time.
-func (p *NavigationMode) Clock(parent *Inspector) {
+func (p *NavigationMode[F]) Clock(parent *Inspector[F]) {
 
 }
 
 // KeyPressed in navigation mode, which either adjusts our view of the trace
 // table or fires off some command.
-func (p *NavigationMode) KeyPressed(parent *Inspector, key uint16) bool {
+func (p *NavigationMode[F]) KeyPressed(parent *Inspector[F], key uint16) bool {
 	module := parent.tabs.Selected()
 	//
 	switch key {
@@ -104,15 +105,15 @@ func (p *NavigationMode) KeyPressed(parent *Inspector, key uint16) bool {
 	return false
 }
 
-func (p *NavigationMode) gotoInputMode(parent *Inspector) Mode {
+func (p *NavigationMode[F]) gotoInputMode(parent *Inspector[F]) Mode[F] {
 	prompt := termio.NewColouredText("[history ↑/↓] row? ", termio.TERM_YELLOW)
 	history := parent.currentView().targetRowHistory
 	history_index := uint(len(history))
 	//
-	return newInputMode(prompt, history_index, history, newUintHandler(parent.gotoRow))
+	return newInputMode[F](prompt, history_index, history, newUintHandler(parent.gotoRow))
 }
 
-func (p *NavigationMode) filterInputMode(parent *Inspector) Mode {
+func (p *NavigationMode[F]) filterInputMode(parent *Inspector[F]) Mode[F] {
 	prompt := termio.NewColouredText("[history ↑/↓] regex? ", termio.TERM_YELLOW)
 	// Determine current active filter
 	filter := parent.currentView().columnFilter
@@ -123,10 +124,10 @@ func (p *NavigationMode) filterInputMode(parent *Inspector) Mode {
 		history_index--
 	}
 	//
-	return newInputMode(prompt, history_index, history, newRegexHandler(parent.filterColumns))
+	return newInputMode[F](prompt, history_index, history, newRegexHandler(parent.filterColumns))
 }
 
-func (p *NavigationMode) scanInputMode(parent *Inspector) Mode {
+func (p *NavigationMode[F]) scanInputMode(parent *Inspector[F]) Mode[F] {
 	var (
 		prompt        = termio.NewColouredText("[history ↑/↓] expression? ", termio.TERM_YELLOW)
 		history       = parent.currentView().scanHistory
@@ -142,5 +143,5 @@ func (p *NavigationMode) scanInputMode(parent *Inspector) Mode {
 		return columns.Contains(col)
 	}
 	// Construct input mode
-	return newInputMode(prompt, history_index, history, newQueryHandler(env, parent.matchQuery))
+	return newInputMode[F](prompt, history_index, history, newQueryHandler(env, parent.matchQuery))
 }

--- a/pkg/cmd/trace.go
+++ b/pkg/cmd/trace.go
@@ -576,11 +576,10 @@ func columnBytesSummariser(col RawColumn) string {
 
 func uniqueElementsSummariser(col RawColumn) string {
 	data := col.Data
-	elems := hash.NewSet[hash.BytesKey](data.Len() / 2)
+	elems := hash.NewSet[word.BigEndian](data.Len() / 2)
 	// Add all the elements
 	for i := uint(0); i < data.Len(); i++ {
-		bytes := data.Get(i).Bytes()
-		elems.Insert(hash.NewBytesKey(bytes))
+		elems.Insert(data.Get(i))
 	}
 	// Done
 	return fmt.Sprintf("%d", elems.Size())

--- a/pkg/cmd/trace.go
+++ b/pkg/cmd/trace.go
@@ -28,6 +28,7 @@ import (
 	"github.com/consensys/go-corset/pkg/util/collection/array"
 	"github.com/consensys/go-corset/pkg/util/collection/hash"
 	"github.com/consensys/go-corset/pkg/util/collection/set"
+	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 	"github.com/consensys/go-corset/pkg/util/termio"
 	"github.com/consensys/go-corset/pkg/util/word"
 	log "github.com/sirupsen/logrus"
@@ -138,7 +139,7 @@ func init() {
 // RawColumn provides a convenient alias
 type RawColumn = trace.RawColumn[word.BigEndian]
 
-func expandColumns(tf lt.TraceFile, schema sc.AnySchema, builder ir.TraceBuilder) lt.TraceFile {
+func expandColumns(tf lt.TraceFile, schema sc.AnySchema[bls12_377.Element], builder ir.TraceBuilder) lt.TraceFile {
 	var (
 		rcols []RawColumn
 		// Construct expanded tr

--- a/pkg/cmd/util/schema_stack.go
+++ b/pkg/cmd/util/schema_stack.go
@@ -74,7 +74,7 @@ type SchemaStack struct {
 	// Binfile represents the top of this stack.
 	binfile binfile.BinaryFile
 	// The various layers which are refined from the binfile.
-	schemas []schema.AnySchema
+	schemas []schema.AnySchema[bls12_377.Element]
 	// Register mapping used
 	mapping schema.LimbsMap
 	// Name of IR used for corresponding schema
@@ -150,13 +150,13 @@ func (p *SchemaStack) HasUniqueSchema() bool {
 
 // Schemas returns the stack of schemas according to the selected layers, where
 // higher-level layers come first.
-func (p *SchemaStack) Schemas() []schema.AnySchema {
+func (p *SchemaStack) Schemas() []schema.AnySchema[bls12_377.Element] {
 	return p.schemas
 }
 
 // SchemaOf returns the schema associated with the given IR representation.  If
 // there is no match, this will panic.
-func (p *SchemaStack) SchemaOf(ir string) schema.AnySchema {
+func (p *SchemaStack) SchemaOf(ir string) schema.AnySchema[bls12_377.Element] {
 	for i, n := range p.names {
 		if n == ir {
 			return p.schemas[i]
@@ -173,12 +173,12 @@ func (p *SchemaStack) TraceBuilder() ir.TraceBuilder {
 
 // UniqueSchema returns the first schema on the stack which, when
 // HasUniqueSchema() holds, means the uniquely specified schema.
-func (p *SchemaStack) UniqueSchema() schema.AnySchema {
+func (p *SchemaStack) UniqueSchema() schema.AnySchema[bls12_377.Element] {
 	return p.schemas[0]
 }
 
 // LowestSchema returns the last (i.e. lowest) schema on the stack.
-func (p *SchemaStack) LowestSchema() schema.AnySchema {
+func (p *SchemaStack) LowestSchema() schema.AnySchema[bls12_377.Element] {
 	n := len(p.schemas) - 1
 	return p.schemas[n]
 }

--- a/pkg/corset/compiler.go
+++ b/pkg/corset/compiler.go
@@ -19,12 +19,12 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	"github.com/consensys/go-corset/pkg/corset/ast"
 	"github.com/consensys/go-corset/pkg/corset/compiler"
 	"github.com/consensys/go-corset/pkg/ir/mir"
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/util"
+	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 	"github.com/consensys/go-corset/pkg/util/source"
 )
 
@@ -176,14 +176,14 @@ func includeStdlib(stdlib bool, srcfiles []*source.File) []*source.File {
 	return srcfiles
 }
 
-func constructSourceMap(schema schema.AnySchema, scope *compiler.ModuleScope,
+func constructSourceMap(schema schema.AnySchema[bls12_377.Element], scope *compiler.ModuleScope,
 	env compiler.GlobalEnvironment) *SourceMap {
 	//
 	enumerations := []Enumeration{OPCODE_ENUMERATION}
 	return &SourceMap{constructSourceModule(schema, scope, env), enumerations}
 }
 
-func constructSourceModule(schema schema.AnySchema, scope *compiler.ModuleScope,
+func constructSourceModule(schema schema.AnySchema[bls12_377.Element], scope *compiler.ModuleScope,
 	env compiler.GlobalEnvironment) SourceModule {
 	//
 	var (
@@ -242,7 +242,8 @@ func constructSourceModule(schema schema.AnySchema, scope *compiler.ModuleScope,
 
 // Determine the reference reference in the schema which corresponds with a
 // given (Corset) path.
-func determineRegisterRef(path util.Path, sc schema.AnySchema, env compiler.GlobalEnvironment) schema.RegisterRef {
+func determineRegisterRef[F any](path util.Path, sc schema.AnySchema[F], env compiler.GlobalEnvironment,
+) schema.RegisterRef {
 	var (
 		mid schema.ModuleId
 		rid schema.RegisterId
@@ -281,7 +282,7 @@ func constructDisplayModifier(modifier string) uint {
 
 // OPCODE_ENUMERATION provides a default enumeration for the existing ":opcode"
 // display modifier.
-var OPCODE_ENUMERATION map[fr.Element]string = map[fr.Element]string{}
+var OPCODE_ENUMERATION map[uint64]string = map[uint64]string{}
 
 // ContextOf attempts to reconstruct an AST context from a given module name.
 // This is helpful if we want to know the "root" module for a given family of
@@ -308,101 +309,100 @@ func ContextOf(name string) ast.Context {
 }
 
 func init() {
-	OPCODE_ENUMERATION[fr.NewElement(0)] = "STOP"
-	OPCODE_ENUMERATION[fr.NewElement(0x0)] = "STOP"
-	OPCODE_ENUMERATION[fr.NewElement(0x1)] = "ADD"
-	OPCODE_ENUMERATION[fr.NewElement(0x2)] = "MUL"
-	OPCODE_ENUMERATION[fr.NewElement(0x3)] = "SUB"
-	OPCODE_ENUMERATION[fr.NewElement(0x4)] = "DIV"
-	OPCODE_ENUMERATION[fr.NewElement(0x5)] = "SDIV"
-	OPCODE_ENUMERATION[fr.NewElement(0x6)] = "MOD"
-	OPCODE_ENUMERATION[fr.NewElement(0x7)] = "SMOD"
-	OPCODE_ENUMERATION[fr.NewElement(0x8)] = "ADDMOD"
-	OPCODE_ENUMERATION[fr.NewElement(0x9)] = "MULMOD"
-	OPCODE_ENUMERATION[fr.NewElement(0xa)] = "EXP"
-	OPCODE_ENUMERATION[fr.NewElement(0xb)] = "SIGNEXTEND"
-	OPCODE_ENUMERATION[fr.NewElement(0x10)] = "LT"
-	OPCODE_ENUMERATION[fr.NewElement(0x11)] = "GT"
-	OPCODE_ENUMERATION[fr.NewElement(0x12)] = "SLT"
-	OPCODE_ENUMERATION[fr.NewElement(0x13)] = "SGT"
-	OPCODE_ENUMERATION[fr.NewElement(0x14)] = "EQ"
-	OPCODE_ENUMERATION[fr.NewElement(0x15)] = "ISZERO"
-	OPCODE_ENUMERATION[fr.NewElement(0x16)] = "AND"
-	OPCODE_ENUMERATION[fr.NewElement(0x17)] = "OR"
-	OPCODE_ENUMERATION[fr.NewElement(0x18)] = "XOR"
-	OPCODE_ENUMERATION[fr.NewElement(0x19)] = "NOT"
-	OPCODE_ENUMERATION[fr.NewElement(0x1a)] = "BYTE"
-	OPCODE_ENUMERATION[fr.NewElement(0x1b)] = "SHL"
-	OPCODE_ENUMERATION[fr.NewElement(0x1c)] = "SHR"
-	OPCODE_ENUMERATION[fr.NewElement(0x1d)] = "SAR"
-	OPCODE_ENUMERATION[fr.NewElement(0x20)] = "SHA3"
-	OPCODE_ENUMERATION[fr.NewElement(0x30)] = "ADDRESS"
-	OPCODE_ENUMERATION[fr.NewElement(0x31)] = "BALANCE"
-	OPCODE_ENUMERATION[fr.NewElement(0x32)] = "ORIGIN"
-	OPCODE_ENUMERATION[fr.NewElement(0x33)] = "CALLER"
-	OPCODE_ENUMERATION[fr.NewElement(0x34)] = "CALLVALUE"
-	OPCODE_ENUMERATION[fr.NewElement(0x35)] = "CALLDATALOAD"
-	OPCODE_ENUMERATION[fr.NewElement(0x36)] = "CALLDATASIZE"
-	OPCODE_ENUMERATION[fr.NewElement(0x37)] = "CALLDATACOPY"
-	OPCODE_ENUMERATION[fr.NewElement(0x38)] = "CODESIZE"
-	OPCODE_ENUMERATION[fr.NewElement(0x39)] = "CODECOPY"
-	OPCODE_ENUMERATION[fr.NewElement(0x3a)] = "GASPRICE"
-	OPCODE_ENUMERATION[fr.NewElement(0x3b)] = "EXTCODESIZE"
-	OPCODE_ENUMERATION[fr.NewElement(0x3c)] = "EXTCODECOPY"
-	OPCODE_ENUMERATION[fr.NewElement(0x3d)] = "RETURNDATASIZE"
-	OPCODE_ENUMERATION[fr.NewElement(0x3e)] = "RETURNDATACOPY"
-	OPCODE_ENUMERATION[fr.NewElement(0x3f)] = "EXTCODEHASH"
-	OPCODE_ENUMERATION[fr.NewElement(0x40)] = "BLOCKHASH"
-	OPCODE_ENUMERATION[fr.NewElement(0x41)] = "COINBASE"
-	OPCODE_ENUMERATION[fr.NewElement(0x42)] = "TIMESTAMP"
-	OPCODE_ENUMERATION[fr.NewElement(0x43)] = "NUMBER"
-	OPCODE_ENUMERATION[fr.NewElement(0x44)] = "DIFFICULTY"
-	OPCODE_ENUMERATION[fr.NewElement(0x45)] = "GASLIMIT"
-	OPCODE_ENUMERATION[fr.NewElement(0x46)] = "CHAINID"
-	OPCODE_ENUMERATION[fr.NewElement(0x47)] = "SELFBALANCE"
-	OPCODE_ENUMERATION[fr.NewElement(0x48)] = "BASEFEE"
-	OPCODE_ENUMERATION[fr.NewElement(0x50)] = "POP"
-	OPCODE_ENUMERATION[fr.NewElement(0x51)] = "MLOAD"
-	OPCODE_ENUMERATION[fr.NewElement(0x52)] = "MSTORE"
-	OPCODE_ENUMERATION[fr.NewElement(0x53)] = "MSTORE8"
-	OPCODE_ENUMERATION[fr.NewElement(0x54)] = "SLOAD"
-	OPCODE_ENUMERATION[fr.NewElement(0x55)] = "SSTORE"
-	OPCODE_ENUMERATION[fr.NewElement(0x56)] = "JUMP"
-	OPCODE_ENUMERATION[fr.NewElement(0x57)] = "JUMPI"
-	OPCODE_ENUMERATION[fr.NewElement(0x58)] = "PC"
-	OPCODE_ENUMERATION[fr.NewElement(0x59)] = "MSIZE"
-	OPCODE_ENUMERATION[fr.NewElement(0x5a)] = "GAS"
-	OPCODE_ENUMERATION[fr.NewElement(0x5b)] = "JUMPDEST"
+	OPCODE_ENUMERATION[0x0] = "STOP"
+	OPCODE_ENUMERATION[0x1] = "ADD"
+	OPCODE_ENUMERATION[0x2] = "MUL"
+	OPCODE_ENUMERATION[0x3] = "SUB"
+	OPCODE_ENUMERATION[0x4] = "DIV"
+	OPCODE_ENUMERATION[0x5] = "SDIV"
+	OPCODE_ENUMERATION[0x6] = "MOD"
+	OPCODE_ENUMERATION[0x7] = "SMOD"
+	OPCODE_ENUMERATION[0x8] = "ADDMOD"
+	OPCODE_ENUMERATION[0x9] = "MULMOD"
+	OPCODE_ENUMERATION[0xa] = "EXP"
+	OPCODE_ENUMERATION[0xb] = "SIGNEXTEND"
+	OPCODE_ENUMERATION[0x10] = "LT"
+	OPCODE_ENUMERATION[0x11] = "GT"
+	OPCODE_ENUMERATION[0x12] = "SLT"
+	OPCODE_ENUMERATION[0x13] = "SGT"
+	OPCODE_ENUMERATION[0x14] = "EQ"
+	OPCODE_ENUMERATION[0x15] = "ISZERO"
+	OPCODE_ENUMERATION[0x16] = "AND"
+	OPCODE_ENUMERATION[0x17] = "OR"
+	OPCODE_ENUMERATION[0x18] = "XOR"
+	OPCODE_ENUMERATION[0x19] = "NOT"
+	OPCODE_ENUMERATION[0x1a] = "BYTE"
+	OPCODE_ENUMERATION[0x1b] = "SHL"
+	OPCODE_ENUMERATION[0x1c] = "SHR"
+	OPCODE_ENUMERATION[0x1d] = "SAR"
+	OPCODE_ENUMERATION[0x20] = "SHA3"
+	OPCODE_ENUMERATION[0x30] = "ADDRESS"
+	OPCODE_ENUMERATION[0x31] = "BALANCE"
+	OPCODE_ENUMERATION[0x32] = "ORIGIN"
+	OPCODE_ENUMERATION[0x33] = "CALLER"
+	OPCODE_ENUMERATION[0x34] = "CALLVALUE"
+	OPCODE_ENUMERATION[0x35] = "CALLDATALOAD"
+	OPCODE_ENUMERATION[0x36] = "CALLDATASIZE"
+	OPCODE_ENUMERATION[0x37] = "CALLDATACOPY"
+	OPCODE_ENUMERATION[0x38] = "CODESIZE"
+	OPCODE_ENUMERATION[0x39] = "CODECOPY"
+	OPCODE_ENUMERATION[0x3a] = "GASPRICE"
+	OPCODE_ENUMERATION[0x3b] = "EXTCODESIZE"
+	OPCODE_ENUMERATION[0x3c] = "EXTCODECOPY"
+	OPCODE_ENUMERATION[0x3d] = "RETURNDATASIZE"
+	OPCODE_ENUMERATION[0x3e] = "RETURNDATACOPY"
+	OPCODE_ENUMERATION[0x3f] = "EXTCODEHASH"
+	OPCODE_ENUMERATION[0x40] = "BLOCKHASH"
+	OPCODE_ENUMERATION[0x41] = "COINBASE"
+	OPCODE_ENUMERATION[0x42] = "TIMESTAMP"
+	OPCODE_ENUMERATION[0x43] = "NUMBER"
+	OPCODE_ENUMERATION[0x44] = "DIFFICULTY"
+	OPCODE_ENUMERATION[0x45] = "GASLIMIT"
+	OPCODE_ENUMERATION[0x46] = "CHAINID"
+	OPCODE_ENUMERATION[0x47] = "SELFBALANCE"
+	OPCODE_ENUMERATION[0x48] = "BASEFEE"
+	OPCODE_ENUMERATION[0x50] = "POP"
+	OPCODE_ENUMERATION[0x51] = "MLOAD"
+	OPCODE_ENUMERATION[0x52] = "MSTORE"
+	OPCODE_ENUMERATION[0x53] = "MSTORE8"
+	OPCODE_ENUMERATION[0x54] = "SLOAD"
+	OPCODE_ENUMERATION[0x55] = "SSTORE"
+	OPCODE_ENUMERATION[0x56] = "JUMP"
+	OPCODE_ENUMERATION[0x57] = "JUMPI"
+	OPCODE_ENUMERATION[0x58] = "PC"
+	OPCODE_ENUMERATION[0x59] = "MSIZE"
+	OPCODE_ENUMERATION[0x5a] = "GAS"
+	OPCODE_ENUMERATION[0x5b] = "JUMPDEST"
 	// EIP-1153
-	OPCODE_ENUMERATION[fr.NewElement(0x5c)] = "TLOAD"
-	OPCODE_ENUMERATION[fr.NewElement(0x5d)] = "TSTORE"
+	OPCODE_ENUMERATION[0x5c] = "TLOAD"
+	OPCODE_ENUMERATION[0x5d] = "TSTORE"
 	// EIP-5656
-	OPCODE_ENUMERATION[fr.NewElement(0x5e)] = "MCOPY"
+	OPCODE_ENUMERATION[0x5e] = "MCOPY"
 	// Push (inc PUSH0)
 	for i := uint64(0); i <= 32; i++ {
-		OPCODE_ENUMERATION[fr.NewElement(i+0x5f)] = fmt.Sprintf("PUSH%d", i)
+		OPCODE_ENUMERATION[i+0x5f] = fmt.Sprintf("PUSH%d", i)
 	}
 	// Dup
 	for i := uint64(0); i < 16; i++ {
-		OPCODE_ENUMERATION[fr.NewElement(i+0x80)] = fmt.Sprintf("DUP%d", i+1)
+		OPCODE_ENUMERATION[i+0x80] = fmt.Sprintf("DUP%d", i+1)
 	}
 	// Swap
 	for i := uint64(0); i < 16; i++ {
-		OPCODE_ENUMERATION[fr.NewElement(i+0x90)] = fmt.Sprintf("SWAP%d", i+1)
+		OPCODE_ENUMERATION[i+0x90] = fmt.Sprintf("SWAP%d", i+1)
 	}
 	// Log
 	for i := uint64(0); i <= 4; i++ {
-		OPCODE_ENUMERATION[fr.NewElement(i+0xa0)] = fmt.Sprintf("LOG%d", i)
+		OPCODE_ENUMERATION[i+0xa0] = fmt.Sprintf("LOG%d", i)
 	}
 	//
-	OPCODE_ENUMERATION[fr.NewElement(0xf0)] = "CREATE"
-	OPCODE_ENUMERATION[fr.NewElement(0xf1)] = "CALL"
-	OPCODE_ENUMERATION[fr.NewElement(0xf2)] = "CALLCODE"
-	OPCODE_ENUMERATION[fr.NewElement(0xf3)] = "RETURN"
-	OPCODE_ENUMERATION[fr.NewElement(0xf4)] = "DELEGATECALL"
-	OPCODE_ENUMERATION[fr.NewElement(0xf5)] = "CREATE2"
-	OPCODE_ENUMERATION[fr.NewElement(0xfa)] = "STATICCALL"
-	OPCODE_ENUMERATION[fr.NewElement(0xfd)] = "REVERT"
-	OPCODE_ENUMERATION[fr.NewElement(0xfe)] = "INVALID"
-	OPCODE_ENUMERATION[fr.NewElement(0xff)] = "SELFDESTRUCT"
+	OPCODE_ENUMERATION[0xf0] = "CREATE"
+	OPCODE_ENUMERATION[0xf1] = "CALL"
+	OPCODE_ENUMERATION[0xf2] = "CALLCODE"
+	OPCODE_ENUMERATION[0xf3] = "RETURN"
+	OPCODE_ENUMERATION[0xf4] = "DELEGATECALL"
+	OPCODE_ENUMERATION[0xf5] = "CREATE2"
+	OPCODE_ENUMERATION[0xfa] = "STATICCALL"
+	OPCODE_ENUMERATION[0xfd] = "REVERT"
+	OPCODE_ENUMERATION[0xfe] = "INVALID"
+	OPCODE_ENUMERATION[0xff] = "SELFDESTRUCT"
 }

--- a/pkg/corset/source_map.go
+++ b/pkg/corset/source_map.go
@@ -16,7 +16,6 @@ import (
 	"encoding/gob"
 	"math/big"
 
-	"github.com/consensys/gnark-crypto/ecc/bls12-377/fr"
 	"github.com/consensys/go-corset/pkg/binfile"
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/util"
@@ -57,7 +56,7 @@ func (p *SourceMap) SubstituteConstants(mapping map[string]big.Int) {
 
 // Enumeration is a mapping from field elements to explicitly given names.  For
 // example, mapping opcode bytes to their names.
-type Enumeration map[fr.Element]string
+type Enumeration map[uint64]string
 
 // SourceModule represents an entity at the source-level which groups together
 // related columns.  Modules can be either concrete (in which case they

--- a/pkg/ir/air/constraint.go
+++ b/pkg/ir/air/constraint.go
@@ -36,7 +36,7 @@ import (
 // should never change, unless the underlying prover changes in some way to
 // offer different or more fundamental primitives.
 type ConstraintBound interface {
-	schema.Constraint
+	schema.Constraint[bls12_377.Element]
 
 	constraint.Assertion[bls12_377.Element, ir.Testable[bls12_377.Element]] |
 		interleaving.Constraint[bls12_377.Element, *ColumnAccess] |
@@ -105,7 +105,8 @@ func (p Air[C]) Air() {
 // Accepts determines whether a given constraint accepts a given trace or
 // not.  If not, a failure is produced.  Otherwise, a bitset indicating
 // branch coverage is returned.
-func (p Air[C]) Accepts(trace trace.Trace[bls12_377.Element], schema schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Air[C]) Accepts(trace trace.Trace[bls12_377.Element], schema schema.AnySchema[bls12_377.Element],
+) (bit.Set, schema.Failure) {
 	return p.constraint.Accepts(trace, schema)
 }
 
@@ -121,7 +122,7 @@ func (p Air[C]) Bounds(module uint) util.Bounds {
 // Consistent applies a number of internal consistency checks.  Whilst not
 // strictly necessary, these can highlight otherwise hidden problems as an aid
 // to debugging.
-func (p Air[C]) Consistent(schema schema.AnySchema) []error {
+func (p Air[C]) Consistent(schema schema.AnySchema[bls12_377.Element]) []error {
 	return p.constraint.Consistent(schema)
 }
 
@@ -144,7 +145,7 @@ func (p Air[C]) Name() string {
 // so it can be printed.
 //
 //nolint:revive
-func (p Air[C]) Lisp(schema schema.AnySchema) sexp.SExp {
+func (p Air[C]) Lisp(schema schema.AnySchema[bls12_377.Element]) sexp.SExp {
 	return p.constraint.Lisp(schema)
 }
 

--- a/pkg/ir/air/constraint.go
+++ b/pkg/ir/air/constraint.go
@@ -38,12 +38,12 @@ import (
 type ConstraintBound interface {
 	schema.Constraint
 
-	constraint.Assertion[ir.Testable[bls12_377.Element]] |
-		interleaving.Constraint[*ColumnAccess] |
-		lookup.Constraint[*ColumnAccess] |
-		permutation.Constraint |
-		ranged.Constraint[*ColumnAccess] |
-		vanishing.Constraint[LogicalTerm]
+	constraint.Assertion[bls12_377.Element, ir.Testable[bls12_377.Element]] |
+		interleaving.Constraint[bls12_377.Element, *ColumnAccess] |
+		lookup.Constraint[bls12_377.Element, *ColumnAccess] |
+		permutation.Constraint[bls12_377.Element] |
+		ranged.Constraint[bls12_377.Element, *ColumnAccess] |
+		vanishing.Constraint[bls12_377.Element, LogicalTerm]
 }
 
 // Air attempts to encapsulate the notion of a valid constraint at the AIR
@@ -82,12 +82,12 @@ func NewLookupConstraint(handle string, targets []lookup.Vector[bls12_377.Elemen
 // NewPermutationConstraint creates a new permutation
 func NewPermutationConstraint(handle string, context schema.ModuleId, targets []schema.RegisterId,
 	sources []schema.RegisterId) Constraint {
-	return newAir(permutation.NewPermutationConstraint(handle, context, targets, sources))
+	return newAir(permutation.NewConstraint[bls12_377.Element](handle, context, targets, sources))
 }
 
 // NewRangeConstraint constructs a new AIR range constraint
 func NewRangeConstraint(handle string, ctx schema.ModuleId, expr ColumnAccess, bitwidth uint) RangeConstraint {
-	return newAir(ranged.NewRangeConstraint(handle, ctx, &expr, bitwidth))
+	return newAir(ranged.NewConstraint(handle, ctx, &expr, bitwidth))
 }
 
 // NewVanishingConstraint constructs a new AIR vanishing constraint

--- a/pkg/ir/air/gadgets/bitwidth.go
+++ b/pkg/ir/air/gadgets/bitwidth.go
@@ -256,7 +256,7 @@ func (p *typeDecomposition) AddSource(source sc.RegisterRef) {
 
 // Compute computes the values of columns defined by this assignment.
 // This requires computing the value of each byte column in the decomposition.
-func (p *typeDecomposition) Compute(tr trace.Trace[bls12_377.Element], schema sc.AnySchema,
+func (p *typeDecomposition) Compute(tr trace.Trace[bls12_377.Element], schema sc.AnySchema[bls12_377.Element],
 ) ([]array.MutArray[bls12_377.Element], error) {
 	// Read inputs
 	sources := assignment.ReadRegisters(tr, p.sources...)
@@ -280,7 +280,7 @@ func (p *typeDecomposition) Bounds(_ sc.ModuleId) util.Bounds {
 // Consistent performs some simple checks that the given schema is consistent.
 // This provides a double check of certain key properties, such as that
 // registers used for assignments are large enough, etc.
-func (p *typeDecomposition) Consistent(schema sc.AnySchema) []error {
+func (p *typeDecomposition) Consistent(schema sc.AnySchema[bls12_377.Element]) []error {
 	return nil
 }
 
@@ -302,7 +302,7 @@ func (p *typeDecomposition) RegistersWritten() []sc.RegisterRef {
 
 // Lisp converts this schema element into a simple S-Expression, for example
 // so it can be printed.
-func (p *typeDecomposition) Lisp(schema sc.AnySchema) sexp.SExp {
+func (p *typeDecomposition) Lisp(schema sc.AnySchema[bls12_377.Element]) sexp.SExp {
 	var (
 		targets = sexp.EmptyList()
 		sources = sexp.EmptyList()
@@ -350,7 +350,7 @@ type byteDecomposition struct {
 
 // Compute computes the values of columns defined by this assignment.
 // This requires computing the value of each byte column in the decomposition.
-func (p *byteDecomposition) Compute(tr trace.Trace[bls12_377.Element], schema sc.AnySchema,
+func (p *byteDecomposition) Compute(tr trace.Trace[bls12_377.Element], schema sc.AnySchema[bls12_377.Element],
 ) ([]array.MutArray[bls12_377.Element], error) {
 	var n = uint(len(p.targets))
 	// Read inputs
@@ -373,7 +373,7 @@ func (p *byteDecomposition) Bounds(_ sc.ModuleId) util.Bounds {
 // Consistent performs some simple checks that the given schema is consistent.
 // This provides a double check of certain key properties, such as that
 // registers used for assignments are large enough, etc.
-func (p *byteDecomposition) Consistent(schema sc.AnySchema) []error {
+func (p *byteDecomposition) Consistent(schema sc.AnySchema[bls12_377.Element]) []error {
 	var (
 		bitwidth = schema.Register(p.source).Width
 		total    = uint(0)
@@ -411,7 +411,7 @@ func (p *byteDecomposition) RegistersWritten() []sc.RegisterRef {
 
 // Lisp converts this schema element into a simple S-Expression, for example
 // so it can be printed.
-func (p *byteDecomposition) Lisp(schema sc.AnySchema) sexp.SExp {
+func (p *byteDecomposition) Lisp(schema sc.AnySchema[bls12_377.Element]) sexp.SExp {
 	var (
 		srcModule = schema.Module(p.source.Module())
 		source    = srcModule.Register(p.source.Register())

--- a/pkg/ir/air/schema.go
+++ b/pkg/ir/air/schema.go
@@ -36,10 +36,10 @@ type (
 	Schema = schema.UniformSchema[Module]
 	// Module captures the essence of a module at the AIR level.  Specifically, it
 	// is limited to only those constraint forms permitted at the AIR level.
-	Module = *schema.Table[Constraint]
+	Module = *schema.Table[bls12_377.Element, Constraint]
 	// Constraint captures the essence of a constraint at the AIR level.
 	Constraint interface {
-		schema.Constraint
+		schema.Constraint[bls12_377.Element]
 		// Air marks the constraints as been valid for the AIR representation.
 		Air()
 	}

--- a/pkg/ir/air/schema.go
+++ b/pkg/ir/air/schema.go
@@ -68,22 +68,22 @@ type (
 	// Assertion captures the notion of an arbitrary property which should hold for
 	// all acceptable traces.  However, such a property is not enforced by the
 	// prover.
-	Assertion = Air[constraint.Assertion[ir.Testable[bls12_377.Element]]]
+	Assertion = Air[constraint.Assertion[bls12_377.Element, ir.Testable[bls12_377.Element]]]
 	// InterleavingConstraint captures the essence of an interleaving constraint
 	// at the MIR level.
-	InterleavingConstraint = Air[interleaving.Constraint[*ColumnAccess]]
+	InterleavingConstraint = Air[interleaving.Constraint[bls12_377.Element, *ColumnAccess]]
 	// LookupConstraint captures the essence of a lookup constraint at the AIR
 	// level.  At the AIR level, lookup constraints are only permitted between
 	// columns (i.e. not arbitrary expressions).
-	LookupConstraint = Air[lookup.Constraint[*ColumnAccess]]
+	LookupConstraint = Air[lookup.Constraint[bls12_377.Element, *ColumnAccess]]
 	// PermutationConstraint captures the essence of a permutation constraint at the
 	// AIR level. Specifically, it represents a constraint that one (or more)
 	// columns are a permutation of another.
-	PermutationConstraint = Air[permutation.Constraint]
+	PermutationConstraint = Air[permutation.Constraint[bls12_377.Element]]
 	// RangeConstraint captures the essence of a range constraints at the AIR level.
-	RangeConstraint = Air[ranged.Constraint[*ColumnAccess]]
+	RangeConstraint = Air[ranged.Constraint[bls12_377.Element, *ColumnAccess]]
 	// VanishingConstraint captures the essence of a vanishing constraint at the AIR level.
-	VanishingConstraint = Air[vanishing.Constraint[LogicalTerm]]
+	VanishingConstraint = Air[vanishing.Constraint[bls12_377.Element, LogicalTerm]]
 )
 
 // Following types capture permitted expression forms at the AIR level.

--- a/pkg/ir/assignment/computation.go
+++ b/pkg/ir/assignment/computation.go
@@ -63,7 +63,7 @@ func (p *Computation[F]) Bounds(_ sc.ModuleId) util.Bounds {
 // Compute computes the values of columns defined by this assignment. This
 // requires copying the data in the source columns, and sorting that data
 // according to the permutation criteria.
-func (p *Computation[F]) Compute(trace tr.Trace[F], schema sc.AnySchema,
+func (p *Computation[F]) Compute(trace tr.Trace[F], schema sc.AnySchema[F],
 ) ([]array.MutArray[F], error) {
 	// Identify Computation
 	fn := findNative[F](p.Function)
@@ -74,7 +74,7 @@ func (p *Computation[F]) Compute(trace tr.Trace[F], schema sc.AnySchema,
 // Consistent performs some simple checks that the given schema is consistent.
 // This provides a double check of certain key properties, such as that
 // registers used for assignments are large enough, etc.
-func (p *Computation[F]) Consistent(_ sc.AnySchema) []error {
+func (p *Computation[F]) Consistent(_ sc.AnySchema[F]) []error {
 	// NOTE: this is where we could (in principle) check the type of the
 	// function being defined to ensure it is, for example, typed correctly.
 	return nil
@@ -107,7 +107,7 @@ func (p *Computation[F]) Subdivide(mapping schema.LimbsMap) sc.Assignment[F] {
 
 // Lisp converts this schema element into a simple S-Expression, for example
 // so it can be printed.
-func (p *Computation[F]) Lisp(schema sc.AnySchema) sexp.SExp {
+func (p *Computation[F]) Lisp(schema sc.AnySchema[F]) sexp.SExp {
 	var (
 		targets = sexp.EmptyList()
 		sources = sexp.EmptyList()

--- a/pkg/ir/assignment/computed_register.go
+++ b/pkg/ir/assignment/computed_register.go
@@ -71,7 +71,7 @@ func (p *ComputedRegister[F]) Bounds(mid sc.ModuleId) util.Bounds {
 // Compute the values of columns defined by this assignment. Specifically, this
 // creates a new column which contains the result of evaluating a given
 // expression on each row.
-func (p *ComputedRegister[F]) Compute(tr trace.Trace[F], schema schema.AnySchema,
+func (p *ComputedRegister[F]) Compute(tr trace.Trace[F], schema schema.AnySchema[F],
 ) ([]array.MutArray[F], error) {
 	var (
 		trModule = tr.Module(p.Target.Module())
@@ -112,7 +112,7 @@ func (p *ComputedRegister[F]) Compute(tr trace.Trace[F], schema schema.AnySchema
 // consistent with its enclosing schema This provides a double check of certain
 // key properties, such as that registers used for assignments are valid,
 // etc.
-func (p *ComputedRegister[F]) Consistent(schema sc.AnySchema) []error {
+func (p *ComputedRegister[F]) Consistent(schema sc.AnySchema[F]) []error {
 	return nil
 }
 
@@ -172,7 +172,7 @@ func (p *ComputedRegister[F]) Subdivide(mapping schema.LimbsMap) sc.Assignment[F
 // Lisp converts this constraint into an S-Expression.
 //
 //nolint:revive
-func (p *ComputedRegister[F]) Lisp(schema sc.AnySchema) sexp.SExp {
+func (p *ComputedRegister[F]) Lisp(schema sc.AnySchema[F]) sexp.SExp {
 	var (
 		module          = schema.Module(p.Target.Module())
 		target          = module.Register(p.Target.Register())

--- a/pkg/ir/assignment/lexicographic_sort.go
+++ b/pkg/ir/assignment/lexicographic_sort.go
@@ -81,7 +81,7 @@ func (p *LexicographicSort[F]) Bounds(_ sc.ModuleId) util.Bounds {
 // Compute computes the values of columns defined as needed to support the
 // LexicographicSortingGadget. That includes the delta column, and the bit
 // selectors.
-func (p *LexicographicSort[F]) Compute(trace tr.Trace[F], schema sc.AnySchema,
+func (p *LexicographicSort[F]) Compute(trace tr.Trace[F], schema sc.AnySchema[F],
 ) ([]array.MutArray[F], error) {
 	var (
 		// Exact number of (signed) columns involved in the sort
@@ -105,7 +105,7 @@ func (p *LexicographicSort[F]) Compute(trace tr.Trace[F], schema sc.AnySchema,
 // Consistent performs some simple checks that the given schema is consistent.
 // This provides a double check of certain key properties, such as that
 // registers used for assignments are large enough, etc.
-func (p *LexicographicSort[F]) Consistent(schema sc.AnySchema) []error {
+func (p *LexicographicSort[F]) Consistent(schema sc.AnySchema[F]) []error {
 	var (
 		errors   []error
 		bitwidth = uint(0)
@@ -155,7 +155,7 @@ func (p *LexicographicSort[F]) RegistersWritten() []sc.RegisterRef {
 
 // Lisp converts this schema element into a simple S-Expression, for example
 // so it can be printed.
-func (p *LexicographicSort[F]) Lisp(schema sc.AnySchema) sexp.SExp {
+func (p *LexicographicSort[F]) Lisp(schema sc.AnySchema[F]) sexp.SExp {
 	var (
 		targets = sexp.EmptyList()
 		sources = sexp.EmptyList()

--- a/pkg/ir/assignment/sorted_permutation.go
+++ b/pkg/ir/assignment/sorted_permutation.go
@@ -69,7 +69,7 @@ func (p *SortedPermutation[F]) Bounds(_ sc.ModuleId) util.Bounds {
 // Compute computes the values of columns defined by this assignment. This
 // requires copying the data in the source columns, and sorting that data
 // according to the permutation criteria.
-func (p *SortedPermutation[F]) Compute(trace tr.Trace[F], schema sc.AnySchema) ([]array.MutArray[F], error) {
+func (p *SortedPermutation[F]) Compute(trace tr.Trace[F], schema sc.AnySchema[F]) ([]array.MutArray[F], error) {
 	// Read inputs
 	sources := ReadRegisters(trace, p.Sources...)
 	// Apply native function
@@ -81,7 +81,7 @@ func (p *SortedPermutation[F]) Compute(trace tr.Trace[F], schema sc.AnySchema) (
 // Consistent performs some simple checks that the given schema is consistent.
 // This provides a double check of certain key properties, such as that
 // registers used for assignments are large enough, etc.
-func (p *SortedPermutation[F]) Consistent(schema sc.AnySchema) []error {
+func (p *SortedPermutation[F]) Consistent(schema sc.AnySchema[F]) []error {
 	var errors []error
 	// // Sanity check source types
 	for i := range p.Sources {
@@ -125,7 +125,7 @@ func (p *SortedPermutation[F]) Subdivide(mapping schema.LimbsMap) sc.Assignment[
 
 // Lisp converts this schema element into a simple S-Expression, for example
 // so it can be printed.
-func (p *SortedPermutation[F]) Lisp(schema sc.AnySchema) sexp.SExp {
+func (p *SortedPermutation[F]) Lisp(schema sc.AnySchema[F]) sexp.SExp {
 	var (
 		targets = sexp.EmptyList()
 		sources = sexp.EmptyList()

--- a/pkg/ir/builder/validation.go
+++ b/pkg/ir/builder/validation.go
@@ -27,7 +27,7 @@ import (
 // TraceValidation validates that values held in trace columns match the
 // expected type.  This is really a sanity check that the trace is not
 // malformed.
-func TraceValidation[F field.Element[F]](parallel bool, schema sc.AnySchema, tr tr.Trace[F]) []error {
+func TraceValidation[F field.Element[F]](parallel bool, schema sc.AnySchema[F], tr tr.Trace[F]) []error {
 	var (
 		errors []error
 		// Start timer
@@ -50,7 +50,7 @@ func TraceValidation[F field.Element[F]](parallel bool, schema sc.AnySchema, tr 
 // SequentialTraceValidation validates that values held in trace columns match
 // the expected type.  This is really a sanity check that the trace is not
 // malformed.
-func SequentialTraceValidation[F field.Element[F]](schema sc.AnySchema, tr trace.Trace[F]) []error {
+func SequentialTraceValidation[F field.Element[F]](schema sc.AnySchema[F], tr trace.Trace[F]) []error {
 	var errors []error
 	//
 	for i := uint(0); i < max(schema.Width(), tr.Width()); i++ {
@@ -77,7 +77,7 @@ func SequentialTraceValidation[F field.Element[F]](schema sc.AnySchema, tr trace
 // ParallelTraceValidation validates that values held in trace columns match the
 // expected type.  This is really a sanity check that the trace is not
 // malformed.
-func ParallelTraceValidation[F field.Element[F]](schema sc.AnySchema, trace tr.Trace[F]) []error {
+func ParallelTraceValidation[F field.Element[F]](schema sc.AnySchema[F], trace tr.Trace[F]) []error {
 	var (
 		errors []error
 		// Construct a communication channel for errors.

--- a/pkg/ir/mir/constraint.go
+++ b/pkg/ir/mir/constraint.go
@@ -65,19 +65,19 @@ func NewLookupConstraint(handle string, targets []lookup.Vector[bls12_377.Elemen
 // NewPermutationConstraint creates a new permutation
 func NewPermutationConstraint(handle string, context schema.ModuleId, targets []schema.RegisterId,
 	sources []schema.RegisterId) Constraint {
-	return Constraint{permutation.NewPermutationConstraint(handle, context, targets, sources)}
+	return Constraint{permutation.NewConstraint[bls12_377.Element](handle, context, targets, sources)}
 }
 
 // NewRangeConstraint constructs a new Range constraint!
 func NewRangeConstraint(handle string, ctx schema.ModuleId, expr Term, bitwidth uint) Constraint {
-	return Constraint{ranged.NewRangeConstraint(handle, ctx, expr, bitwidth)}
+	return Constraint{ranged.NewConstraint(handle, ctx, expr, bitwidth)}
 }
 
 // NewSortedConstraint creates a new Sorted
 func NewSortedConstraint(handle string, context schema.ModuleId, bitwidth uint, selector util.Option[Term],
 	sources []Term, signs []bool, strict bool) Constraint {
 	//
-	return Constraint{sorted.NewSortedConstraint(handle, context, bitwidth, selector, sources, signs, strict)}
+	return Constraint{sorted.NewConstraint(handle, context, bitwidth, selector, sources, signs, strict)}
 }
 
 // Accepts determines whether a given constraint accepts a given trace or

--- a/pkg/ir/mir/constraint.go
+++ b/pkg/ir/mir/constraint.go
@@ -33,7 +33,7 @@ import (
 // are permitted.  As such, we want to try and ensure that arbitrary constraints
 // are not found at the Constraint level.
 type Constraint struct {
-	constraint schema.Constraint
+	constraint schema.Constraint[bls12_377.Element]
 }
 
 // NewAssertion constructs a new assertion
@@ -46,7 +46,7 @@ func NewAssertion(handle string, ctx schema.ModuleId, term LogicalTerm) Constrai
 func NewVanishingConstraint(handle string, ctx schema.ModuleId, domain util.Option[int],
 	term LogicalTerm) Constraint {
 	//
-	return Constraint{vanishing.NewConstraint(handle, ctx, domain, term)}
+	return Constraint{vanishing.NewConstraint[bls12_377.Element](handle, ctx, domain, term)}
 }
 
 // NewInterleavingConstraint creates a new interleaving constraint with a given handle.
@@ -83,7 +83,9 @@ func NewSortedConstraint(handle string, context schema.ModuleId, bitwidth uint, 
 // Accepts determines whether a given constraint accepts a given trace or
 // not.  If not, a failure is produced.  Otherwise, a bitset indicating
 // branch coverage is returned.
-func (p Constraint) Accepts(trace trace.Trace[bls12_377.Element], schema schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Constraint) Accepts(trace trace.Trace[bls12_377.Element],
+	schema schema.AnySchema[bls12_377.Element]) (bit.Set, schema.Failure) {
+	//
 	return p.constraint.Accepts(trace, schema)
 }
 
@@ -99,7 +101,7 @@ func (p Constraint) Bounds(module uint) util.Bounds {
 // Consistent applies a number of internal consistency checks.  Whilst not
 // strictly necessary, these can highlight otherwise hidden problems as an aid
 // to debugging.
-func (p Constraint) Consistent(schema schema.AnySchema) []error {
+func (p Constraint) Consistent(schema schema.AnySchema[bls12_377.Element]) []error {
 	return p.constraint.Consistent(schema)
 }
 
@@ -122,13 +124,13 @@ func (p Constraint) Name() string {
 // so it can be printed.
 //
 //nolint:revive
-func (p Constraint) Lisp(schema schema.AnySchema) sexp.SExp {
+func (p Constraint) Lisp(schema schema.AnySchema[bls12_377.Element]) sexp.SExp {
 	return p.constraint.Lisp(schema)
 }
 
 // Subdivide implementation for the FieldAgnosticModule interface.
 func (p Constraint) Subdivide(mapping schema.LimbsMap) Constraint {
-	var constraint schema.Constraint
+	var constraint schema.Constraint[bls12_377.Element]
 	//
 	switch c := p.constraint.(type) {
 	case Assertion:
@@ -159,7 +161,7 @@ func (p Constraint) Substitute(mapping map[string]bls12_377.Element) {
 }
 
 // Unwrap provides access to the underlying constraint.
-func (p Constraint) Unwrap() schema.Constraint {
+func (p Constraint) Unwrap() schema.Constraint[bls12_377.Element] {
 	return p.constraint
 }
 

--- a/pkg/ir/mir/encoding.go
+++ b/pkg/ir/mir/encoding.go
@@ -61,7 +61,7 @@ const (
 	vectorAccessTag     = byte(40)
 )
 
-func encode_constraint(constraint schema.Constraint) ([]byte, error) {
+func encode_constraint(constraint schema.Constraint[bls12_377.Element]) ([]byte, error) {
 	switch c := constraint.(type) {
 	case Assertion:
 		return encode_assertion(c)
@@ -316,7 +316,7 @@ func encode_range(c RangeConstraint) ([]byte, error) {
 	return buffer.Bytes(), err
 }
 
-func decode_constraint(bytes []byte) (schema.Constraint, error) {
+func decode_constraint(bytes []byte) (schema.Constraint[bls12_377.Element], error) {
 	switch bytes[0] {
 	case assertionTag:
 		return decode_assertion(bytes[1:])
@@ -339,7 +339,7 @@ func decode_constraint(bytes []byte) (schema.Constraint, error) {
 	}
 }
 
-func decode_assertion(data []byte) (schema.Constraint, error) {
+func decode_assertion(data []byte) (schema.Constraint[bls12_377.Element], error) {
 	var (
 		buffer     = bytes.NewBuffer(data)
 		gobDecoder = gob.NewDecoder(buffer)
@@ -360,7 +360,7 @@ func decode_assertion(data []byte) (schema.Constraint, error) {
 	return assertion, err
 }
 
-func decode_interleaving(data []byte) (schema.Constraint, error) {
+func decode_interleaving(data []byte) (schema.Constraint[bls12_377.Element], error) {
 	var (
 		buffer       = bytes.NewBuffer(data)
 		gobDecoder   = gob.NewDecoder(buffer)
@@ -391,7 +391,7 @@ func decode_interleaving(data []byte) (schema.Constraint, error) {
 	return interleaving, nil
 }
 
-func decode_lookup(data []byte) (schema.Constraint, error) {
+func decode_lookup(data []byte) (schema.Constraint[bls12_377.Element], error) {
 	var (
 		buffer     = bytes.NewBuffer(data)
 		gobDecoder = gob.NewDecoder(buffer)
@@ -446,7 +446,7 @@ func decode_lookup_vector(buf *bytes.Buffer) (lookup.Vector[bls12_377.Element, T
 	return vector, nil
 }
 
-func decode_permutation(data []byte) (schema.Constraint, error) {
+func decode_permutation(data []byte) (schema.Constraint[bls12_377.Element], error) {
 	var (
 		buffer      = bytes.NewBuffer(data)
 		gobDecoder  = gob.NewDecoder(buffer)
@@ -473,7 +473,7 @@ func decode_permutation(data []byte) (schema.Constraint, error) {
 	return permutation, nil
 }
 
-func decode_sorted(selector bool, data []byte) (schema.Constraint, error) {
+func decode_sorted(selector bool, data []byte) (schema.Constraint[bls12_377.Element], error) {
 	var (
 		buffer     = bytes.NewBuffer(data)
 		gobDecoder = gob.NewDecoder(buffer)
@@ -516,7 +516,7 @@ func decode_sorted(selector bool, data []byte) (schema.Constraint, error) {
 	return sorted, err
 }
 
-func decode_range(data []byte) (schema.Constraint, error) {
+func decode_range(data []byte) (schema.Constraint[bls12_377.Element], error) {
 	var (
 		buffer     = bytes.NewBuffer(data)
 		gobDecoder = gob.NewDecoder(buffer)
@@ -541,7 +541,7 @@ func decode_range(data []byte) (schema.Constraint, error) {
 	return constraint, err
 }
 
-func decode_vanishing(data []byte) (schema.Constraint, error) {
+func decode_vanishing(data []byte) (schema.Constraint[bls12_377.Element], error) {
 	var (
 		buffer     = bytes.NewBuffer(data)
 		gobDecoder = gob.NewDecoder(buffer)

--- a/pkg/ir/mir/schema.go
+++ b/pkg/ir/mir/schema.go
@@ -52,25 +52,25 @@ type (
 	// Assertion captures the notion of an arbitrary property which should hold for
 	// all acceptable traces.  However, such a property is not enforced by the
 	// prover.
-	Assertion = constraint.Assertion[LogicalTerm]
+	Assertion = constraint.Assertion[bls12_377.Element, LogicalTerm]
 	// InterleavingConstraint captures the essence of an interleaving constraint
 	// at the MIR level.
-	InterleavingConstraint = interleaving.Constraint[Term]
+	InterleavingConstraint = interleaving.Constraint[bls12_377.Element, Term]
 	// LookupConstraint captures the essence of a lookup constraint at the MIR
 	// level.
-	LookupConstraint = lookup.Constraint[Term]
+	LookupConstraint = lookup.Constraint[bls12_377.Element, Term]
 	// PermutationConstraint captures the essence of a permutation constraint at the
 	// MIR level.
-	PermutationConstraint = permutation.Constraint
+	PermutationConstraint = permutation.Constraint[bls12_377.Element]
 	// RangeConstraint captures the essence of a range constraints at the MIR level.
-	RangeConstraint = ranged.Constraint[Term]
+	RangeConstraint = ranged.Constraint[bls12_377.Element, Term]
 	// SortedConstraint captures the essence of a sorted constraint at the MIR
 	// level.
-	SortedConstraint = sorted.Constraint[Term]
+	SortedConstraint = sorted.Constraint[bls12_377.Element, Term]
 	// VanishingConstraint captures the essence of a vanishing constraint at the MIR
 	// level. A vanishing constraint is a row constraint which must evaluate to
 	// zero.
-	VanishingConstraint = vanishing.Constraint[LogicalTerm]
+	VanishingConstraint = vanishing.Constraint[bls12_377.Element, LogicalTerm]
 )
 
 // Following types capture permitted expression forms at the MIR level.

--- a/pkg/ir/mir/schema.go
+++ b/pkg/ir/mir/schema.go
@@ -31,7 +31,7 @@ import (
 type (
 	// Module captures the essence of a module at the MIR level.  Specifically, it
 	// is limited to only those constraint forms permitted at the MIR level.
-	Module = *schema.Table[Constraint]
+	Module = *schema.Table[bls12_377.Element, Constraint]
 	// Schema captures the notion of an MIR schema which is uniform and consists of
 	// MIR modules only.
 	Schema = schema.UniformSchema[Module]
@@ -135,11 +135,11 @@ func SubstituteConstants[M schema.Module](schema schema.MixedSchema[M, Module], 
 }
 
 func init() {
-	gob.Register(schema.Constraint(&VanishingConstraint{}))
-	gob.Register(schema.Constraint(&RangeConstraint{}))
-	gob.Register(schema.Constraint(&PermutationConstraint{}))
-	gob.Register(schema.Constraint(&LookupConstraint{}))
-	gob.Register(schema.Constraint(&SortedConstraint{}))
+	gob.Register(schema.Constraint[bls12_377.Element](&VanishingConstraint{}))
+	gob.Register(schema.Constraint[bls12_377.Element](&RangeConstraint{}))
+	gob.Register(schema.Constraint[bls12_377.Element](&PermutationConstraint{}))
+	gob.Register(schema.Constraint[bls12_377.Element](&LookupConstraint{}))
+	gob.Register(schema.Constraint[bls12_377.Element](&SortedConstraint{}))
 	//
 	gob.Register(Term(&Add{}))
 	gob.Register(Term(&Mul{}))

--- a/pkg/schema/agnostic/mapping.go
+++ b/pkg/schema/agnostic/mapping.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	sc "github.com/consensys/go-corset/pkg/schema"
+	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 )
 
 // Subdivide a mixed schema of field agnostic modules according to the given
@@ -56,7 +57,7 @@ type limbsMap struct {
 // newRegisterMappings constructs a new schema mapping for a given schema and
 // parameter combination.  This determines, amongst other things,  the
 // composition of limbs for all registers in the schema.
-func newRegisterMappings(field sc.FieldConfig, schema sc.AnySchema) sc.LimbsMap {
+func newRegisterMappings(field sc.FieldConfig, schema sc.AnySchema[bls12_377.Element]) sc.LimbsMap {
 	var mappings []registerLimbsMap
 	//
 	for i := range schema.Width() {

--- a/pkg/schema/assignment.go
+++ b/pkg/schema/assignment.go
@@ -38,11 +38,11 @@ type Assignment[F any] interface {
 	// assignment depends must exist (e.g. are either inputs or have been
 	// computed already).  Computed columns do not exist in the original trace,
 	// but are added during trace expansion to form the final trace.
-	Compute(tr.Trace[F], Schema[Constraint]) ([]array.MutArray[F], error)
+	Compute(tr.Trace[F], AnySchema[F]) ([]array.MutArray[F], error)
 	// Consistent applies a number of internal consistency checks.  Whilst not
 	// strictly necessary, these can highlight otherwise hidden problems as an aid
 	// to debugging.
-	Consistent(Schema[Constraint]) []error
+	Consistent(AnySchema[F]) []error
 	// Identifier registers which are expanded by this assignment.  A register
 	// is expanded when its length maybe changed.  For example, when going from
 	// a trace which contains only rows of input/output values to a trace where
@@ -56,5 +56,5 @@ type Assignment[F any] interface {
 	RegistersWritten() []RegisterRef
 	// Lisp converts this schema element into a simple S-Expression, for example
 	// so it can be printed.
-	Lisp(AnySchema) sexp.SExp
+	Lisp(AnySchema[F]) sexp.SExp
 }

--- a/pkg/schema/constraint.go
+++ b/pkg/schema/constraint.go
@@ -16,17 +16,16 @@ import (
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/bit"
-	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
 // Constraint represents an element which can "accept" a trace, or either reject
 // with an error (or eventually perhaps report a warning).
-type Constraint interface {
+type Constraint[F any] interface {
 	// Accepts determines whether a given constraint accepts a given trace or
 	// not.  If not, a failure is produced.  Otherwise, a bitset indicating
 	// branch coverage is returned.
-	Accepts(trace.Trace[bls12_377.Element], AnySchema) (bit.Set, Failure)
+	Accepts(trace.Trace[F], AnySchema[F]) (bit.Set, Failure)
 	// Determine the well-definedness bounds for this constraint in both the
 	// negative (left) or positive (right) directions.  For example, consider an
 	// expression such as "(shift X -1)".  This is technically undefined for the
@@ -36,7 +35,7 @@ type Constraint interface {
 	// Consistent applies a number of internal consistency checks.  Whilst not
 	// strictly necessary, these can highlight otherwise hidden problems as an aid
 	// to debugging.
-	Consistent(Schema[Constraint]) []error
+	Consistent(AnySchema[F]) []error
 	// Contexts returns the evaluation contexts (i.e. enclosing module + length
 	// multiplier) for this constraint.  Most constraints have only a single
 	// evaluation context, though some (e.g. lookups) have more.  Note that all
@@ -48,7 +47,7 @@ type Constraint interface {
 	Name() string
 	// Lisp converts this schema element into a simple S-Expression, for example
 	// so it can be printed.
-	Lisp(AnySchema) sexp.SExp
+	Lisp(AnySchema[F]) sexp.SExp
 	// Substitute any matchined labelled constants within this constraint
-	Substitute(map[string]bls12_377.Element)
+	Substitute(map[string]F)
 }

--- a/pkg/schema/constraint/assertion.go
+++ b/pkg/schema/constraint/assertion.go
@@ -84,7 +84,7 @@ func NewAssertion[F field.Element[F], T ir.Testable[F]](handle string, ctx schem
 // Consistent applies a number of internal consistency checks.  Whilst not
 // strictly necessary, these can highlight otherwise hidden problems as an aid
 // to debugging.
-func (p Assertion[F, T]) Consistent(schema schema.AnySchema) []error {
+func (p Assertion[F, T]) Consistent(schema schema.AnySchema[F]) []error {
 	return CheckConsistent(p.Context, schema, p.Property)
 }
 
@@ -113,7 +113,7 @@ func (p Assertion[F, T]) Bounds(module uint) util.Bounds {
 // of a table. If so, return nil otherwise return an error.
 //
 //nolint:revive
-func (p Assertion[F, T]) Accepts(tr trace.Trace[F], sc schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Assertion[F, T]) Accepts(tr trace.Trace[F], sc schema.AnySchema[F]) (bit.Set, schema.Failure) {
 	var (
 		coverage bit.Set
 		trModule = tr.Module(p.Context)
@@ -146,7 +146,7 @@ func (p Assertion[F, T]) Accepts(tr trace.Trace[F], sc schema.AnySchema) (bit.Se
 // Lisp converts this constraint into an S-Expression.
 //
 //nolint:revive
-func (p Assertion[F, T]) Lisp(schema schema.AnySchema) sexp.SExp {
+func (p Assertion[F, T]) Lisp(schema schema.AnySchema[F]) sexp.SExp {
 	var module = schema.Module(p.Context)
 	// Construct the list
 	return sexp.NewList([]sexp.SExp{

--- a/pkg/schema/constraint/failure.go
+++ b/pkg/schema/constraint/failure.go
@@ -17,12 +17,11 @@ import (
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/collection/set"
-	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 )
 
 // InternalFailure is a generic mechanism for reporting failures, particularly
 // as arising from evaluation of a given expression.
-type InternalFailure struct {
+type InternalFailure[F any] struct {
 	// Handle of the failing constraint
 	Handle string
 	// Module in which constraint failed.
@@ -36,12 +35,12 @@ type InternalFailure struct {
 }
 
 // Message provides a suitable error message
-func (p *InternalFailure) Message() string {
+func (p *InternalFailure[F]) Message() string {
 	return p.Error
 }
 
 // RequiredCells identifies the cells required to evaluate the failing constraint at the failing row.
-func (p *InternalFailure) RequiredCells(tr trace.Trace[bls12_377.Element]) *set.AnySortedSet[trace.CellRef] {
+func (p *InternalFailure[F]) RequiredCells(tr trace.Trace[F]) *set.AnySortedSet[trace.CellRef] {
 	if p.Term != nil {
 		return p.Term.RequiredCells(int(p.Row), p.Context)
 	}

--- a/pkg/schema/constraint/interleaving/constraint.go
+++ b/pkg/schema/constraint/interleaving/constraint.go
@@ -50,7 +50,7 @@ func NewConstraint[F field.Element[F], E ir.Evaluable[F]](handle string, targetC
 // Consistent applies a number of internal consistency checks.  Whilst not
 // strictly necessary, these can highlight otherwise hidden problems as an aid
 // to debugging.
-func (p Constraint[F, E]) Consistent(schema schema.AnySchema) []error {
+func (p Constraint[F, E]) Consistent(schema schema.AnySchema[F]) []error {
 	// TODO: check column access, and widths, etc.
 	return nil
 }
@@ -81,7 +81,7 @@ func (p Constraint[F, E]) Bounds(module uint) util.Bounds {
 
 // Accepts checks whether a Interleave holds between the source and
 // target columns.
-func (p Constraint[F, E]) Accepts(tr trace.Trace[F], sc schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Constraint[F, E]) Accepts(tr trace.Trace[F], sc schema.AnySchema[F]) (bit.Set, schema.Failure) {
 	var (
 		coverage bit.Set
 		srcTrMod = tr.Module(p.SourceContext)
@@ -134,7 +134,7 @@ func (p Constraint[F, E]) Accepts(tr trace.Trace[F], sc schema.AnySchema) (bit.S
 
 // Lisp converts this schema element into a simple S-Expression, for example
 // so it can be printed.
-func (p Constraint[F, E]) Lisp(schema schema.AnySchema) sexp.SExp {
+func (p Constraint[F, E]) Lisp(schema schema.AnySchema[F]) sexp.SExp {
 	var (
 		sourceModule = schema.Module(p.SourceContext)
 		targetModule = schema.Module(p.TargetContext)

--- a/pkg/schema/constraint/interleaving/constraint.go
+++ b/pkg/schema/constraint/interleaving/constraint.go
@@ -21,14 +21,14 @@ import (
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/bit"
-	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
+	"github.com/consensys/go-corset/pkg/util/field"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
 // Constraint declares a constraint that one expression represents the
 // interleaving of one or more expressions.  For example, suppose X=[1,2] and
 // Y=[3,4].  Then Z=[1,3,2,4] is the interleaving of X and Y.
-type Constraint[E ir.Evaluable[bls12_377.Element]] struct {
+type Constraint[F field.Element[F], E ir.Evaluable[F]] struct {
 	Handle string
 	// Context in which all target columns are evaluated.
 	TargetContext schema.ModuleId
@@ -41,23 +41,23 @@ type Constraint[E ir.Evaluable[bls12_377.Element]] struct {
 }
 
 // NewConstraint creates a new Interleave
-func NewConstraint[E ir.Evaluable[bls12_377.Element]](handle string, targetContext schema.ModuleId,
-	sourceContext schema.ModuleId, target E, sources []E) Constraint[E] {
+func NewConstraint[F field.Element[F], E ir.Evaluable[F]](handle string, targetContext schema.ModuleId,
+	sourceContext schema.ModuleId, target E, sources []E) Constraint[F, E] {
 	//
-	return Constraint[E]{handle, targetContext, sourceContext, target, sources}
+	return Constraint[F, E]{handle, targetContext, sourceContext, target, sources}
 }
 
 // Consistent applies a number of internal consistency checks.  Whilst not
 // strictly necessary, these can highlight otherwise hidden problems as an aid
 // to debugging.
-func (p Constraint[E]) Consistent(schema schema.AnySchema) []error {
+func (p Constraint[F, E]) Consistent(schema schema.AnySchema) []error {
 	// TODO: check column access, and widths, etc.
 	return nil
 }
 
 // Name returns a unique name for a given constraint.  This is useful
 // purely for identifying constraints in reports, etc.
-func (p Constraint[E]) Name() string {
+func (p Constraint[F, E]) Name() string {
 	return p.Handle
 }
 
@@ -66,7 +66,7 @@ func (p Constraint[E]) Name() string {
 // evaluation context, though some (e.g. lookups) have more.  Note that all
 // constraints have at least one context (which we can call the "primary"
 // context).
-func (p Constraint[E]) Contexts() []schema.ModuleId {
+func (p Constraint[F, E]) Contexts() []schema.ModuleId {
 	return []schema.ModuleId{p.TargetContext, p.SourceContext}
 }
 
@@ -75,13 +75,13 @@ func (p Constraint[E]) Contexts() []schema.ModuleId {
 // expression such as "(shift X -1)".  This is technically undefined for the
 // first row of any trace and, by association, any constraint evaluating this
 // expression on that first row is also undefined (and hence must pass).
-func (p Constraint[E]) Bounds(module uint) util.Bounds {
+func (p Constraint[F, E]) Bounds(module uint) util.Bounds {
 	return util.EMPTY_BOUND
 }
 
 // Accepts checks whether a Interleave holds between the source and
 // target columns.
-func (p Constraint[E]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Constraint[F, E]) Accepts(tr trace.Trace[F], sc schema.AnySchema) (bit.Set, schema.Failure) {
 	var (
 		coverage bit.Set
 		srcTrMod = tr.Module(p.SourceContext)
@@ -101,7 +101,7 @@ func (p Constraint[E]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnyS
 		s, s_err := p.Sources[row%n].EvalAt(row/n, srcTrMod, srcScMod)
 		// Checks
 		if t_err != nil {
-			return coverage, &constraint.InternalFailure{
+			return coverage, &constraint.InternalFailure[F]{
 				Handle:  p.Handle,
 				Context: p.TargetContext,
 				Row:     uint(row),
@@ -109,7 +109,7 @@ func (p Constraint[E]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnyS
 				Error:   t_err.Error(),
 			}
 		} else if s_err != nil {
-			return coverage, &constraint.InternalFailure{
+			return coverage, &constraint.InternalFailure[F]{
 				Handle:  p.Handle,
 				Context: p.SourceContext,
 				Row:     uint(row / n),
@@ -118,7 +118,7 @@ func (p Constraint[E]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnyS
 			}
 		} else if t.Cmp(s) != 0 {
 			// Evaluation failure
-			return coverage, &Failure{
+			return coverage, &Failure[F]{
 				p.Handle,
 				p.TargetContext,
 				p.Target,
@@ -134,7 +134,7 @@ func (p Constraint[E]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnyS
 
 // Lisp converts this schema element into a simple S-Expression, for example
 // so it can be printed.
-func (p Constraint[E]) Lisp(schema schema.AnySchema) sexp.SExp {
+func (p Constraint[F, E]) Lisp(schema schema.AnySchema) sexp.SExp {
 	var (
 		sourceModule = schema.Module(p.SourceContext)
 		targetModule = schema.Module(p.TargetContext)
@@ -164,7 +164,7 @@ func (p Constraint[E]) Lisp(schema schema.AnySchema) sexp.SExp {
 }
 
 // Substitute any matchined labelled constants within this constraint
-func (p Constraint[E]) Substitute(mapping map[string]bls12_377.Element) {
+func (p Constraint[F, E]) Substitute(mapping map[string]F) {
 	for _, s := range p.Sources {
 		s.Substitute(mapping)
 	}

--- a/pkg/schema/constraint/interleaving/failure.go
+++ b/pkg/schema/constraint/interleaving/failure.go
@@ -19,36 +19,35 @@ import (
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/collection/set"
-	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 )
 
 // Failure provides structural information about a failing lookup constraint.
-type Failure struct {
+type Failure[F any] struct {
 	// Handle of the failing constraint
 	Handle string
 	// Relevant context for target expressions.
 	TargetContext schema.ModuleId
 	// Target expression involved
-	Target ir.Evaluable[bls12_377.Element]
+	Target ir.Evaluable[F]
 	// Relevant context for source expressions.
 	SourceContext schema.ModuleId
 	// Source expression which were missing
-	Source ir.Evaluable[bls12_377.Element]
+	Source ir.Evaluable[F]
 	// Target row on which constraint
 	Row uint
 }
 
 // Message provides a suitable error message
-func (p *Failure) Message() string {
+func (p *Failure[F]) Message() string {
 	return fmt.Sprintf("interleaving \"%s\" failed (row %d)", p.Handle, p.Row)
 }
 
-func (p *Failure) String() string {
+func (p *Failure[F]) String() string {
 	return p.Message()
 }
 
 // RequiredCells identifies the cells required to evaluate the failing constraint at the failing row.
-func (p *Failure) RequiredCells(tr trace.Trace[bls12_377.Element]) *set.AnySortedSet[trace.CellRef] {
+func (p *Failure[F]) RequiredCells(tr trace.Trace[F]) *set.AnySortedSet[trace.CellRef] {
 	var res = set.NewAnySortedSet[trace.CellRef]()
 	//
 	res.InsertSorted(p.Source.RequiredCells(int(p.Row), p.SourceContext))

--- a/pkg/schema/constraint/lookup/constraint.go
+++ b/pkg/schema/constraint/lookup/constraint.go
@@ -84,7 +84,7 @@ func NewConstraint[F field.Element[F], E ir.Evaluable[F]](handle string, targets
 // Consistent applies a number of internal consistency checks.  Whilst not
 // strictly necessary, these can highlight otherwise hidden problems as an aid
 // to debugging.
-func (p Constraint[F, E]) Consistent(_ schema.AnySchema) []error {
+func (p Constraint[F, E]) Consistent(_ schema.AnySchema[F]) []error {
 	return nil
 }
 
@@ -140,7 +140,7 @@ func (p Constraint[F, E]) Bounds(module uint) util.Bounds {
 // all rows of the source columns.
 //
 //nolint:revive
-func (p Constraint[F, E]) Accepts(tr trace.Trace[F], sc schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Constraint[F, E]) Accepts(tr trace.Trace[F], sc schema.AnySchema[F]) (bit.Set, schema.Failure) {
 	var (
 		coverage bit.Set
 		st       State[F, E]
@@ -162,7 +162,7 @@ func (p Constraint[F, E]) Accepts(tr trace.Trace[F], sc schema.AnySchema) (bit.S
 // so it can be printed.
 //
 //nolint:revive
-func (p Constraint[F, E]) Lisp(schema schema.AnySchema) sexp.SExp {
+func (p Constraint[F, E]) Lisp(schema schema.AnySchema[F]) sexp.SExp {
 	var (
 		sources = sexp.EmptyList()
 		targets = sexp.EmptyList()
@@ -196,7 +196,7 @@ func (p Constraint[F, E]) Substitute(mapping map[string]F) {
 	}
 }
 
-func (p *Constraint[F, E]) insertTargetVectors(tr trace.Trace[F], sc schema.AnySchema) (
+func (p *Constraint[F, E]) insertTargetVectors(tr trace.Trace[F], sc schema.AnySchema[F]) (
 	State[F, E], schema.Failure) {
 	//
 	var (
@@ -245,7 +245,7 @@ type State[F field.Element[F], E ir.Evaluable[F]] struct {
 	buffer []F
 }
 
-func (p *State[F, E]) checkSourceVectors(sources []Vector[F, E], tr trace.Trace[F], sc schema.AnySchema,
+func (p *State[F, E]) checkSourceVectors(sources []Vector[F, E], tr trace.Trace[F], sc schema.AnySchema[F],
 ) schema.Failure {
 	// Choose optimised loop
 	for _, source := range sources {

--- a/pkg/schema/constraint/lookup/failure.go
+++ b/pkg/schema/constraint/lookup/failure.go
@@ -19,32 +19,31 @@ import (
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/collection/set"
-	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 )
 
 // Failure provides structural information about a failing lookup constraint.
-type Failure struct {
+type Failure[F any] struct {
 	// Handle of the failing constraint
 	Handle string
 	// Relevant context for source expressions.
 	Context schema.ModuleId
 	// Source expressions which were missing
-	Sources []ir.Evaluable[bls12_377.Element]
+	Sources []ir.Evaluable[F]
 	// Row on which the constraint failed
 	Row uint
 }
 
 // Message provides a suitable error message
-func (p *Failure) Message() string {
+func (p *Failure[F]) Message() string {
 	return fmt.Sprintf("lookup \"%s\" failed (row %d)", p.Handle, p.Row)
 }
 
-func (p *Failure) String() string {
+func (p *Failure[F]) String() string {
 	return p.Message()
 }
 
 // RequiredCells identifies the cells required to evaluate the failing constraint at the failing row.
-func (p *Failure) RequiredCells(_ trace.Trace[bls12_377.Element]) *set.AnySortedSet[trace.CellRef] {
+func (p *Failure[F]) RequiredCells(_ trace.Trace[F]) *set.AnySortedSet[trace.CellRef] {
 	res := set.NewAnySortedSet[trace.CellRef]()
 	// Handle terms
 	for _, e := range p.Sources {

--- a/pkg/schema/constraint/lookup/geometry.go
+++ b/pkg/schema/constraint/lookup/geometry.go
@@ -19,7 +19,6 @@ import (
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/schema/agnostic"
 	"github.com/consensys/go-corset/pkg/util/field"
-	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 )
 
 // Geometry defines the "geometry" of a lookup.  That is the maximum
@@ -35,7 +34,7 @@ type Geometry struct {
 // NewGeometry returns the calculated "geometry" for this lookup.  That
 // is, for each source/target pair, the maximum bitwidth of any source or target
 // value.
-func NewGeometry[E ir.Evaluable[bls12_377.Element], T schema.RegisterMap](c Constraint[E],
+func NewGeometry[F field.Element[F], E ir.Evaluable[F], T schema.RegisterMap](c Constraint[F, E],
 	mapping schema.ModuleMap[T]) Geometry {
 	//
 	var geometry []uint = make([]uint, c.Sources[0].Len())

--- a/pkg/schema/constraint/lookup/vector.go
+++ b/pkg/schema/constraint/lookup/vector.go
@@ -103,7 +103,7 @@ func (p *Vector[F, E]) Len() uint {
 }
 
 // Lisp returns a textual representation of this vector.
-func (p *Vector[F, E]) Lisp(schema schema.AnySchema) sexp.SExp {
+func (p *Vector[F, E]) Lisp(schema schema.AnySchema[F]) sexp.SExp {
 	var (
 		module = schema.Module(p.Module)
 		terms  = sexp.EmptyList()

--- a/pkg/schema/constraint/permutation/constraint.go
+++ b/pkg/schema/constraint/permutation/constraint.go
@@ -54,7 +54,7 @@ func NewConstraint[F field.Element[F]](handle string, context schema.ModuleId, t
 // Consistent applies a number of internal consistency checks.  Whilst not
 // strictly necessary, these can highlight otherwise hidden problems as an aid
 // to debugging.
-func (p Constraint[F]) Consistent(schema schema.AnySchema) []error {
+func (p Constraint[F]) Consistent(schema schema.AnySchema[F]) []error {
 	// TODO: check column access, and widths, etc.
 	return nil
 }
@@ -85,7 +85,7 @@ func (p Constraint[F]) Bounds(module uint) util.Bounds {
 
 // Accepts checks whether a permutation holds between the source and
 // target columns.
-func (p Constraint[F]) Accepts(tr trace.Trace[F], _ schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Constraint[F]) Accepts(tr trace.Trace[F], _ schema.AnySchema[F]) (bit.Set, schema.Failure) {
 	var (
 		// Coverage currently always empty for permutation constraints.
 		coverage bit.Set
@@ -112,7 +112,7 @@ func (p Constraint[F]) Accepts(tr trace.Trace[F], _ schema.AnySchema) (bit.Set, 
 
 // Lisp converts this schema element into a simple S-Expression, for example
 // so it can be printed.
-func (p Constraint[F]) Lisp(schema schema.AnySchema) sexp.SExp {
+func (p Constraint[F]) Lisp(schema schema.AnySchema[F]) sexp.SExp {
 	var (
 		module  = schema.Module(p.Context)
 		targets = sexp.EmptyList()

--- a/pkg/schema/constraint/ranged/constraint.go
+++ b/pkg/schema/constraint/ranged/constraint.go
@@ -52,7 +52,7 @@ func NewConstraint[F field.Element[F], E ir.Evaluable[F]](handle string, context
 // Consistent applies a number of internal consistency checks.  Whilst not
 // strictly necessary, these can highlight otherwise hidden problems as an aid
 // to debugging.
-func (p Constraint[F, E]) Consistent(schema schema.AnySchema) []error {
+func (p Constraint[F, E]) Consistent(schema schema.AnySchema[F]) []error {
 	return constraint.CheckConsistent(p.Context, schema, p.Expr)
 }
 
@@ -90,7 +90,7 @@ func (p Constraint[F, E]) Bounds(module uint) util.Bounds {
 // nil otherwise return an error.
 //
 //nolint:revive
-func (p Constraint[F, E]) Accepts(tr trace.Trace[F], sc schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Constraint[F, E]) Accepts(tr trace.Trace[F], sc schema.AnySchema[F]) (bit.Set, schema.Failure) {
 	var (
 		coverage bit.Set
 		trModule = tr.Module(p.Context)
@@ -128,7 +128,7 @@ func (p Constraint[F, E]) Accepts(tr trace.Trace[F], sc schema.AnySchema) (bit.S
 // it can be printed.
 //
 //nolint:revive
-func (p Constraint[F, E]) Lisp(schema schema.AnySchema) sexp.SExp {
+func (p Constraint[F, E]) Lisp(schema schema.AnySchema[F]) sexp.SExp {
 	module := schema.Module(p.Context)
 	//
 	return sexp.NewList([]sexp.SExp{

--- a/pkg/schema/constraint/ranged/failure.go
+++ b/pkg/schema/constraint/ranged/failure.go
@@ -19,17 +19,16 @@ import (
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/collection/set"
-	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 )
 
 // Failure provides structural information about a failing type constraint.
-type Failure struct {
+type Failure[F any] struct {
 	// Handle of the failing constraint
 	Handle string
 	// Enclosing context
 	Context schema.ModuleId
 	// Constraint expression
-	Expr ir.Evaluable[bls12_377.Element]
+	Expr ir.Evaluable[F]
 	// Range restriction
 	Bitwidth uint
 	// Row on which the constraint failed
@@ -37,16 +36,16 @@ type Failure struct {
 }
 
 // Message provides a suitable error message
-func (p *Failure) Message() string {
+func (p *Failure[F]) Message() string {
 	// Construct useful error message
 	return fmt.Sprintf("range \"%s\" is u%d does not hold (row %d)", p.Handle, p.Bitwidth, p.Row)
 }
 
-func (p *Failure) String() string {
+func (p *Failure[F]) String() string {
 	return p.Message()
 }
 
 // RequiredCells identifies the cells required to evaluate the failing constraint at the failing row.
-func (p *Failure) RequiredCells(tr trace.Trace[bls12_377.Element]) *set.AnySortedSet[trace.CellRef] {
+func (p *Failure[F]) RequiredCells(tr trace.Trace[F]) *set.AnySortedSet[trace.CellRef] {
 	return p.Expr.RequiredCells(int(p.Row), p.Context)
 }

--- a/pkg/schema/constraint/sorted/constraint.go
+++ b/pkg/schema/constraint/sorted/constraint.go
@@ -22,13 +22,12 @@ import (
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/bit"
 	"github.com/consensys/go-corset/pkg/util/field"
-	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
 // Constraint declares a constraint that one (or more) columns are
 // lexicographically sorted.
-type Constraint[E ir.Evaluable[bls12_377.Element]] struct {
+type Constraint[F field.Element[F], E ir.Evaluable[F]] struct {
 	Handle string
 	// Evaluation Context for this constraint which must match that of the
 	// source expressions.
@@ -48,24 +47,24 @@ type Constraint[E ir.Evaluable[bls12_377.Element]] struct {
 	Strict bool
 }
 
-// NewSortedConstraint creates a new Sorted
-func NewSortedConstraint[E ir.Evaluable[bls12_377.Element]](handle string, context schema.ModuleId, bitwidth uint,
-	selector util.Option[E], sources []E, signs []bool, strict bool) Constraint[E] {
+// NewConstraint creates a new Sorted
+func NewConstraint[F field.Element[F], E ir.Evaluable[F]](handle string, context schema.ModuleId, bitwidth uint,
+	selector util.Option[E], sources []E, signs []bool, strict bool) Constraint[F, E] {
 	//
-	return Constraint[E]{handle, context, bitwidth, selector, sources, signs, strict}
+	return Constraint[F, E]{handle, context, bitwidth, selector, sources, signs, strict}
 }
 
 // Consistent applies a number of internal consistency checks.  Whilst not
 // strictly necessary, these can highlight otherwise hidden problems as an aid
 // to debugging.
-func (p Constraint[E]) Consistent(schema schema.AnySchema) []error {
+func (p Constraint[F, E]) Consistent(schema schema.AnySchema) []error {
 	// TODO: add more useful checks
 	return nil
 }
 
 // Name returns a unique name for a given constraint.  This is useful
 // purely for identifying constraints in reports, etc.
-func (p Constraint[E]) Name() string {
+func (p Constraint[F, E]) Name() string {
 	return p.Handle
 }
 
@@ -74,7 +73,7 @@ func (p Constraint[E]) Name() string {
 // evaluation context, though some (e.g. lookups) have more.  Note that all
 // constraints have at least one context (which we can call the "primary"
 // context).
-func (p Constraint[E]) Contexts() []schema.ModuleId {
+func (p Constraint[F, E]) Contexts() []schema.ModuleId {
 	return []schema.ModuleId{p.Context}
 }
 
@@ -83,7 +82,7 @@ func (p Constraint[E]) Contexts() []schema.ModuleId {
 // expression such as "(shift X -1)".  This is technically undefined for the
 // first row of any trace and, by association, any constraint evaluating this
 // expression on that first row is also undefined (and hence must pass).
-func (p Constraint[E]) Bounds(module uint) util.Bounds {
+func (p Constraint[F, E]) Bounds(module uint) util.Bounds {
 	var bound util.Bounds
 	//
 	if module == p.Context {
@@ -98,7 +97,7 @@ func (p Constraint[E]) Bounds(module uint) util.Bounds {
 
 // Accepts checks whether a Sorted holds between the source and
 // target columns.
-func (p Constraint[E]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Constraint[F, E]) Accepts(tr trace.Trace[F], sc schema.AnySchema) (bit.Set, schema.Failure) {
 	var (
 		coverage bit.Set
 		// Determine enclosing module
@@ -112,11 +111,11 @@ func (p Constraint[E]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnyS
 	// Sanity check enough rows
 	if bounds.End < height {
 		// Determine permitted range on delta value
-		deltaBound := field.TwoPowN[bls12_377.Element](p.BitWidth)
+		deltaBound := field.TwoPowN[F](p.BitWidth)
 		// Construct temporary buffers which are reused between evaluations to
 		// reduce memory pressure.
-		lhs := make([]bls12_377.Element, len(p.Sources))
-		rhs := make([]bls12_377.Element, len(p.Sources))
+		lhs := make([]F, len(p.Sources))
+		rhs := make([]F, len(p.Sources))
 		// Check all in-bounds values
 		for k := bounds.Start + 1; k < (height - bounds.End); k++ {
 			// Check selector
@@ -126,7 +125,7 @@ func (p Constraint[E]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnyS
 				val, err := selector.EvalAt(int(k), trModule, scModule)
 				// Check whether active (or not)
 				if err != nil {
-					return coverage, &constraint.InternalFailure{
+					return coverage, &constraint.InternalFailure[F]{
 						Handle:  p.Handle,
 						Context: p.Context,
 						Row:     k,
@@ -138,7 +137,7 @@ func (p Constraint[E]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnyS
 			}
 			// Check sorting between rows k-1 and k
 			if ok, err := sorted(k-1, k, deltaBound, p.Sources, p.Signs, p.Strict, trModule, scModule, lhs, rhs); err != nil {
-				return coverage, &constraint.InternalFailure{Handle: p.Handle, Context: p.Context, Row: k, Error: err.Error()}
+				return coverage, &constraint.InternalFailure[F]{Handle: p.Handle, Context: p.Context, Row: k, Error: err.Error()}
 			} else if !ok {
 				return coverage, &Failure{fmt.Sprintf("sorted constraint \"%s\" failed (rows %d ~ %d)", p.Handle, k-1, k)}
 			}
@@ -150,7 +149,7 @@ func (p Constraint[E]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnyS
 
 // Lisp converts this schema element into a simple S-Expression, for example
 // so it can be printed.
-func (p Constraint[E]) Lisp(schema schema.AnySchema) sexp.SExp {
+func (p Constraint[F, E]) Lisp(schema schema.AnySchema) sexp.SExp {
 	var (
 		module  = schema.Module(p.Context)
 		kind    = "sorted"
@@ -193,7 +192,7 @@ func (p Constraint[E]) Lisp(schema schema.AnySchema) sexp.SExp {
 }
 
 // Substitute any matchined labelled constants within this constraint
-func (p Constraint[E]) Substitute(mapping map[string]bls12_377.Element) {
+func (p Constraint[F, E]) Substitute(mapping map[string]F) {
 	for _, s := range p.Sources {
 		s.Substitute(mapping)
 	}

--- a/pkg/schema/constraint/sorted/constraint.go
+++ b/pkg/schema/constraint/sorted/constraint.go
@@ -57,7 +57,7 @@ func NewConstraint[F field.Element[F], E ir.Evaluable[F]](handle string, context
 // Consistent applies a number of internal consistency checks.  Whilst not
 // strictly necessary, these can highlight otherwise hidden problems as an aid
 // to debugging.
-func (p Constraint[F, E]) Consistent(schema schema.AnySchema) []error {
+func (p Constraint[F, E]) Consistent(schema schema.AnySchema[F]) []error {
 	// TODO: add more useful checks
 	return nil
 }
@@ -97,7 +97,7 @@ func (p Constraint[F, E]) Bounds(module uint) util.Bounds {
 
 // Accepts checks whether a Sorted holds between the source and
 // target columns.
-func (p Constraint[F, E]) Accepts(tr trace.Trace[F], sc schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Constraint[F, E]) Accepts(tr trace.Trace[F], sc schema.AnySchema[F]) (bit.Set, schema.Failure) {
 	var (
 		coverage bit.Set
 		// Determine enclosing module
@@ -149,7 +149,7 @@ func (p Constraint[F, E]) Accepts(tr trace.Trace[F], sc schema.AnySchema) (bit.S
 
 // Lisp converts this schema element into a simple S-Expression, for example
 // so it can be printed.
-func (p Constraint[F, E]) Lisp(schema schema.AnySchema) sexp.SExp {
+func (p Constraint[F, E]) Lisp(schema schema.AnySchema[F]) sexp.SExp {
 	var (
 		module  = schema.Module(p.Context)
 		kind    = "sorted"

--- a/pkg/schema/constraint/util.go
+++ b/pkg/schema/constraint/util.go
@@ -18,7 +18,6 @@ import (
 	"github.com/consensys/go-corset/pkg/ir"
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
-	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 )
 
 // CheckConsistent performs a simple consistency check for terms in a given
@@ -50,7 +49,7 @@ func CheckConsistent[E ir.Contextual](module uint, schema schema.AnySchema, term
 
 // DetermineHandle is a very simple helper which determines a suitable qualified
 // name for the given constraint handle.
-func DetermineHandle(handle string, ctx schema.ModuleId, tr trace.Trace[bls12_377.Element]) string {
+func DetermineHandle[F any](handle string, ctx schema.ModuleId, tr trace.Trace[F]) string {
 	modName := tr.Module(ctx).Name()
 	//
 	return trace.QualifiedColumnName(modName, handle)

--- a/pkg/schema/constraint/util.go
+++ b/pkg/schema/constraint/util.go
@@ -23,7 +23,7 @@ import (
 // CheckConsistent performs a simple consistency check for terms in a given
 // module.  Specifically, to check that: (1) the module exists; (2) all used
 // registers existing with then given module.
-func CheckConsistent[E ir.Contextual](module uint, schema schema.AnySchema, terms ...E) []error {
+func CheckConsistent[F any, E ir.Contextual](module uint, schema schema.AnySchema[F], terms ...E) []error {
 	var errs []error
 	// Sanity check module
 	if module >= schema.Width() {

--- a/pkg/schema/constraint/vanishing/constraint.go
+++ b/pkg/schema/constraint/vanishing/constraint.go
@@ -56,13 +56,13 @@ func NewConstraint[F field.Element[F], T ir.Testable[F]](handle string, context 
 // Consistent applies a number of internal consistency checks.  Whilst not
 // strictly necessary, these can highlight otherwise hidden problems as an aid
 // to debugging.
-func (p Constraint[T, F]) Consistent(schema schema.AnySchema) []error {
+func (p Constraint[F, T]) Consistent(schema schema.AnySchema[F]) []error {
 	return constraint.CheckConsistent(p.Context, schema, p.Constraint)
 }
 
 // Name returns a unique name for a given constraint.  This is useful
 // purely for identifying constraints in reports, etc.
-func (p Constraint[T, F]) Name() string {
+func (p Constraint[F, T]) Name() string {
 	return p.Handle
 }
 
@@ -71,7 +71,7 @@ func (p Constraint[T, F]) Name() string {
 // evaluation context, though some (e.g. lookups) have more.  Note that all
 // constraints have at least one context (which we can call the "primary"
 // context).
-func (p Constraint[T, F]) Contexts() []schema.ModuleId {
+func (p Constraint[F, T]) Contexts() []schema.ModuleId {
 	return []schema.ModuleId{p.Context}
 }
 
@@ -94,7 +94,7 @@ func (p Constraint[F, T]) Bounds(module uint) util.Bounds {
 // of a table.  If so, return nil otherwise return an error.
 //
 //nolint:revive
-func (p Constraint[F, T]) Accepts(tr trace.Trace[F], sc schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Constraint[F, T]) Accepts(tr trace.Trace[F], sc schema.AnySchema[F]) (bit.Set, schema.Failure) {
 	var (
 		// Handle is used for error reporting.
 		handle = constraint.DetermineHandle(p.Handle, p.Context, tr)
@@ -183,7 +183,7 @@ func HoldsLocally[F field.Element[F], T ir.Testable[F]](k uint, handle string, t
 // Lisp converts this constraint into an S-Expression.
 //
 //nolint:revive
-func (p Constraint[F, T]) Lisp(schema schema.AnySchema) sexp.SExp {
+func (p Constraint[F, T]) Lisp(schema schema.AnySchema[F]) sexp.SExp {
 	var (
 		module = schema.Module(p.Context)
 		name   string

--- a/pkg/schema/constraint/vanishing/constraint.go
+++ b/pkg/schema/constraint/vanishing/constraint.go
@@ -21,7 +21,7 @@ import (
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/bit"
-	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
+	"github.com/consensys/go-corset/pkg/util/field"
 	"github.com/consensys/go-corset/pkg/util/source/sexp"
 )
 
@@ -31,7 +31,7 @@ import (
 // ignored.  This is parameterised by the type of the constraint expression.
 // Thus, we can reuse this definition across the various intermediate
 // representations (e.g. Mid-Level IR, Arithmetic IR, etc).
-type Constraint[T ir.Testable[bls12_377.Element]] struct {
+type Constraint[F field.Element[F], T ir.Testable[F]] struct {
 	// A unique identifier for this constraint.  This is primarily
 	// useful for debugging.
 	Handle string
@@ -48,21 +48,21 @@ type Constraint[T ir.Testable[bls12_377.Element]] struct {
 }
 
 // NewConstraint constructs a new vanishing constraint!
-func NewConstraint[T ir.Testable[bls12_377.Element]](handle string, context schema.ModuleId,
-	domain util.Option[int], constraint T) Constraint[T] {
-	return Constraint[T]{handle, context, domain, constraint}
+func NewConstraint[F field.Element[F], T ir.Testable[F]](handle string, context schema.ModuleId,
+	domain util.Option[int], constraint T) Constraint[F, T] {
+	return Constraint[F, T]{handle, context, domain, constraint}
 }
 
 // Consistent applies a number of internal consistency checks.  Whilst not
 // strictly necessary, these can highlight otherwise hidden problems as an aid
 // to debugging.
-func (p Constraint[E]) Consistent(schema schema.AnySchema) []error {
+func (p Constraint[T, F]) Consistent(schema schema.AnySchema) []error {
 	return constraint.CheckConsistent(p.Context, schema, p.Constraint)
 }
 
 // Name returns a unique name for a given constraint.  This is useful
 // purely for identifying constraints in reports, etc.
-func (p Constraint[E]) Name() string {
+func (p Constraint[T, F]) Name() string {
 	return p.Handle
 }
 
@@ -71,7 +71,7 @@ func (p Constraint[E]) Name() string {
 // evaluation context, though some (e.g. lookups) have more.  Note that all
 // constraints have at least one context (which we can call the "primary"
 // context).
-func (p Constraint[E]) Contexts() []schema.ModuleId {
+func (p Constraint[T, F]) Contexts() []schema.ModuleId {
 	return []schema.ModuleId{p.Context}
 }
 
@@ -82,7 +82,7 @@ func (p Constraint[E]) Contexts() []schema.ModuleId {
 // expression on that first row is also undefined (and hence must pass).
 //
 //nolint:revive
-func (p Constraint[T]) Bounds(module uint) util.Bounds {
+func (p Constraint[F, T]) Bounds(module uint) util.Bounds {
 	if p.Context == module {
 		return p.Constraint.Bounds()
 	}
@@ -94,7 +94,7 @@ func (p Constraint[T]) Bounds(module uint) util.Bounds {
 // of a table.  If so, return nil otherwise return an error.
 //
 //nolint:revive
-func (p Constraint[T]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnySchema) (bit.Set, schema.Failure) {
+func (p Constraint[F, T]) Accepts(tr trace.Trace[F], sc schema.AnySchema) (bit.Set, schema.Failure) {
 	var (
 		// Handle is used for error reporting.
 		handle = constraint.DetermineHandle(p.Handle, p.Context, tr)
@@ -132,8 +132,8 @@ func (p Constraint[T]) Accepts(tr trace.Trace[bls12_377.Element], sc schema.AnyS
 
 // HoldsGlobally checks whether a given expression vanishes (i.e. evaluates to
 // zero) for all rows of a trace.  If not, report an appropriate error.
-func HoldsGlobally[T ir.Testable[bls12_377.Element]](handle string, ctx schema.ModuleId, constraint T,
-	trMod trace.Module[bls12_377.Element], scMod schema.Module) (bit.Set, schema.Failure) {
+func HoldsGlobally[F field.Element[F], T ir.Testable[F]](handle string, ctx schema.ModuleId, constraint T,
+	trMod trace.Module[F], scMod schema.Module) (bit.Set, schema.Failure) {
 	//
 	var (
 		coverage bit.Set
@@ -160,13 +160,13 @@ func HoldsGlobally[T ir.Testable[bls12_377.Element]](handle string, ctx schema.M
 
 // HoldsLocally checks whether a given constraint holds (e.g. vanishes) on a
 // specific row of a trace. If not, report an appropriate error.
-func HoldsLocally[T ir.Testable[bls12_377.Element]](k uint, handle string, term T, ctx schema.ModuleId,
-	trMod trace.Module[bls12_377.Element], scMod schema.Module) (schema.Failure, uint) {
+func HoldsLocally[F field.Element[F], T ir.Testable[F]](k uint, handle string, term T, ctx schema.ModuleId,
+	trMod trace.Module[F], scMod schema.Module) (schema.Failure, uint) {
 	//
 	ok, id, err := term.TestAt(int(k), trMod, scMod)
 	// Check for errors
 	if err != nil {
-		return &constraint.InternalFailure{
+		return &constraint.InternalFailure[F]{
 			Handle:  handle,
 			Context: ctx,
 			Row:     k,
@@ -174,7 +174,7 @@ func HoldsLocally[T ir.Testable[bls12_377.Element]](k uint, handle string, term 
 			Error:   err.Error()}, id
 	} else if !ok {
 		// Evaluation failure
-		return &Failure{handle, term, ctx, k}, id
+		return &Failure[F]{handle, term, ctx, k}, id
 	}
 	// Success
 	return nil, id
@@ -183,7 +183,7 @@ func HoldsLocally[T ir.Testable[bls12_377.Element]](k uint, handle string, term 
 // Lisp converts this constraint into an S-Expression.
 //
 //nolint:revive
-func (p Constraint[T]) Lisp(schema schema.AnySchema) sexp.SExp {
+func (p Constraint[F, T]) Lisp(schema schema.AnySchema) sexp.SExp {
 	var (
 		module = schema.Module(p.Context)
 		name   string
@@ -216,6 +216,6 @@ func (p Constraint[T]) Lisp(schema schema.AnySchema) sexp.SExp {
 }
 
 // Substitute any matchined labelled constants within this constraint
-func (p Constraint[T]) Substitute(mapping map[string]bls12_377.Element) {
+func (p Constraint[F, T]) Substitute(mapping map[string]F) {
 	p.Constraint.Substitute(mapping)
 }

--- a/pkg/schema/constraint/vanishing/failure.go
+++ b/pkg/schema/constraint/vanishing/failure.go
@@ -19,15 +19,14 @@ import (
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/collection/set"
-	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 )
 
 // Failure provides structural information about a failing vanishing constraint.
-type Failure struct {
+type Failure[F any] struct {
 	// Handle of the failing constraint
 	Handle string
 	// Constraint expression
-	Constraint ir.Testable[bls12_377.Element]
+	Constraint ir.Testable[F]
 	// Module where constraint failed
 	Context schema.ModuleId
 	// Row on which the constraint failed
@@ -35,16 +34,16 @@ type Failure struct {
 }
 
 // Message provides a suitable error message
-func (p *Failure) Message() string {
+func (p *Failure[F]) Message() string {
 	// Construct useful error message
 	return fmt.Sprintf("constraint \"%s\" does not hold (row %d)", p.Handle, p.Row)
 }
 
 // RequiredCells identifies the cells required to evaluate the failing constraint at the failing row.
-func (p *Failure) RequiredCells(tr trace.Trace[bls12_377.Element]) *set.AnySortedSet[trace.CellRef] {
+func (p *Failure[F]) RequiredCells(tr trace.Trace[F]) *set.AnySortedSet[trace.CellRef] {
 	return p.Constraint.RequiredCells(int(p.Row), p.Context)
 }
 
-func (p *Failure) String() string {
+func (p *Failure[F]) String() string {
 	return p.Message()
 }

--- a/pkg/schema/mixed_schema.go
+++ b/pkg/schema/mixed_schema.go
@@ -32,7 +32,7 @@ type MixedSchema[M1 Module, M2 Module] struct {
 	right []M2
 }
 
-var _ Schema[Constraint] = MixedSchema[Module, Module]{}
+var _ Schema[bls12_377.Element, Constraint[bls12_377.Element]] = MixedSchema[Module, Module]{}
 
 // NewMixedSchema constructs a new schema composed of two distinct sets of
 // modules, referred to as the "left" and the "right".  Those on the left are
@@ -71,7 +71,7 @@ func (p MixedSchema[M1, M2]) Consistent() []error {
 
 // Constraints returns an iterator over all constraints defined in this
 // schema.
-func (p MixedSchema[M1, M2]) Constraints() iter.Iterator[Constraint] {
+func (p MixedSchema[M1, M2]) Constraints() iter.Iterator[Constraint[bls12_377.Element]] {
 	leftIter := constraintsOf(p.left)
 	rightIter := constraintsOf(p.right)
 	//

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -13,25 +13,17 @@
 package schema
 
 import (
-	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/collection/iter"
-	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 )
 
 // Any converts a concrete schema into a generic view of the schema.
-func Any[C Constraint](schema Schema[C]) AnySchema {
-	return schema.(Schema[Constraint])
+func Any[F any, C Constraint[F]](schema Schema[F, C]) AnySchema[F] {
+	return schema.(Schema[F, Constraint[F]])
 }
 
 // AnySchema captures a generic view of a schema, which is useful in situations
 // where exactly details about the schema are not important.
-type AnySchema = Schema[Constraint]
-
-// ============================================================================
-
-// Expander functions are responsible for "filling" traces according to a given
-// schema.  More specifically, the determine values for all computed columns.
-type Expander[M any, C any] func(Schema[C], trace.Trace[bls12_377.Element]) trace.Trace[bls12_377.Element]
+type AnySchema[F any] Schema[F, Constraint[F]]
 
 // ============================================================================
 
@@ -42,11 +34,11 @@ type Expander[M any, C any] func(Schema[C], trace.Trace[bls12_377.Element]) trac
 // in the final trace, whilst constraints are properties which should hold for
 // any acceptable trace.  Finally, assignments represent arbitrary computations
 // which "assign" values to registers during "trace expansion".
-type Schema[C any] interface {
+type Schema[F any, C any] interface {
 	// Assignments returns an iterator over the assignments of this schema.
 	// That is, the set of computations used to determine values for all
 	// computed columns.
-	Assignments() iter.Iterator[Assignment[bls12_377.Element]]
+	Assignments() iter.Iterator[Assignment[F]]
 	// Consistent applies a number of internal consistency checks.  Whilst not
 	// strictly necessary, these can highlight otherwise hidden problems as an aid
 	// to debugging.

--- a/pkg/schema/uniform_schema.go
+++ b/pkg/schema/uniform_schema.go
@@ -28,7 +28,7 @@ type UniformSchema[M Module] struct {
 }
 
 // Sanity check
-var _ Schema[Constraint] = UniformSchema[Module]{}
+var _ Schema[bls12_377.Element, Constraint[bls12_377.Element]] = UniformSchema[Module]{}
 
 // NewUniformSchema constructs a new schema comprising the given modules.
 func NewUniformSchema[M Module](modules []M) UniformSchema[M] {
@@ -57,7 +57,7 @@ func (p UniformSchema[M]) Consistent() []error {
 
 // Constraints returns an iterator over all constraints defined in this
 // schema.
-func (p UniformSchema[M]) Constraints() iter.Iterator[Constraint] {
+func (p UniformSchema[M]) Constraints() iter.Iterator[Constraint[bls12_377.Element]] {
 	return constraintsOf(p.modules)
 }
 
@@ -112,10 +112,10 @@ func assignmentsOf[M Module](modules []M) iter.Iterator[Assignment[bls12_377.Ele
 
 // Extract an iterator over all the constraints in a given array using a
 // projecting iterator.
-func constraintsOf[M Module](modules []M) iter.Iterator[Constraint] {
+func constraintsOf[M Module](modules []M) iter.Iterator[Constraint[bls12_377.Element]] {
 	arrIter := iter.NewArrayIterator(modules)
 	//
-	return iter.NewFlattenIterator(arrIter, func(m M) iter.Iterator[Constraint] {
+	return iter.NewFlattenIterator(arrIter, func(m M) iter.Iterator[Constraint[bls12_377.Element]] {
 		return m.Constraints()
 	})
 }

--- a/pkg/test/util/framework.go
+++ b/pkg/test/util/framework.go
@@ -29,6 +29,7 @@ import (
 	"github.com/consensys/go-corset/pkg/trace/json"
 	"github.com/consensys/go-corset/pkg/trace/lt"
 	"github.com/consensys/go-corset/pkg/util"
+	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 )
 
 // TestDir determines the (relative) location of the test directory.  That is
@@ -192,7 +193,8 @@ func checkTraces(t *testing.T, test string, maxPadding uint, opt uint, cfg Confi
 	}
 }
 
-func checkTrace[C sc.Constraint](t *testing.T, tf lt.TraceFile, id traceId, schema sc.Schema[C], mapping sc.LimbsMap) {
+func checkTrace[C sc.Constraint[bls12_377.Element]](t *testing.T, tf lt.TraceFile, id traceId,
+	schema sc.Schema[bls12_377.Element, C], mapping sc.LimbsMap) {
 	// Construct the trace
 	tr, errs := ir.NewTraceBuilder().
 		WithExpansion(id.expand).

--- a/pkg/util/collection/hash/hash_key.go
+++ b/pkg/util/collection/hash/hash_key.go
@@ -1,0 +1,120 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package hash
+
+import (
+	"bytes"
+	"hash/fnv"
+)
+
+// A reasonably simple hashset implementation which permits collisions.  Observe
+// that, for example, hashicorp's go-set is *not* a suitable replacement here,
+// since that does not handle collisions.  Specifically, it assumes the hash
+// function always uniquely identifies the data in question.  I don't want to
+// make that assumption here.
+
+// Hasher provides a generic definition of a hashing function suitable for use
+// within the hashset.  This is similar to the Hasher interface provided in
+// go-set, except that it additionally includes equality.
+type Hasher[T any] interface {
+	// Check whether two items are equal (or not).
+	Equals(T) bool
+	// Return a suitable hashcode.
+	Hash() uint64
+}
+
+// ============================================================================
+// BytesKey Implementation
+// ============================================================================
+
+var _ Hasher[BytesKey] = BytesKey{}
+
+// BytesKey wraps a bytes array as something which can be safely placed into a
+// HashSet.
+type BytesKey struct {
+	bytes []byte
+}
+
+// NewBytesKey constructs a new bytes key.
+func NewBytesKey(bytes []byte) BytesKey {
+	return BytesKey{bytes}
+}
+
+// Equals compares two BytesKeys to check whether they represent the same
+// underlying byte array (or not).
+func (p BytesKey) Equals(other BytesKey) bool {
+	return bytes.Equal(p.bytes, other.bytes)
+}
+
+// Hash generat6es a 64-bit hashcode from the underlying bytes array.
+func (p BytesKey) Hash() uint64 {
+	hash := fnv.New64a()
+	hash.Write(p.bytes)
+	// Done
+	return hash.Sum64()
+}
+
+var _ Hasher[BytesKey] = BytesKey{}
+
+// ============================================================================
+// ArrayKey Implementation
+// ============================================================================
+
+const (
+	offset64 uint64 = 14695981039346656037
+	prime64  uint64 = 1099511628211
+)
+
+// Array provides a mechanism for hashing hashes (or other uint64 values).
+type Array[F Hasher[F]] struct {
+	elements []F
+}
+
+// NewArray constructs a new bytes key.
+func NewArray[F Hasher[F]](hashes []F) Array[F] {
+	return Array[F]{hashes}
+}
+
+// Equals compares two arrays to check whether they represent the same
+// underlying byte array (or not).
+func (p Array[F]) Equals(other Array[F]) bool {
+	var (
+		n = len(p.elements)
+		m = len(other.elements)
+	)
+	//
+	if n != m {
+		return false
+	}
+	//
+	for i := range n {
+		if !p.elements[i].Equals(other.elements[i]) {
+			return false
+		}
+	}
+	//
+	return true
+}
+
+// Hash generat6es a 64-bit hashcode from the underlying bytes array.
+func (p Array[F]) Hash() uint64 {
+	// FNV1a hash implementation
+	hash := offset64
+	//
+	for _, c := range p.elements {
+		hash ^= c.Hash()
+		hash *= prime64
+	}
+	//
+	return hash
+}

--- a/pkg/util/collection/hash/hash_map.go
+++ b/pkg/util/collection/hash/hash_map.go
@@ -136,7 +136,7 @@ func (p *Map[K, V]) String() string {
 
 			first = false
 
-			r.WriteString(fmt.Sprintf("%s:=%s", any(k), any(b.values[i])))
+			r.WriteString(fmt.Sprintf("%v:=%v", any(k), any(b.values[i])))
 		}
 	}
 	// Write closing brace

--- a/pkg/util/collection/hash/hash_set.go
+++ b/pkg/util/collection/hash/hash_set.go
@@ -13,27 +13,9 @@
 package hash
 
 import (
-	"bytes"
 	"fmt"
-	"hash/fnv"
 	"strings"
 )
-
-// A reasonably simple hashset implementation which permits collisions.  Observe
-// that, for example, hashicorp's go-set is *not* a suitable replacement here,
-// since that does not handle collisions.  Specifically, it assumes the hash
-// function always uniquely identifies the data in question.  I don't want to
-// make that assumption here.
-
-// Hasher provides a generic definition of a hashing function suitable for use
-// within the hashset.  This is similar to the Hasher interface provided in
-// go-set, except that it additionally includes equality.
-type Hasher[T any] interface {
-	// Check whether two items are equal (or not).
-	Equals(T) bool
-	// Return a suitable hashcode.
-	Hash() uint64
-}
 
 // Set defines a generic set implementation backed by a map.  This is a true
 // hashtable in that collisions are handle gracefully using buckets, rather than
@@ -121,7 +103,7 @@ func (p *Set[T]) String() string {
 
 			first = false
 
-			r.WriteString(fmt.Sprintf("%s", any(i)))
+			r.WriteString(fmt.Sprintf("%v", any(i)))
 		}
 	}
 	// Write closing brace
@@ -170,33 +152,4 @@ func (b *hashSetBucket[T]) contains(item T) bool {
 	}
 
 	return false
-}
-
-// ============================================================================
-// Key Implementations
-// ============================================================================
-
-// BytesKey wraps a bytes array as something which can be safely placed into a
-// HashSet.
-type BytesKey struct {
-	bytes []byte
-}
-
-// NewBytesKey constructs a new bytes key.
-func NewBytesKey(bytes []byte) BytesKey {
-	return BytesKey{bytes}
-}
-
-// Equals compares two BytesKeys to check whether they represent the same
-// underlying byte array (or not).
-func (p BytesKey) Equals(other BytesKey) bool {
-	return bytes.Equal(p.bytes, other.bytes)
-}
-
-// Hash generat6es a 64-bit hashcode from the underlying bytes array.
-func (p BytesKey) Hash() uint64 {
-	hash := fnv.New64a()
-	hash.Write(p.bytes)
-	// Done
-	return hash.Sum64()
 }


### PR DESCRIPTION
This refactors existing constraint implementations to be generic over the field element being used.  In most cases, this was straightforward.