### PR TITLE
feat: support "pub" modifier for functions

### DIFF
--- a/pkg/asm/assembler/lexer.go
+++ b/pkg/asm/assembler/lexer.go
@@ -66,6 +66,9 @@ const KEYWORD_INCLUDE uint = 22
 // KEYWORD_FN signals a function declaration
 const KEYWORD_FN uint = 23
 
+// KEYWORD_PUB signals a public function declaration
+const KEYWORD_PUB uint = 24
+
 // RIGHTARROW signals "->"
 const RIGHTARROW uint = 30
 
@@ -192,6 +195,7 @@ var rules []lex.LexRule[rune] = []lex.LexRule[rune]{
 	lex.Rule(whitespace, WHITESPACE),
 	lex.Rule(number, NUMBER),
 	lex.Rule(strung, STRING),
+	lex.Rule(lex.String("pub"), KEYWORD_PUB),
 	lex.Rule(lex.String("const"), KEYWORD_CONST),
 	lex.Rule(lex.String("include"), KEYWORD_INCLUDE),
 	lex.Rule(lex.String("fn"), KEYWORD_FN),

--- a/pkg/asm/compiler/mir.go
+++ b/pkg/asm/compiler/mir.go
@@ -38,7 +38,7 @@ type MirModule[F field.Element[F]] struct {
 
 // Initialise this module
 func (p MirModule[F]) Initialise(mid uint, fn MicroFunction, iomap io.Map) MirModule[F] {
-	builder := ir.NewModuleBuilder[F, mir.Constraint[F], mir.Term[F]](fn.Name(), mid, 1, false, false)
+	builder := ir.NewModuleBuilder[F, mir.Constraint[F], mir.Term[F]](fn.Name(), mid, 1, false, fn.IsPublic(), false)
 	// Add corresponding assignment for this function.
 	builder.AddAssignment(program.NewAssignment[F](mid, fn, iomap))
 	//

--- a/pkg/asm/concretize.go
+++ b/pkg/asm/concretize.go
@@ -140,5 +140,5 @@ func subdivideFunction(mapping sc.LimbsMap, fn MicroFunction) MicroFunction {
 		nbuses[i] = bus.Split(env)
 	}
 	// Done
-	return io.NewFunction(fn.Name(), env.Limbs(), nbuses, ninsns)
+	return io.NewFunction(fn.Name(), fn.IsPublic(), env.Limbs(), nbuses, ninsns)
 }

--- a/pkg/asm/lower.go
+++ b/pkg/asm/lower.go
@@ -43,7 +43,7 @@ func lowerFunction(vectorize bool, f MacroFunction) MicroFunction {
 		insns[pc] = insn.Lower(uint(pc))
 	}
 	// Sanity checks (for now)
-	fn := io.NewFunction(f.Name(), f.Registers(), f.Buses(), insns)
+	fn := io.NewFunction(f.Name(), f.IsPublic(), f.Registers(), f.Buses(), insns)
 	// Apply vectorisation (if enabled).
 	if vectorize {
 		fn = vectorizeFunction(fn)
@@ -65,7 +65,7 @@ func vectorizeFunction(f MicroFunction) MicroFunction {
 	// Remove all uncreachable instructions and compact remainder.
 	insns = pruneUnreachableInstructions(insns)
 	//
-	return io.NewFunction(f.Name(), f.Registers(), f.Buses(), insns)
+	return io.NewFunction(f.Name(), f.IsPublic(), f.Registers(), f.Buses(), insns)
 }
 
 func vectorizeInstruction(pc uint, insns []micro.Instruction) micro.Instruction {

--- a/pkg/asm/program/module.go
+++ b/pkg/asm/program/module.go
@@ -90,6 +90,11 @@ func (p *Module[F, T]) LengthMultiplier() uint {
 	return 1
 }
 
+// IsPublic implementation for schema.Module interface.
+func (p *Module[F, T]) IsPublic() bool {
+	return p.function.IsPublic()
+}
+
 // IsSynthetic implementation for schema.Module interface.
 func (p *Module[F, T]) IsSynthetic() bool {
 	panic("unsupported operation")

--- a/pkg/binfile/binfile.go
+++ b/pkg/binfile/binfile.go
@@ -208,7 +208,7 @@ const BINFILE_MAJOR_VERSION uint16 = 8
 // BINFILE_MINOR_VERSION gives the minor version of the binary file format.  The
 // expected interpretation is that older versions are compatible with newer
 // ones, but not vice-versa.
-const BINFILE_MINOR_VERSION uint16 = 1
+const BINFILE_MINOR_VERSION uint16 = 2
 
 // ZKBINARY is used as the file identifier for binary file types.  This just
 // helps us identify actual binary files from corrupted files.

--- a/pkg/cmd/debug/source_map.go
+++ b/pkg/cmd/debug/source_map.go
@@ -33,6 +33,7 @@ func printSourceMapModule(indent uint, module corset.SourceModule) {
 	if module.Public {
 		fmt.Printf("pub ")
 	}
+	//
 	if module.Virtual {
 		fmt.Printf("virtual ")
 	}

--- a/pkg/cmd/debug/source_map.go
+++ b/pkg/cmd/debug/source_map.go
@@ -30,6 +30,9 @@ func printSourceMapModule(indent uint, module corset.SourceModule) {
 	fmt.Println()
 	printIndent(indent)
 	//
+	if module.Public {
+		fmt.Printf("pub ")
+	}
 	if module.Virtual {
 		fmt.Printf("virtual ")
 	}

--- a/pkg/cmd/generate/class.go
+++ b/pkg/cmd/generate/class.go
@@ -121,11 +121,11 @@ func generateClassContents[F any](className string, super string, mod corset.Sou
 	generateJavaModuleFillAndValidateRow(className, mod, schema, builder.Indent())
 	// Generate any submodules
 	for _, submod := range mod.Submodules {
-		if !submod.Virtual {
+		if submod.Public && !submod.Virtual {
 			name := toPascalCase(submod.Name)
 			superSub := fmt.Sprintf("%s.%s", super, name)
 			generateClassContents(name, superSub, submod, metadata, spillage, schema, builder.Indent())
-		} else {
+		} else if submod.Public {
 			generateJavaModuleColumnSetters(className, submod, schema, builder.Indent())
 		}
 	}
@@ -290,8 +290,8 @@ func generateJavaModuleSubmoduleFields(submodules []corset.SourceModule, builder
 	first := true
 	//
 	for _, m := range submodules {
-		// Only consider non-virtual modules (for now)
-		if !m.Virtual {
+		// Only consider public, non-virtual modules (for now)
+		if m.Public && !m.Virtual {
 			className := toPascalCase(m.Name)
 			// Determine suitable name for field
 			fieldName := toCamelCase(m.Name)
@@ -353,7 +353,7 @@ func generateJavaModuleConstructor(classname string, mod corset.SourceModule, bu
 		// Determine suitable name for field
 		fieldName := toCamelCase(m.Name)
 		// Only support non-virtual modules for now
-		if !m.Virtual {
+		if m.Public && !m.Virtual {
 			innerBuilder.WriteIndentedString("this.", fieldName, " = new ", className, "();\n")
 		}
 	}
@@ -385,7 +385,7 @@ func generateJavaModuleOpen[F any](mod corset.SourceModule, schema sc.AnySchema[
 		// Determine suitable name for field
 		fieldName := toCamelCase(m.Name)
 		// Only support non-virtual modules for now
-		if !m.Virtual {
+		if m.Public && !m.Virtual {
 			innerBuilder.WriteIndentedString("this.", fieldName, "().open(registers);\n")
 		}
 	}

--- a/pkg/cmd/generate/interface.go
+++ b/pkg/cmd/generate/interface.go
@@ -97,9 +97,9 @@ func generateInterfaceContents(className string, mod corset.SourceModule, builde
 	generateInterfaceValidateRow(className, builder.Indent())
 	// Generate any submodules
 	for _, submod := range mod.Submodules {
-		if !submod.Virtual {
+		if submod.Public && !submod.Virtual {
 			generateInterfaceContents(toPascalCase(submod.Name), submod, builder.Indent())
-		} else {
+		} else if submod.Public {
 			generateInterfaceColumnSetters(className, submod, builder.Indent())
 		}
 	}
@@ -117,8 +117,8 @@ func generateInterfaceSubmoduleAccessors(submodules []corset.SourceModule, build
 	first := true
 	//
 	for _, m := range submodules {
-		// Only consider non-virtual modules (for now)
-		if !m.Virtual {
+		// Only consider non-virtual, public modules (for now)
+		if !m.Virtual && m.Public {
 			className := toPascalCase(m.Name)
 			// Determine suitable name for field
 			fieldName := toCamelCase(m.Name)

--- a/pkg/cmd/generate/union.go
+++ b/pkg/cmd/generate/union.go
@@ -32,6 +32,7 @@ func unionModules(left corset.SourceModule, right corset.SourceModule) *corset.S
 	//
 	return &corset.SourceModule{
 		Name:       left.Name,
+		Public:     left.Public || right.Public,
 		Synthetic:  false,
 		Virtual:    left.Virtual,
 		Selector:   util.None[string](),

--- a/pkg/cmd/inspector/inspect.go
+++ b/pkg/cmd/inspector/inspect.go
@@ -379,5 +379,5 @@ func initInspectorTabs[F field.Element[F]](states []ModuleState[F]) *widget.Tabs
 }
 
 func concreteModules(m *corset.SourceModule) bool {
-	return !m.Virtual
+	return !m.Virtual && m.Public
 }

--- a/pkg/cmd/inspector/module_state.go
+++ b/pkg/cmd/inspector/module_state.go
@@ -31,6 +31,8 @@ import (
 // ModuleState provides state regarding how to display the trace for a given
 // module, including related aspects like filter histories, etc.
 type ModuleState[F field.Element[F]] struct {
+	// public indicates whether or not this module is externally visible.
+	public bool
 	// Corresponding trace
 	trace tr.Trace[F]
 	// Name of the source-level module
@@ -105,6 +107,7 @@ func newModuleState[F field.Element[F]](module *corset.SourceModule, trace tr.Tr
 	}
 	//
 	state.name = module.Name
+	state.public = module.Public
 	state.trace = trace
 	// Include all columns initially
 	state.columnFilter.Computed = true

--- a/pkg/corset/compiler.go
+++ b/pkg/corset/compiler.go
@@ -237,6 +237,7 @@ func constructSourceModule(schema schema.AnySchema[bls12_377.Element], scope *co
 	//
 	return SourceModule{
 		Name:       scope.Name(),
+		Public:     scope.IsPublic(),
 		Synthetic:  false,
 		Virtual:    scope.Virtual(),
 		Selector:   scope.Selector(),

--- a/pkg/corset/compiler/externs.go
+++ b/pkg/corset/compiler/externs.go
@@ -22,11 +22,11 @@ import (
 
 // DeclareExterns adds externally defined symbols to the given scope in such a
 // way that they can then be resolved against.
-func DeclareExterns[M schema.RegisterMap](scope *ModuleScope, externs ...M) {
+func DeclareExterns[M schema.ModuleView](scope *ModuleScope, externs ...M) {
 	for _, e := range externs {
 		path := file.NewAbsolutePath(e.Name())
 		// Declare external module
-		scope.Declare(e.Name(), util.None[string]())
+		scope.Declare(e.Name(), util.None[string](), e.IsPublic())
 		// Define external symbol
 		for _, r := range e.Registers() {
 			scope.Define(NewExternSymbolDefinition(path, r))

--- a/pkg/corset/compiler/resolver.go
+++ b/pkg/corset/compiler/resolver.go
@@ -34,10 +34,10 @@ type DeclPredicate = array.Predicate[ast.Declaration]
 // a symbol (e.g. a column) is referred to which doesn't exist.  Likewise, if
 // two modules or columns with identical names are declared in the same scope,
 // etc.
-func ResolveCircuit[M schema.RegisterMap](srcmap *source.Maps[ast.Node], circuit *ast.Circuit,
+func ResolveCircuit[M schema.ModuleView](srcmap *source.Maps[ast.Node], circuit *ast.Circuit,
 	externs ...M) (*ModuleScope, []SyntaxError) {
 	// Construct top-level scope
-	scope := NewModuleScope()
+	scope := NewModuleScope(true)
 	// Define natives
 	for _, i := range NATIVE_SIGNATURES {
 		scope.Define(&i)
@@ -50,7 +50,7 @@ func ResolveCircuit[M schema.RegisterMap](srcmap *source.Maps[ast.Node], circuit
 	DeclareExterns(scope, externs...)
 	// Register modules
 	for _, m := range circuit.Modules {
-		scope.Declare(m.Name, extractSelector(nil))
+		scope.Declare(m.Name, extractSelector(nil), true)
 	}
 	// Construct resolver
 	r := resolver{srcmap}
@@ -107,7 +107,7 @@ func (r *resolver) initialiseDeclarationsInModule(scope *ModuleScope, decls []as
 			// Attempt to declare the perspective.  Note, we don't need to check
 			// whether or not this succeeds here as, if it fails, this will be
 			// caught below.
-			scope.Declare(def.Name(), extractSelector(def.Selector))
+			scope.Declare(def.Name(), extractSelector(def.Selector), true)
 		}
 	}
 	// Second, initialise all symbol (e.g. column) definitions.

--- a/pkg/corset/compiler/translator.go
+++ b/pkg/corset/compiler/translator.go
@@ -103,7 +103,7 @@ func (t *translator) translateModules(circuit *ast.Circuit) {
 // one MIR module.
 func (t *translator) translateModule(name string) {
 	// Always include module with base multiplier (even if empty).
-	t.schema.NewModule(name, 1, true, false)
+	t.schema.NewModule(name, 1, true, true, false)
 	// Initialise the corresponding family of MIR modules.
 	for _, regIndex := range t.env.RegistersOf(name) {
 		var (
@@ -115,7 +115,7 @@ func (t *translator) translateModule(name string) {
 		// Check whether module created this already (or not)
 		if _, ok := t.schema.HasModule(moduleName); !ok {
 			// No, therefore create new module.
-			t.schema.NewModule(moduleName, regInfo.Context.LengthMultiplier(), true, false)
+			t.schema.NewModule(moduleName, regInfo.Context.LengthMultiplier(), true, true, false)
 		}
 	}
 	// Translate all corset registers in this module into MIR registers across

--- a/pkg/corset/source_map.go
+++ b/pkg/corset/source_map.go
@@ -66,6 +66,8 @@ type Enumeration map[uint64]string
 type SourceModule struct {
 	// Name of this submodule.
 	Name string
+	// Public indicates whether or not this module is externally visible or not.
+	Public bool
 	// Synthetic indicates whether or not this module was automatically
 	// generated or not.
 	Synthetic bool

--- a/pkg/ir/air/gadgets/bitwidth.go
+++ b/pkg/ir/air/gadgets/bitwidth.go
@@ -191,7 +191,7 @@ func (p *BitwidthGadget[F]) applyRecursiveBitwidthGadget(ref sc.RegisterRef, bit
 func (p *BitwidthGadget[F]) constructTypeProof(handle string, bitwidth uint) sc.ModuleId {
 	var (
 		// Create new module for this type proof
-		mid    = p.schema.NewModule(handle, 1, false, true)
+		mid    = p.schema.NewModule(handle, 1, false, false, true)
 		module = p.schema.Module(mid)
 		// Determine limb widths.
 		loWidth, hiWidth = determineLimbSplit(bitwidth)

--- a/pkg/ir/mir/concretize.go
+++ b/pkg/ir/mir/concretize.go
@@ -58,7 +58,7 @@ func concretizeModule[F1 Element[F1], F2 Element[F2]](m Module[F1]) Module[F2] {
 		constraints = concretizeConstraints[F1, F2](m.RawConstraints())
 	)
 	// Initialise new module
-	r = r.Init(m.Name(), m.LengthMultiplier(), m.AllowPadding(), m.IsSynthetic())
+	r = r.Init(m.Name(), m.LengthMultiplier(), m.AllowPadding(), m.IsPublic(), m.IsSynthetic())
 	// Add concretized components
 	r.AddRegisters(m.Registers()...)
 	r.AddAssignments(assignments...)

--- a/pkg/ir/mir/lower.go
+++ b/pkg/ir/mir/lower.go
@@ -58,7 +58,7 @@ func NewAirLowering[F field.Element[F]](mirSchema Schema[F]) AirLowering[F] {
 	)
 	// Initialise AIR modules
 	for _, m := range mirSchema.RawModules() {
-		airSchema.NewModule(m.Name(), m.LengthMultiplier(), m.AllowPadding(), m.IsSynthetic())
+		airSchema.NewModule(m.Name(), m.LengthMultiplier(), m.AllowPadding(), m.IsPublic(), m.IsSynthetic())
 	}
 	//
 	return AirLowering[F]{

--- a/pkg/schema/module.go
+++ b/pkg/schema/module.go
@@ -38,10 +38,24 @@ type ModuleMap[T RegisterMap] interface {
 // ModuleId abstracts the notion of a "module identifier"
 type ModuleId = uint
 
+// ModuleView provides access to certain structural information about a module.
+type ModuleView interface {
+	RegisterMap
+	// Module name
+	Name() string
+	// IsPublic indicates whether or not this module is externally visible.
+	IsPublic() bool
+	// IsSynthetic modules are generated during compilation, rather than being
+	// provided by the user.
+	IsSynthetic() bool
+	// Returns the number of registers in this module.
+	Width() uint
+}
+
 // Module represents a "table" within a schema which contains zero or more rows
 // for a given set of registers.
 type Module[F any] interface {
-	RegisterMap
+	ModuleView
 	// Assignments returns an iterator over the assignments of this module.
 	// These are the computations used to assign values to all computed columns
 	// in this module.
@@ -53,21 +67,14 @@ type Module[F any] interface {
 	// strictly necessary, these can highlight otherwise hidden problems as an aid
 	// to debugging.
 	Consistent(fieldWidth uint, schema AnySchema[F]) []error
+	// AllowPadding determines the amount of initial padding a module expects.
+	AllowPadding() bool
 	// Identifies the length multiplier for this module.  For every trace, the
 	// height of the corresponding module must be a multiple of this.  This is
 	// used specifically to support interleaving constraints.
 	LengthMultiplier() uint
-	// AllowPadding determines the amount of initial padding a module expects.
-	AllowPadding() bool
-	// Module name
-	Name() string
-	// IsSynthetic modules are generated during compilation, rather than being
-	// provided by the user.
-	IsSynthetic() bool
 	// Substitute any matchined labelled constants within this module
 	Substitute(map[string]F)
-	// Returns the number of registers in this module.
-	Width() uint
 }
 
 // FieldAgnosticModule captures the notion of a module which is agnostic to the
@@ -92,6 +99,7 @@ type Table[F any, C Constraint[F]] struct {
 	name        string
 	multiplier  uint
 	padding     bool
+	public      bool
 	synthetic   bool
 	registers   []Register
 	constraints []C
@@ -99,13 +107,13 @@ type Table[F any, C Constraint[F]] struct {
 }
 
 // NewTable constructs a table module with the given registers and constraints.
-func NewTable[F any, C Constraint[F]](name string, multiplier uint, padding, synthetic bool) *Table[F, C] {
-	return &Table[F, C]{name, multiplier, padding, synthetic, nil, nil, nil}
+func NewTable[F any, C Constraint[F]](name string, multiplier uint, padding, public, synthetic bool) *Table[F, C] {
+	return &Table[F, C]{name, multiplier, padding, public, synthetic, nil, nil, nil}
 }
 
 // Init implementation for ir.InitModule interface.
-func (p *Table[F, C]) Init(name string, multiplier uint, padding, synthetic bool) *Table[F, C] {
-	return &Table[F, C]{name, multiplier, padding, synthetic, nil, nil, nil}
+func (p *Table[F, C]) Init(name string, multiplier uint, padding, public, synthetic bool) *Table[F, C] {
+	return &Table[F, C]{name, multiplier, padding, public, synthetic, nil, nil, nil}
 }
 
 // Assignments provides access to those assignments defined as part of this
@@ -167,6 +175,11 @@ func (p *Table[F, C]) LengthMultiplier() uint {
 // initial padding row, and allow defensive padding as well.
 func (p *Table[F, C]) AllowPadding() bool {
 	return p.padding
+}
+
+// IsPublic identifies whether or not this module is externally visible.
+func (p *Table[F, C]) IsPublic() bool {
+	return p.public
 }
 
 // IsSynthetic modules are generated during compilation, rather than being
@@ -251,7 +264,7 @@ func (p *Table[F, C]) Subdivide(mapping LimbsMap) *Table[F, C] {
 		}
 	}
 	//
-	return &Table[F, C]{p.name, p.multiplier, p.padding, p.synthetic, registers, constraints, assignments}
+	return &Table[F, C]{p.name, p.multiplier, p.padding, p.public, p.synthetic, registers, constraints, assignments}
 }
 
 // ============================================================================

--- a/pkg/test/assembly_unit_test.go
+++ b/pkg/test/assembly_unit_test.go
@@ -24,7 +24,7 @@ func Test_AsmUnit_BitShift(t *testing.T) {
 }
 
 func Test_AsmUnit_ByteShift(t *testing.T) {
-	util.CheckWithFields(t, false, "asm/unit/byte_shift", util.ASM_MAX_PADDING, sc.BLS12_377)
+	util.CheckWithFields(t, false, "asm/unit/byte_shift", util.ASM_MAX_PADDING, sc.BLS12_377, sc.KOALABEAR_16)
 }
 
 func Test_AsmUnit_Dec4(t *testing.T) {
@@ -32,11 +32,11 @@ func Test_AsmUnit_Dec4(t *testing.T) {
 }
 
 func Test_AsmUnit_Dec251(t *testing.T) {
-	util.CheckWithFields(t, false, "asm/unit/dec251", util.ASM_MAX_PADDING, sc.BLS12_377)
+	util.CheckWithFields(t, false, "asm/unit/dec251", util.ASM_MAX_PADDING, sc.BLS12_377, sc.KOALABEAR_16)
 }
 
 func Test_AsmUnit_Diamond(t *testing.T) {
-	util.CheckWithFields(t, false, "asm/unit/diamond", util.ASM_MAX_PADDING, sc.BLS12_377)
+	util.CheckWithFields(t, false, "asm/unit/diamond", util.ASM_MAX_PADDING, sc.BLS12_377, sc.KOALABEAR_16)
 }
 
 func Test_AsmUnit_ParseNonDecimal(t *testing.T) {
@@ -44,7 +44,8 @@ func Test_AsmUnit_ParseNonDecimal(t *testing.T) {
 }
 
 func Test_AsmUnit_Counter(t *testing.T) {
-	util.CheckWithFields(t, false, "asm/unit/counter", util.ASM_MAX_PADDING, sc.BLS12_377, sc.GF_8209, sc.GF_251)
+	util.CheckWithFields(t, false, "asm/unit/counter", util.ASM_MAX_PADDING, sc.BLS12_377, sc.KOALABEAR_16, sc.GF_8209,
+		sc.GF_251)
 }
 
 func Test_AsmUnit_Counter256(t *testing.T) {
@@ -87,7 +88,8 @@ func Test_AsmUnit_SlowPow(t *testing.T) {
 }
 
 func Test_AsmUnit_Sub(t *testing.T) {
-	util.CheckWithFields(t, false, "asm/unit/sub", util.ASM_MAX_PADDING, sc.BLS12_377, sc.GF_8209, sc.GF_251)
+	util.CheckWithFields(t, false, "asm/unit/sub", util.ASM_MAX_PADDING, sc.BLS12_377, sc.KOALABEAR_16, sc.GF_8209,
+		sc.GF_251)
 }
 
 func Test_AsmUnit_RecPow(t *testing.T) {

--- a/pkg/test/assembly_util_test.go
+++ b/pkg/test/assembly_util_test.go
@@ -36,11 +36,11 @@ func Test_AsmUtil_FillBytes(t *testing.T) {
 }
 
 func Test_AsmUtil_Log2(t *testing.T) {
-	util.CheckWithFields(t, false, "asm/util/log2", util.ASM_MAX_PADDING, sc.BLS12_377)
+	util.CheckWithFields(t, false, "asm/util/log2", util.ASM_MAX_PADDING, sc.BLS12_377, sc.KOALABEAR_16)
 }
 
 func Test_AsmUtil_Log256(t *testing.T) {
-	util.CheckWithFields(t, false, "asm/util/log256", util.ASM_MAX_PADDING, sc.BLS12_377)
+	util.CheckWithFields(t, false, "asm/util/log256", util.ASM_MAX_PADDING, sc.BLS12_377, sc.KOALABEAR_16)
 }
 func Test_AsmUtil_Min(t *testing.T) {
 	util.CheckWithFields(t, false, "asm/util/min", util.ASM_MAX_PADDING, sc.BLS12_377, sc.KOALABEAR_16)


### PR DESCRIPTION
This adds support for a "pub" modifier on functions which is used to specify whether or not the function is "externally visible".  This has a somewhat odd meaning: non-externally visible functions are not available in the generated Trace.java interface, nor are they initially visible in the inspector.  At this time, that is their only meaning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `pub` modifier to functions, propagates visibility through IO/IR/AIR/schema and tooling, and shows/exports only public modules in Java generation, source-map debug, and inspector; bumps binfile minor version.
> 
> - **Assembler/Parsing**:
>   - Add `pub` keyword; support `pub fn` and record visibility in `io.Function`.
> - **IO/Function & Pipeline**:
>   - `Function` gains `public` flag; `NewFunction(...)` signature updated and used across lowering, vectorization, concretization.
> - **Schema/IR/AIR**:
>   - Introduce `ModuleView` with `IsPublic`; `Table`/builders carry `public` flag; all builders/init paths (`SchemaBuilder`, MIR/AIR lower/concretize) propagate `IsPublic`.
>   - Program/module wrappers and MIR module init honor `fn.IsPublic()`.
> - **Compiler**:
>   - `ModuleScope` tracks `public`; extern/resolve updated to use `ModuleView`; source map construction sets `SourceModule.Public`.
> - **Source Map & Tooling**:
>   - `SourceModule` gains `Public`; debug prints `pub`; union preserves `Public`.
>   - Java class/interface generators and inspector now include only public, non-virtual submodules.
> - **Binfile**:
>   - Bump minor version to `v8.2`.
> - **Tests**:
>   - Expand field coverage in several ASM tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2318075ffa7d8e4bc206ceb6447171333ad570bc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->