### PR TITLE
feat: support inspector scan over perspective columns

### DIFF
--- a/pkg/cmd/inspector/module_state.go
+++ b/pkg/cmd/inspector/module_state.go
@@ -97,7 +97,7 @@ func (p *ModuleState) gotoRow(ncol uint) uint {
 	if col != ncol {
 		// Update history
 		rowOffsetStr := fmt.Sprintf("%d", ncol)
-		p.targetRowHistory = history_append(p.targetRowHistory, rowOffsetStr)
+		p.targetRowHistory = historyAppend(p.targetRowHistory, rowOffsetStr)
 	}
 	// failed
 	return row
@@ -114,7 +114,7 @@ func (p *ModuleState) applyColumnFilter(filter SourceColumnFilter, history bool)
 		//
 		if history {
 			regex_string := filter.Regex.String()
-			p.columnFilterHistory = history_append(p.columnFilterHistory, regex_string)
+			p.columnFilterHistory = historyAppend(p.columnFilterHistory, regex_string)
 		}
 	}
 }
@@ -123,18 +123,9 @@ func (p *ModuleState) applyColumnFilter(filter SourceColumnFilter, history bool)
 // trace, looking for the first row where the query holds.
 func (p *ModuleState) matchQuery(col uint, forwards bool, query *Query) termio.FormattedText {
 	var (
-		mapping  = p.view.Data().Mapping()
 		width, _ = p.view.Data().Dimensions()
 		// Construct query environment
-		env = func(col string, row uint) big.Int {
-			id, ok := mapping.HasRegister(col)
-			//
-			if !ok {
-				panic(fmt.Sprintf("unknown column \"%s\"", col))
-			}
-			//
-			return p.view.Data().DataOf(id).Get(row)
-		}
+		env = buildEnvironment(p.view.Data())
 		// Direction text
 		dir string
 		// Determine current cursor offset
@@ -147,13 +138,13 @@ func (p *ModuleState) matchQuery(col uint, forwards bool, query *Query) termio.F
 		dir = "backwards"
 	}
 	// Always update history
-	p.scanHistory = history_append(p.scanHistory, query.String())
+	p.scanHistory = historyAppend(p.scanHistory, query.String())
 	p.lastQuery = query
 	// evaluate forward
 	for i := col; i < width; {
-		val := query.Eval(i, env)
+		val, active := query.Eval(i, env)
 		//
-		if val.Cmp(biZero) == 0 {
+		if active && val.Cmp(biZero) == 0 {
 			p.view.Goto(i, row)
 			msg := fmt.Sprintf("%s from row %d, matched row %d", dir, col, i)
 
@@ -175,9 +166,43 @@ func (p *ModuleState) matchQuery(col uint, forwards bool, query *Query) termio.F
 // History append will append a given item to the end of the history.  However,
 // if that item already existed in the history, then that is removed.  This is
 // to avoid duplicates in the history.
-func history_append[T comparable](history []T, item T) []T {
+func historyAppend[T comparable](history []T, item T) []T {
 	// Remove previous entry (if applicable)
 	history = array.RemoveMatching(history, func(ith T) bool { return ith == item })
 	// Add item to end
 	return append(history, item)
+}
+
+// Build an environment suitable for querying from a given module's data.
+func buildEnvironment(data view.ModuleData) QueryEnv {
+	var (
+		mapping = data.Mapping()
+	)
+	//
+	return func(col string, row uint) (big.Int, bool) {
+		var (
+			id register.Id
+			ok bool
+		)
+		// Look in the register mapping first
+		if id, ok = mapping.HasRegister(col); !ok {
+			var (
+				srcId  view.SourceColumnId
+				srcCol view.SourceColumn
+			)
+			// Failed, so try for a source column.
+			if srcId, ok = data.HasSourceColumn(col); !ok {
+				// give up
+				panic(fmt.Sprintf("unknown column \"%s\"", col))
+			}
+			// Extract source column
+			srcCol = data.SourceColumn(srcId)
+			// Extract underlying register id
+			id = srcCol.Register
+			// Check whether source column actually active
+			ok = data.IsActive(srcCol, row)
+		}
+		//
+		return data.DataOf(id).Get(row), ok
+	}
 }

--- a/pkg/cmd/inspector/nav_mode.go
+++ b/pkg/cmd/inspector/nav_mode.go
@@ -151,10 +151,14 @@ func (p *NavigationMode) scanInputMode(parent *Inspector) Mode {
 		history      = parent.currentView().scanHistory
 		historyIndex = uint(len(history))
 		columns      set.SortedSet[string]
-		mapping      = parent.CurrentModule().view.Data().Mapping()
+		data         = parent.CurrentModule().view.Data()
 	)
 	// Identify available columns
-	for _, c := range mapping.Registers() {
+	for _, c := range data.Mapping().Registers() {
+		columns.Insert(c.Name)
+	}
+	//
+	for _, c := range data.SourceColumns() {
 		columns.Insert(c.Name)
 	}
 	// Construct environment

--- a/pkg/cmd/view/module_data.go
+++ b/pkg/cmd/view/module_data.go
@@ -69,10 +69,15 @@ type ModuleData interface {
 	Mapping() register.LimbsMap
 	// Name returns the name of the given module
 	Name() string
+	// HasSourceColumn is useful for querying whether a source column exists
+	// with the given name.
+	HasSourceColumn(name string) (SourceColumnId, bool)
 	// SourceColumn returns the source column associated with a given id.
 	SourceColumn(col SourceColumnId) SourceColumn
 	// SourceColumnOf returns the source column associated with a given name.
 	SourceColumnOf(name string) SourceColumn
+	// SourceColumns returns the set of all known source columns.
+	SourceColumns() []SourceColumn
 }
 
 // ============================================================================
@@ -145,10 +150,27 @@ func (p *moduleData[F]) IsActive(col SourceColumn, row uint) bool {
 	return val.BitLen() != 0
 }
 
+// SourceColumns returns the set of all known source columns.
+func (p *moduleData[F]) SourceColumns() []SourceColumn {
+	return p.rows
+}
+
 // SourceColumn returns the source column associated with the given source
 // column id.
 func (p *moduleData[F]) SourceColumn(col SourceColumnId) SourceColumn {
 	return p.rows[col.Unwrap()]
+}
+
+// SourceColumnOf returns the source column associated with the given source
+// column name.  This will panic if the given source column does not exist.
+func (p *moduleData[F]) HasSourceColumn(name string) (SourceColumnId, bool) {
+	for i, col := range p.rows {
+		if col.Name == name {
+			return register.NewId(uint(i)), true
+		}
+	}
+
+	return register.UnusedId(), false
 }
 
 // SourceColumnOf returns the source column associated with the given source

--- a/pkg/util/source/bexp/parser.go
+++ b/pkg/util/source/bexp/parser.go
@@ -148,6 +148,7 @@ var identifierStart lex.Scanner[rune] = lex.Or(
 var identifierRest lex.Scanner[rune] = lex.Many(lex.Or(
 	lex.Unit('_'),
 	lex.Unit('\''),
+	lex.Unit('/'),
 	lex.Unit('$'),
 	lex.Within('0', '9'),
 	lex.Within('a', 'z'),


### PR DESCRIPTION
This updates the inspector scan command to fully support perspective columns.  That is, you can use the actual name for a perspective column (i.e. rather than the underlying register name).  Furthermore, the scan will only match rows where the perspective is active.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Inspector scan can now reference perspective/source columns by name and only matches when those columns are active; adds view helpers and parser tweak.
> 
> - **Inspector**:
>   - Refactor query environment to resolve both `register` and `source` columns; add `buildEnvironment` and use in `matchQuery`.
>   - Make `QueryEnv` and `Query.Eval` return `(big.Int, bool)` and propagate activity through eval helpers; scans only match when columns are active.
>   - Scan input now includes both register and source column names for validation/autocomplete.
>   - Rename `history_append` to `historyAppend` and update call sites.
> - **View**:
>   - Extend `ModuleData` with `HasSourceColumn` and `SourceColumns`; implement in `module_data`.
> - **Parser**:
>   - Permit `/` in identifiers to support additional column naming.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bea93ad9bcd922d14cf2b7f0f0e974d32494c6f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->