### PR TITLE
chore: update go version to 1.24.6

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b #v5.4.0
         with:
-          go-version: '>=1.20'
+          go-version: '>=1.24'
       # Setup environment
       - run: make install
       # Do the linting

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,5 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b #v5.4.0
         with:
-          go-version: '>=1.20'
+          go-version: '>=1.24'
       - run: make ${{ matrix.test }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: go-test-mod
         args: [ --run=Test_Basic ]
   - repo: https://github.com/golangci/golangci-lint
-    rev: v2.2.1
+    rev: v2.3.1
     hooks:
       - id: golangci-lint
   - repo: https://github.com/executablebooks/mdformat

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GOCORSET_VERSION:=$(shell git describe --always --tags)
 GOCORSET_VERSION_PATH:="github.com/consensys/go-corset/pkg/cmd"
-GOLANGCI_VERSION:=2.2.1
+GOLANGCI_VERSION:=2.3.1
 PROJECT_NAME:=go-corset
 GOPATH_BIN:=$(shell go env GOPATH)/bin
 # Define set of unit tests

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/consensys/go-corset
 
-go 1.23.11
+go 1.24.6
 
 require (
+	github.com/consensys/bavard v0.1.15
 	github.com/consensys/gnark-crypto v0.14.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
@@ -11,7 +12,6 @@ require (
 
 require (
 	github.com/bits-and-blooms/bitset v1.14.3 // indirect
-	github.com/consensys/bavard v0.1.15 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/mmcloughlin/addchain v0.4.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect


### PR DESCRIPTION
This updates the required version of Go to 1.24.6, and also updates the version used for golangci-lint