### PR TITLE
fix: padding inference

### DIFF
--- a/pkg/asm/concretize.go
+++ b/pkg/asm/concretize.go
@@ -100,21 +100,24 @@ func Concretize[F1 Element[F1], F2 Element[F2]](cfg sc.FieldConfig, p MixedMicro
 // SplitRegisters method (which we want to avoid right now).
 func subdivideProgram(mapping schema.LimbsMap, p MicroProgram) MicroProgram {
 	var (
-		fns      = p.Functions()
-		nfns     = make([]*MicroFunction, len(fns))
-		executor = io.NewExecutor(p)
+		fns  = p.Functions()
+		nfns = make([]*MicroFunction, len(fns))
 	)
 	// Split functions
 	for i, fn := range fns {
 		ith := subdivideFunction(mapping, *fn)
 		nfns[i] = &ith
 	}
+	// Constuct subdivided program
+	p = io.NewProgram(nfns)
+	// Construct executor for padding inference
+	executor := io.NewExecutor(p)
 	// Infer padding
 	for _, nfn := range nfns {
 		io.InferPadding(*nfn, executor)
 	}
 	// Done
-	return io.NewProgram(nfns)
+	return p
 }
 
 // Subdivide a given function.  In principle, this should be located within

--- a/pkg/asm/io/bus.go
+++ b/pkg/asm/io/bus.go
@@ -13,6 +13,9 @@
 package io
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/schema/agnostic"
 )
@@ -80,4 +83,14 @@ func (p *Bus) Split(env schema.RegisterAllocator) Bus {
 	data := agnostic.ApplyMapping(env, p.DataLines)
 	//
 	return NewBus(p.Name, p.BusId, address, data)
+}
+
+func (p *Bus) String() string {
+	var builder strings.Builder
+	//
+	builder.WriteString(fmt.Sprintf("%s(%d)", p.Name, p.BusId))
+	builder.WriteString(fmt.Sprintf("%v", p.AddressLines))
+	builder.WriteString(fmt.Sprintf("%v", p.DataLines))
+	//
+	return builder.String()
 }


### PR DESCRIPTION
Padding inference for microprograms was using an incorrect executor. Specifically, the executor held functions before splitting but was being called from functions *after* splitting.  Hence, an incompatibility between registers and limbs.