### PR TITLE
feat: upgrade inspector scan facility

### DIFF
--- a/pkg/cmd/inspector/inspect.go
+++ b/pkg/cmd/inspector/inspect.go
@@ -261,8 +261,28 @@ func (p *Inspector[F]) toggleColumnFilter() bool {
 	return true
 }
 
+func (p *Inspector[F]) nextScanResult(forwards bool) {
+	var (
+		current = p.currentView()
+		msg     termio.FormattedText
+	)
+	//
+	if current.lastQuery == nil {
+		msg = termio.NewColouredText("no previous scan", termio.TERM_RED)
+	} else if forwards {
+		// Dig out the last query
+		msg = p.CurrentModule().matchQuery(current.view.row+1, forwards, current.lastQuery)
+	} else {
+		msg = p.CurrentModule().matchQuery(current.view.row-1, forwards, current.lastQuery)
+	}
+	//
+	p.SetStatus(msg)
+}
+
 func (p *Inspector[F]) matchQuery(query *Query[F]) termio.FormattedText {
-	return p.CurrentModule().matchQuery(query)
+	var current = p.currentView()
+	//
+	return p.CurrentModule().matchQuery(current.view.row, true, query)
 }
 
 // ==================================================================

--- a/pkg/cmd/inspector/nav_mode.go
+++ b/pkg/cmd/inspector/nav_mode.go
@@ -36,7 +36,11 @@ func (p *NavigationMode[F]) Activate(parent *Inspector[F]) {
 	parent.cmdBar.AddLeft(termio.NewColouredText("[t]", termio.TERM_YELLOW))
 	parent.cmdBar.AddLeft(termio.NewText("oggle computed :: "))
 	parent.cmdBar.AddLeft(termio.NewColouredText("[s]", termio.TERM_YELLOW))
-	parent.cmdBar.AddLeft(termio.NewText("scan :: "))
+	parent.cmdBar.AddLeft(termio.NewText("can :: "))
+	parent.cmdBar.AddLeft(termio.NewColouredText("[n]", termio.TERM_YELLOW))
+	parent.cmdBar.AddLeft(termio.NewText("ext match :: "))
+	parent.cmdBar.AddLeft(termio.NewColouredText("[p]", termio.TERM_YELLOW))
+	parent.cmdBar.AddLeft(termio.NewText("revious match :: "))
 	//p.cmdbar.Add(termio.NewFormattedText("[p]erspectives"))
 	parent.cmdBar.AddLeft(termio.NewColouredText("[q]", termio.TERM_RED))
 	parent.cmdBar.AddLeft(termio.NewText("uit"))
@@ -94,6 +98,10 @@ func (p *NavigationMode[F]) KeyPressed(parent *Inspector[F], key uint16) bool {
 		parent.toggleColumnFilter()
 	case 's':
 		parent.EnterMode(p.scanInputMode(parent))
+	case 'n':
+		parent.nextScanResult(true)
+	case 'p':
+		parent.nextScanResult(false)
 	case '#':
 		parent.clearColumnFilter()
 	case '+':
@@ -129,7 +137,7 @@ func (p *NavigationMode[F]) filterInputMode(parent *Inspector[F]) Mode[F] {
 
 func (p *NavigationMode[F]) scanInputMode(parent *Inspector[F]) Mode[F] {
 	var (
-		prompt        = termio.NewColouredText("[history ↑/↓] expression? ", termio.TERM_YELLOW)
+		prompt        = termio.NewColouredText("[history ↑/↓] where $=row, expression? ", termio.TERM_YELLOW)
 		history       = parent.currentView().scanHistory
 		history_index = uint(len(history))
 		columns       set.SortedSet[string]
@@ -140,7 +148,7 @@ func (p *NavigationMode[F]) scanInputMode(parent *Inspector[F]) Mode[F] {
 	}
 	// Construct environment
 	env := func(col string) bool {
-		return columns.Contains(col)
+		return columns.Contains(col) || col == "$"
 	}
 	// Construct input mode
 	return newInputMode[F](prompt, history_index, history, newQueryHandler(env, parent.matchQuery))

--- a/pkg/cmd/inspector/query.go
+++ b/pkg/cmd/inspector/query.go
@@ -22,17 +22,18 @@ import (
 	"github.com/consensys/go-corset/pkg/util/field"
 )
 
-const qVAR = 0
-const qNUM = 1
-const qOR = 2
-const qAND = 3
-const qEQ = 4
-const qNEQ = 5
-const qLT = 6
-const qLTEQ = 7
-const qADD = 8
-const qMUL = 9
-const qSUB = 10
+const qROW = 0
+const qVAR = 1
+const qNUM = 2
+const qOR = 3
+const qAND = 4
+const qEQ = 5
+const qNEQ = 6
+const qLT = 7
+const qLTEQ = 8
+const qADD = 9
+const qMUL = 10
+const qSUB = 11
 
 // Query represents a boolean expression which can be evaluated over a
 // given set of columns.
@@ -51,8 +52,13 @@ type Query[F field.Element[F]] struct {
 func (p *Query[F]) Variable(name string) *Query[F] {
 	var query Query[F]
 	//
-	query.op = qVAR
-	query.name = name
+	if name == "$" {
+		query.op = qROW
+		query.name = name
+	} else {
+		query.op = qVAR
+		query.name = name
+	}
 	//
 	return &query
 }
@@ -146,6 +152,9 @@ func (p *Query[F]) String() string {
 // Eval evaluates the given query in the given environment.
 func (p *Query[F]) Eval(row uint, env map[string]tr.Column[F]) F {
 	switch p.op {
+	case qROW:
+		var val F
+		return val.SetUint64(uint64(row))
 	case qVAR:
 		if col, ok := env[p.name]; ok {
 			return col.Get(int(row))
@@ -293,7 +302,7 @@ func query_string[F field.Element[F]](p Query[F], braces ...int) string {
 	var str string
 	//
 	switch p.op {
-	case qVAR:
+	case qVAR, qROW:
 		return p.name
 	case qNUM:
 		return p.number.String()

--- a/pkg/util/source/bexp/parser.go
+++ b/pkg/util/source/bexp/parser.go
@@ -121,12 +121,14 @@ var number lex.Scanner[rune] = lex.Many(lex.Within('0', '9'))
 var identifierStart lex.Scanner[rune] = lex.Or(
 	lex.Unit('_'),
 	lex.Unit('\''),
+	lex.Unit('$'),
 	lex.Within('a', 'z'),
 	lex.Within('A', 'Z'))
 
 var identifierRest lex.Scanner[rune] = lex.Many(lex.Or(
 	lex.Unit('_'),
 	lex.Unit('\''),
+	lex.Unit('$'),
 	lex.Within('0', '9'),
 	lex.Within('a', 'z'),
 	lex.Within('A', 'Z')))


### PR DESCRIPTION
This puts through some useful upgrades to the inspector "scan" commands, including: allowing the current row to be used in a query (e.g. `$ > 100 && $ < 1000`); starting a scan from the current row; support next and previous matches to cycle through.