### PR TITLE
feat: support CLI option "--enforce-types"

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -144,6 +144,7 @@ func getSchemaStack[F field.Element[F]](cmd *cobra.Command, mode uint, filenames
 	corsetConfig.Stdlib = !GetFlag(cmd, "no-stdlib")
 	corsetConfig.Debug = GetFlag(cmd, "debug")
 	corsetConfig.Legacy = GetFlag(cmd, "legacy")
+	corsetConfig.EnforceTypes = GetFlag(cmd, "enforce-types")
 	// Assembly lowering config
 	asmConfig.Vectorize = GetFlag(cmd, "vectorize")
 	asmConfig.Field = *fieldConfig
@@ -210,6 +211,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("debug", false, "enable debugging constraints")
 	rootCmd.PersistentFlags().Bool("legacy", true, "use legacy register allocator")
 	rootCmd.PersistentFlags().Bool("no-stdlib", false, "prevent standard library from being included")
+	rootCmd.PersistentFlags().Bool("enforce-types", false, "enforce types by default")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "increase logging verbosity")
 	rootCmd.PersistentFlags().UintP("opt", "O", 1, "set optimisation level")
 	// Assembly lowering config

--- a/pkg/corset/compiler.go
+++ b/pkg/corset/compiler.go
@@ -47,6 +47,8 @@ type CompilationConfig struct {
 	Debug bool
 	// Enable legacy register allocator
 	Legacy bool
+	// Enforce all types by default
+	EnforceTypes bool
 }
 
 // CompileSourceFiles compiles one or more source files into a schema.  This
@@ -54,17 +56,17 @@ type CompilationConfig struct {
 // or other forms of error (e.g. type errors).
 func CompileSourceFiles[M schema.Module[bls12_377.Element]](config CompilationConfig, srcfiles []*source.File,
 	externs ...M) (mir.MixedSchema[bls12_377.Element, M], SourceMap, []SyntaxError) {
-	//
 	// Include the standard library (if requested)
 	srcfiles = includeStdlib(config.Stdlib, srcfiles)
 	// Parse all source files (inc stdblib if applicable).
-	circuit, srcmap, errs := compiler.ParseSourceFiles(srcfiles)
+	circuit, srcmap, errs := compiler.ParseSourceFiles(srcfiles, config.EnforceTypes)
 	// Check for parsing errors
 	if errs != nil {
 		return mir.MixedSchema[bls12_377.Element, M]{}, SourceMap{}, errs
 	}
 	// Compile each module into the schema
-	comp := NewCompiler(circuit, srcmap, externs).SetDebug(config.Debug)
+	comp := NewCompiler(circuit, srcmap, externs).
+		SetDebug(config.Debug)
 	// Configure register allocator (if requested)
 	if config.Legacy {
 		comp.SetAllocator(compiler.LegacyAllocator)


### PR DESCRIPTION
This adds support for a simple CLI option which enables type proofs by default.  This is potentially quite expensive, but also useful at times.