### PR TITLE
fix: make constant substitution a module-level concern

### DIFF
--- a/pkg/asm/program/assignment.go
+++ b/pkg/asm/program/assignment.go
@@ -125,6 +125,12 @@ func (p Assignment[F, T]) RegistersWritten() []sc.RegisterRef {
 	return regs
 }
 
+// Substitute implementation for schema.Assignment interface.
+func (p Assignment[F, T]) Substitute(map[string]F) {
+	// Do nothing since assembly instructions do not (at the time of writing)
+	// employ labelled constants.
+}
+
 // Trace a given function with the given arguments in a given I/O environment to
 // produce a given set of output values, along with the complete set of internal
 // traces.

--- a/pkg/asm/program/module.go
+++ b/pkg/asm/program/module.go
@@ -95,6 +95,12 @@ func (p *Module[F, T]) IsSynthetic() bool {
 	panic("unsupported operation")
 }
 
+// Substitute any matchined labelled constants within this module
+func (p *Module[F, T]) Substitute(mapping map[string]F) {
+	// For now, this is a no-operation because assembly has no concept of
+	// labelled constants.  In the future, we might expect this to change.
+}
+
 // Width implementation for schema.Module interface.
 func (p *Module[F, T]) Width() uint {
 	return uint(len(p.function.Registers()))

--- a/pkg/ir/air/gadgets/bitwidth.go
+++ b/pkg/ir/air/gadgets/bitwidth.go
@@ -300,6 +300,11 @@ func (p *typeDecomposition[F]) RegistersWritten() []sc.RegisterRef {
 	return p.targets
 }
 
+// Substitute any matchined labelled constants within this assignment
+func (p *typeDecomposition[F]) Substitute(mapping map[string]F) {
+	// Nothing to do here.
+}
+
 // Lisp converts this schema element into a simple S-Expression, for example
 // so it can be printed.
 func (p *typeDecomposition[F]) Lisp(schema sc.AnySchema[F]) sexp.SExp {
@@ -407,6 +412,11 @@ func (p *byteDecomposition[F]) RegistersRead() []sc.RegisterRef {
 // RegistersWritten identifies registers assigned by this assignment.
 func (p *byteDecomposition[F]) RegistersWritten() []sc.RegisterRef {
 	return p.targets
+}
+
+// Substitute any matchined labelled constants within this assignment
+func (p *byteDecomposition[F]) Substitute(mapping map[string]F) {
+	// Nothing to do here.
 }
 
 // Lisp converts this schema element into a simple S-Expression, for example

--- a/pkg/ir/assignment/computation.go
+++ b/pkg/ir/assignment/computation.go
@@ -100,6 +100,11 @@ func (p *Computation[F]) Subdivide(mapping schema.LimbsMap) sc.Assignment[F] {
 	return p
 }
 
+// Substitute any matchined labelled constants within this assignment
+func (p *Computation[F]) Substitute(map[string]F) {
+	// Nothing to do here.
+}
+
 // ============================================================================
 // Lispify Interface
 // ============================================================================

--- a/pkg/ir/assignment/computed_register.go
+++ b/pkg/ir/assignment/computed_register.go
@@ -165,6 +165,11 @@ func (p *ComputedRegister[F, E]) Subdivide(mapping schema.LimbsMap) sc.Assignmen
 	return p
 }
 
+// Substitute any matchined labelled constants within this assignment
+func (p *ComputedRegister[F, E]) Substitute(mapping map[string]F) {
+	p.Expr.Substitute(mapping)
+}
+
 // Lisp converts this constraint into an S-Expression.
 //
 //nolint:revive

--- a/pkg/ir/assignment/lexicographic_sort.go
+++ b/pkg/ir/assignment/lexicographic_sort.go
@@ -149,6 +149,11 @@ func (p *LexicographicSort[F]) RegistersWritten() []sc.RegisterRef {
 	return p.targets
 }
 
+// Substitute any matchined labelled constants within this assignment
+func (p *LexicographicSort[F]) Substitute(mapping map[string]F) {
+	// Nothing to do here.
+}
+
 // ============================================================================
 // Lispify Interface
 // ============================================================================

--- a/pkg/ir/assignment/sorted_permutation.go
+++ b/pkg/ir/assignment/sorted_permutation.go
@@ -118,6 +118,11 @@ func (p *SortedPermutation[F]) Subdivide(mapping schema.LimbsMap) sc.Assignment[
 	return p
 }
 
+// Substitute any matchined labelled constants within this assignment
+func (p *SortedPermutation[F]) Substitute(mapping map[string]F) {
+	// Nothing to do here.
+}
+
 // ============================================================================
 // Lispify Interface
 // ============================================================================

--- a/pkg/ir/mir/schema.go
+++ b/pkg/ir/mir/schema.go
@@ -136,9 +136,9 @@ type (
 // all expressions used within the schema.
 func SubstituteConstants[F field.Element[F]](schema schema.AnySchema[F], mapping map[string]F) {
 	// Constraints
-	for iter := schema.Constraints(); iter.HasNext(); {
-		constraint := iter.Next()
-		constraint.Substitute(mapping)
+	for iter := schema.Modules(); iter.HasNext(); {
+		module := iter.Next()
+		module.Substitute(mapping)
 	}
 }
 

--- a/pkg/ir/schema_builder.go
+++ b/pkg/ir/schema_builder.go
@@ -262,6 +262,13 @@ func (p *ModuleBuilder[F, C, T]) IsSynthetic() bool {
 	return p.synthetic
 }
 
+// Substitute any matchined labelled constants within this module
+func (p *ModuleBuilder[F, C, T]) Substitute(mapping map[string]F) {
+	for _, c := range p.constraints {
+		c.Substitute(mapping)
+	}
+}
+
 // Width returns the number of registers in this module.
 func (p *ModuleBuilder[F, C, T]) Width() uint {
 	return uint(len(p.registers))

--- a/pkg/schema/assignment.go
+++ b/pkg/schema/assignment.go
@@ -54,6 +54,8 @@ type Assignment[F any] interface {
 	RegistersRead() []RegisterRef
 	// Identifier registers assigned by this assignment.
 	RegistersWritten() []RegisterRef
+	// Substitute any matchined labelled constants within this assignment
+	Substitute(map[string]F)
 	// Lisp converts this schema element into a simple S-Expression, for example
 	// so it can be printed.
 	Lisp(AnySchema[F]) sexp.SExp

--- a/pkg/schema/module.go
+++ b/pkg/schema/module.go
@@ -200,6 +200,10 @@ func (p *Table[F, C]) Registers() []Register {
 
 // Substitute any matchined labelled constants within this module
 func (p *Table[F, C]) Substitute(mapping map[string]F) {
+	for _, c := range p.assignments {
+		c.Substitute(mapping)
+	}
+	//
 	for _, c := range p.constraints {
 		c.Substitute(mapping)
 	}

--- a/pkg/schema/module.go
+++ b/pkg/schema/module.go
@@ -64,6 +64,8 @@ type Module[F any] interface {
 	// IsSynthetic modules are generated during compilation, rather than being
 	// provided by the user.
 	IsSynthetic() bool
+	// Substitute any matchined labelled constants within this module
+	Substitute(map[string]F)
 	// Returns the number of registers in this module.
 	Width() uint
 }
@@ -194,6 +196,13 @@ func (p *Table[F, C]) Register(id RegisterId) Register {
 // Specifically, the index of a register in this array is its register index.
 func (p *Table[F, C]) Registers() []Register {
 	return p.registers
+}
+
+// Substitute any matchined labelled constants within this module
+func (p *Table[F, C]) Substitute(mapping map[string]F) {
+	for _, c := range p.constraints {
+		c.Substitute(mapping)
+	}
 }
 
 // Width returns the number of registers in this Table.


### PR DESCRIPTION
This changes the responsibility for constant substitution from being solely at the constraint level to now being at the module level.  This subsequently allows us to resolve the issue with assembly functions and substituteion (i.e. which arises because assembly functions currently have no notion of constants).