### PR TITLE
feat: tweak implementation of bit_xoan

### DIFF
--- a/testdata/asm/util/bit_xoan.zkasm
+++ b/testdata/asm/util/bit_xoan.zkasm
@@ -109,8 +109,8 @@ and_call:
     return
 not_call:
     ;; we only use ARGUMENT_1
-    res_hi = arg1_hi == 1 ? 0 : 1
-    res_lo = arg1_lo == 1 ? 0 : 1
+    res_hi = 1 - arg1_hi
+    res_lo = 1 - arg1_lo
     RES = ( res_hi * 2 ) + res_lo
     return
 }


### PR DESCRIPTION
This puts in place a minor tweak for the bitwise not case of the bit_xoan function.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rewrites the BIT_NOT case in `bit_xoan_u2` to compute `res = 1 - arg` instead of using conditional checks.
> 
> - **ASM util**:
>   - **`testdata/asm/util/bit_xoan.zkasm`**: Simplifies `not_call` in `bit_xoan_u2` by replacing conditional inversion with arithmetic (`res_hi = 1 - arg1_hi`, `res_lo = 1 - arg1_lo`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2015d9d7708ea9fcd3c9ef8ec3dd89e2313f0989. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->