### PR TITLE
fix: error reporting for conflicting lookup context

### DIFF
--- a/pkg/corset/compiler/translator.go
+++ b/pkg/corset/compiler/translator.go
@@ -443,7 +443,15 @@ func (t *translator) translateDefLookupSources(selector ast.Expr,
 	// Translate target expressions whilst again checking for a conflicting
 	// context.
 	if context.IsConflicted() {
-		return lookup.Vector[bls12_377.Element, mirTerm]{}, context, t.srcmap.SyntaxErrors(sources[j], "conflicting context")
+		var source ast.Expr
+		// Determine offending source expression
+		if j >= uint(len(sources)) {
+			source = selector
+		} else {
+			source = sources[j]
+		}
+		//
+		return lookup.Vector[bls12_377.Element, mirTerm]{}, context, t.srcmap.SyntaxErrors(source, "conflicting context")
 	}
 	// Determine enclosing module
 	module := t.moduleOf(context)

--- a/pkg/test/corset_invalid_test.go
+++ b/pkg/test/corset_invalid_test.go
@@ -509,6 +509,9 @@ func Test_Invalid_Lookup_16(t *testing.T) {
 func Test_Invalid_Lookup_17(t *testing.T) {
 	checkCorsetInvalid(t, "invalid/lookup_invalid_17")
 }
+func Test_Invalid_Lookup_18(t *testing.T) {
+	checkCorsetInvalid(t, "invalid/lookup_invalid_18")
+}
 
 // ===================================================================
 // Interleavings

--- a/testdata/invalid/lookup_invalid_18.lisp
+++ b/testdata/invalid/lookup_invalid_18.lisp
@@ -1,0 +1,7 @@
+;;error:7:23-24:conflicting context
+(module m1)
+(defcolumns (X :i64))
+
+(module m2)
+(defcolumns (A :i1) (B :i64))
+(defclookup m1 (m2.B) A (m1.X))


### PR DESCRIPTION
There was a simple logic error in the mechanism for reporting a conflicting context for a lookup vector.  The problem was the error handling logic did not consider that the selector may be the source of the conflict,