### PR TITLE
feat: support literals with exponents

### DIFF
--- a/pkg/asm/assembler/lexer.go
+++ b/pkg/asm/assembler/lexer.go
@@ -113,6 +113,7 @@ var (
 	decimalRest  = lex.Or(
 		lex.Within('0', '9'),
 		lex.Unit('_'),
+		lex.Unit('^'),
 	)
 
 	hexDigit = lex.Or(

--- a/testdata/asm/util/bit_shift.zkasm
+++ b/testdata/asm/util/bit_shift.zkasm
@@ -26,19 +26,15 @@ base:
 ;; n bits, this operation makes n calls.  Since this is used in
 ;; conjunction with the byte_shr, it only supports n <= 7.
 fn bit_shr256(word u256, n u3) -> (res u256) {
-  var acc, t1 u256
-  var t2 u128
+  var acc u256
   var hi, lo u127
   var b0,b1,b2 u1
-  var o u2
   var m u3
   ;; check for base case
   if n == 0 goto base
   ;; FIXME: workaround for register splitting issue
   hi, b1, lo, b0 = word
-  t1 = hi * 340282366920938463463374607431768211456
-  t2 = b1 * 170141183460469231731687303715884105728
-  o, acc = t1 + t2 + lo
+  acc = (hi * 2^128) + (b1 * 2^127) + lo
   ;; decrement counter
   b2,m = n - 1
   res = bit_shr256(acc,m)
@@ -49,22 +45,17 @@ base:
 }
 
 fn bit_sar256(word u256, n u3) -> (res u256) {
-  var acc, extension, t1 u256
-  var t2 u128
+  var acc u256
   var lo u127
   var hi u126
   var m u3
-  var o u2
   var sign, b0, b1, b2 u1
   ;; check for base case
   if n == 0 goto base
   ;; split of trailing bit
   sign, hi, b1, lo, b0 = word
-  t1 = hi * 340282366920938463463374607431768211456
-  t2 = b1 * 170141183460469231731687303715884105728
   ;; determine sign extension
-  extension = sign * 0xC000000000000000000000000000000000000000000000000000000000000000
-  o, acc = extension + t1 + t2 + lo
+  acc = (sign * (2^255 + 2^254)) + (hi * 2^128) + (b1 * 2^127) + lo
   ;; decrement counter
   b2, m = n - 1
   res = bit_sar256(acc,m)

--- a/testdata/asm/util/byte_shift.zkasm
+++ b/testdata/asm/util/byte_shift.zkasm
@@ -50,18 +50,15 @@ base:
 fn byte_sar256(word u256, n u5) -> (res u256) {
   var head u8
   var tail u247
-  var sign u1
-  var extension u256
+  var sign,b u1
   var acc u256
-  var b,o u1
   var m u5
   ;; check for base case
   if n == 0 goto base
   ;; split of trailing byte
   sign,tail,head = word
   ;; determine extension
-  extension = sign * 0xFF80000000000000000000000000000000000000000000000000000000000000
-  o,acc = extension + tail
+  acc = (sign * 0xFF80 * 256^30) + tail
   ;; decrement counter
   b,m = n - 1
   res = byte_sar256(acc,m)

--- a/testdata/asm/util/set_byte.zkasm
+++ b/testdata/asm/util/set_byte.zkasm
@@ -22,13 +22,13 @@ fn set_byte256(word u256, n u5, value u8) -> (res u256) {
   ;; update hi word
   v = set_byte128(hi, m, value)
   ;; Recombine
-  res = (v * 340282366920938463463374607431768211456) + lo
+  res = (v * 2^128) + lo
   return
 exit_lo:
   ;; update lo word
   v = set_byte128(lo, m, value)
   ;; Recombine
-  res = (hi * 340282366920938463463374607431768211456) + v
+  res = (hi * 2^128) + v
   return
 }
 
@@ -45,13 +45,13 @@ fn set_byte128(word u128, n u4, value u8) -> (res u128) {
   ;; update hi word
   v = set_byte64(hi, m, value)
   ;; Recombine
-  res = (v * 18446744073709551616) + lo
+  res = (v * 2^64) + lo
   return
 exit_lo:
   ;; update lo word
   v = set_byte64(lo, m, value)
   ;; Recombine
-  res = (hi * 18446744073709551616) + v
+  res = (hi * 2^64) + v
   return
 }
 
@@ -68,13 +68,13 @@ fn set_byte64(word u64, n u3, value u8) -> (res u64) {
   ;; update hi word
   v = set_byte32(hi, m, value)
   ;; Recombine
-  res = (v * 4294967296) + lo
+  res = (v * 2^32) + lo
   return
 exit_lo:
   ;; update lo word
   v = set_byte32(lo, m, value)
   ;; Recombine
-  res = (hi * 4294967296) + v
+  res = (hi * 2^32) + v
   return
 }
 
@@ -90,13 +90,13 @@ fn set_byte32(word u32, n u2, value u8) -> (res u32) {
   ;; update hi word
   v = set_byte16(hi, m, value)
   ;; Recombine
-  res = (v * 65536) + lo
+  res = (v * 2^16) + lo
   return
 exit_lo:
   ;; update lo word
   v = set_byte16(lo, m, value)
   ;; Recombine
-  res = (hi * 65536) + v
+  res = (hi * 2^16) + v
   return
 }
 
@@ -106,10 +106,10 @@ fn set_byte16(word u16, n u1, value u8) -> (res u16) {
   hi,lo = word
   ;;
   if n == 1 goto exit_lo
-  res = (value * 256) + lo
+  res = (value * 2^8) + lo
   return
 exit_lo:
   ;; Recombine
-  res = (hi * 256) + value
+  res = (hi * 2^8) + value
   return
 }


### PR DESCRIPTION
This adds support for writing numeric literals of the form e.g. 2^127 which actually does make some assembly programs much simpler to read.