### PR TITLE
fix: native interleaving bitwidth calculation

### DIFF
--- a/pkg/ir/assignment/computation.go
+++ b/pkg/ir/assignment/computation.go
@@ -202,17 +202,17 @@ func idNativeFunction[F field.Element[F]](sources []array.Array[F], _ array.Buil
 func interleaveNativeFunction[F field.Element[F]](sources []array.Array[F], builder array.Builder[F],
 ) []array.MutArray[F] {
 	var (
+		bitwidth   uint
 		height     = sources[0].Len()
-		bitwidth   = sources[0].BitWidth()
 		multiplier = uint(len(sources))
 	)
 	// Sanity check column heights
 	for _, src := range sources {
 		if src.Len() != height {
-			panic("inconsistent column height for interleaving")
-		} else if src.BitWidth() != bitwidth {
-			panic("inconsistent column bitwidth for interleaving")
+			panic(fmt.Sprintf("inconsistent column height for interleaving (%d v %d)", src.Len(), height))
 		}
+		//
+		bitwidth = max(bitwidth, src.BitWidth())
 	}
 	// Construct interleaved column
 	target := builder.NewArray(height*multiplier, bitwidth)


### PR DESCRIPTION
The calculation of the target bitwidth for the native interleaving comptuation incorrectly assumed that bitwidths must match.  In fact, bitwidths in the dynamic arrays do not have to match that of their corresponding register.  For example, if a column contained only 0 or 1 we could implement it using a bit array, regardless of whether its register was a u8 or a u16, etc.

This fix simply updates the calculation to take the maximum bitwidth of any source column to use for the target column.  This is safe, and optimal.