### PR TITLE
feat: improve errors in generated Trace.java files

### DIFF
--- a/pkg/cmd/generate/interface.go
+++ b/pkg/cmd/generate/interface.go
@@ -127,8 +127,8 @@ func generateInterfaceSubmoduleAccessors(submodules []corset.SourceModule, build
 				builder.WriteIndentedString("// Submodules\n")
 			}
 			// Yes, it is.
-			builder.WriteIndentedString(
-				"default ", className, " ", fieldName, "() { throw new IllegalArgumentException(); }\n")
+			builder.WriteIndentedString("default ", className, " ", fieldName, "() {")
+			builder.WriteString(fmt.Sprintf("throw new IllegalArgumentException(\"missing module %s\"); }\n", m.Name))
 			//
 			first = false
 		}
@@ -178,23 +178,25 @@ func generateInterfaceColumnSetters(className string, mod corset.SourceModule,
 				methodName = toCamelCase(fmt.Sprintf("p_%s_%s", mod.Name, methodName))
 			}
 			//
-			generateInterfaceColumnSetter(className, methodName, column, builder)
+			generateInterfaceColumnSetter(className, methodName, mod, column, builder)
 		}
 	}
 }
 
-func generateInterfaceColumnSetter(className string, methodName string, col corset.SourceColumn,
-	builder indentBuilder) {
+func generateInterfaceColumnSetter(className string, methodName string, mod corset.SourceModule,
+	col corset.SourceColumn, builder indentBuilder) {
 	//
+	handle := fmt.Sprintf("%s.%s", mod.Name, col.Name)
 	methodName = toCamelCase(methodName)
 	typeStr := getJavaType(col.Bitwidth)
+	errorMsg := fmt.Sprintf("throw new IllegalArgumentException(\"missing column %s (u%d)\"); }\n", handle, col.Bitwidth)
 	//
-	builder.WriteIndentedString("default ", className, " ", methodName,
-		"(final ", typeStr, " val) { throw new IllegalArgumentException(); }\n")
+	builder.WriteIndentedString("default ", className, " ", methodName, "(final ", typeStr, " val) {")
+	builder.WriteString(errorMsg)
 	// Legacy case for bytes
 	if col.Bitwidth == 8 {
-		builder.WriteIndentedString("default ", className, " ", methodName,
-			"(final UnsignedByte val) { throw new IllegalArgumentException(); }\n")
+		builder.WriteIndentedString("default ", className, " ", methodName, "(final UnsignedByte val) {")
+		builder.WriteString(errorMsg)
 	}
 }
 


### PR DESCRIPTION
This improves the error messages in the generated Trace.java files by including the module and/or column name in the thrown Java exception. This is useful when that exception bubbles up through its enclosing environment into a log, for example.