### PR TITLE
feat: print (ifnot C P) instead of (if C _ P)

### DIFF
--- a/pkg/ir/ite.go
+++ b/pkg/ir/ite.go
@@ -119,9 +119,8 @@ func (p *Ite[F, T]) Lisp(global bool, mapping schema.RegisterMap) sexp.SExp {
 		})
 	} else if p.TrueBranch == nil {
 		return sexp.NewList([]sexp.SExp{
-			sexp.NewSymbol("if"),
+			sexp.NewSymbol("ifnot"),
 			condition,
-			sexp.NewSymbol("_"),
 			p.FalseBranch.Lisp(global, mapping),
 		})
 	}


### PR DESCRIPTION
This makes a very trivial change to the lisp writer for IR nodes to make things a little more readable.