### PR TITLE
fix: linking call arguments

### DIFF
--- a/pkg/asm/assembler/linker.go
+++ b/pkg/asm/assembler/linker.go
@@ -198,6 +198,8 @@ func (p *Linker) linkInstruction(insn macro.Instruction, buses map[uint]io.Bus) 
 		}
 		// allocate & link bus
 		insn.Link(buses[busId])
+		//
+		return p.linkExprs(insn.Sources)
 	case *macro.IfGoto:
 		if insn.Label != "" {
 			deats, ok := p.constmap[insn.Label]

--- a/pkg/test/assembly_invalid_test.go
+++ b/pkg/test/assembly_invalid_test.go
@@ -41,6 +41,9 @@ func Test_AsmInvalid_Basic_05(t *testing.T) {
 func Test_AsmInvalid_Basic_06(t *testing.T) {
 	checkAsmInvalid(t, "asm/invalid/basic_06")
 }
+func Test_AsmInvalid_Basic_07(t *testing.T) {
+	checkAsmInvalid(t, "asm/invalid/basic_07")
+}
 
 // ===================================================================
 // Flow Tests

--- a/testdata/asm/invalid/basic_07.zkasm
+++ b/testdata/asm/invalid/basic_07.zkasm
@@ -1,0 +1,10 @@
+;;error:3:12-16:unknown register or constant
+fn f(arg u256) -> (res u256) {
+   res = g(arg1)
+   return
+}
+
+fn g(arg u256) -> (res u256) {
+   res = 0
+   return
+}


### PR DESCRIPTION
Previously, call arguments were not linked and, hence, this meant no checking was done on them.  Furthermore, it meant constants would fail to be substituted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Linker now resolves and validates `macro.Call` argument expressions; adds failing test for unknown argument reference.
> 
> - **Assembler**:
>   - Linker now processes call argument expressions via `linkExprs` in `linkInstruction` for `macro.Call`, enabling constant substitution and validation of call args.
> - **Tests**:
>   - Add `Test_AsmInvalid_Basic_07` and `testdata/asm/invalid/basic_07.zkasm` expecting "unknown register or constant" when using an undefined call argument.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 49e5c9f85a68da0de2f39fd8deef800c3faa73ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->