### PR TITLE
fix: quote column names in lisp output as needed

### DIFF
--- a/pkg/cmd/debug/schema.go
+++ b/pkg/cmd/debug/schema.go
@@ -128,8 +128,10 @@ func printRegisters[F any](module schema.Module[F], prefix string, filter func(s
 				} else {
 					regT = "𝔽"
 				}
+				// construct name string whilst applying quotes when necessary.
+				name := sexp.NewSymbol(r.Name).String(true)
 				//
-				fmt.Printf("   (\"%s\" %s", r.Name, regT)
+				fmt.Printf("   (%s %s", name, regT)
 				// Print padding
 				fmt.Printf(" 0x%s)\n", r.Padding.Text(16))
 			}


### PR DESCRIPTION
This ensures that column names in the generated lisp are quoted only when they contain certain characters, such as spaces, etc.  This means names for inverses will be quoted, whilst those for user-defined columns will not.