### PR TITLE
feat: enable GF_8209 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,18 +9,19 @@ jobs:
     strategy:
       matrix:
         test: [asm-bench,asm-racer,asm-util,asm-unit,corset-bench,corset-racer,corset-test,unit-test]
-        field: [BLS12_377,KOALABEAR_16]
+        field: [BLS12_377,KOALABEAR_16,GF_8209]
         exclude:
-          - test: asm-bench
-            field: KOALABEAR_16
-          - test: corset-bench
-            field: KOALABEAR_16
-          - test: unit-test
-            field: KOALABEAR_16
-          - test: asm-racer
-            field: KOALABEAR_16
-          - test: corset-racer
-            field: KOALABEAR_16
+          - { field: KOALABEAR_16, test: asm-bench }
+          - { field: KOALABEAR_16, test: asm-racer }
+          - { field: KOALABEAR_16, test: corset-bench }
+          - { field: KOALABEAR_16, test: corset-racer }
+          - { field: KOALABEAR_16, test: unit-test }
+          - { field: GF_8209,      test: asm-bench }
+          - { field: GF_8209,      test: asm-racer }
+          - { field: GF_8209,      test: asm-util }
+          - { field: GF_8209,      test: corset-bench }
+          - { field: GF_8209,      test: corset-racer }
+          - { field: GF_8209,      test: unit-test }
       fail-fast: false
     runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-large
     steps:

--- a/pkg/test/corset_bench_test.go
+++ b/pkg/test/corset_bench_test.go
@@ -16,116 +16,117 @@ import (
 	"testing"
 
 	"github.com/consensys/go-corset/pkg/test/util"
+	"github.com/consensys/go-corset/pkg/util/field"
 )
 
 func Test_Bench_Counter(t *testing.T) {
-	Check(t, true, "corset/bench/counter")
+	util.CheckCorset(t, true, "corset/bench/counter", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_ByteDecomp(t *testing.T) {
-	Check(t, true, "corset/bench/byte_decomposition")
+	util.CheckCorset(t, true, "corset/bench/byte_decomposition", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_BitDecomp(t *testing.T) {
-	Check(t, true, "corset/bench/bit_decomposition")
+	util.CheckCorset(t, true, "corset/bench/bit_decomposition", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_BitShift(t *testing.T) {
-	Check(t, true, "corset/bench/bit_shift")
+	util.CheckCorset(t, true, "corset/bench/bit_shift", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_ByteSorting(t *testing.T) {
-	Check(t, true, "corset/bench/byte_sorting")
+	util.CheckCorset(t, true, "corset/bench/byte_sorting", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_WordSorting(t *testing.T) {
-	Check(t, true, "corset/bench/word_sorting")
+	util.CheckCorset(t, true, "corset/bench/word_sorting", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_Multiplier(t *testing.T) {
-	Check(t, false, "corset/bench/multiplier")
+	util.CheckCorset(t, false, "corset/bench/multiplier", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_Memory16u8(t *testing.T) {
-	Check(t, true, "corset/bench/memory16u8")
+	util.CheckCorset(t, true, "corset/bench/memory16u8", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_Memory32u32(t *testing.T) {
-	util.Check(t, true, "corset/bench/memory32u32")
+	util.CheckCorset(t, true, "corset/bench/memory32u32", field.BLS12_377)
 }
 
 func Test_Bench_Memory32u64(t *testing.T) {
-	util.Check(t, true, "corset/bench/memory32u64")
+	util.CheckCorset(t, true, "corset/bench/memory32u64", field.BLS12_377)
 }
 func Test_Bench_Adder(t *testing.T) {
-	Check(t, true, "corset/bench/adder")
+	util.CheckCorset(t, true, "corset/bench/adder", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_Fields(t *testing.T) {
-	Check(t, true, "corset/bench/fields")
+	util.CheckCorset(t, true, "corset/bench/fields", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_Add(t *testing.T) {
-	util.Check(t, true, "corset/bench/add")
+	util.CheckCorset(t, true, "corset/bench/add", field.BLS12_377)
 }
 
 func Test_Bench_BinStatic(t *testing.T) {
-	Check(t, true, "corset/bench/bin-static")
+	util.CheckCorset(t, true, "corset/bench/bin-static", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_Bin(t *testing.T) {
-	util.Check(t, true, "corset/bench/bin")
+	util.CheckCorset(t, true, "corset/bench/bin", field.BLS12_377)
 }
 
 func Test_Bench_Wcp(t *testing.T) {
-	util.Check(t, true, "corset/bench/wcp")
+	util.CheckCorset(t, true, "corset/bench/wcp", field.BLS12_377)
 }
 
 func Test_Bench_Mxp(t *testing.T) {
-	util.Check(t, true, "corset/bench/mxp")
+	util.CheckCorset(t, true, "corset/bench/mxp", field.BLS12_377)
 }
 
 func Test_Bench_Shf(t *testing.T) {
-	Check(t, true, "corset/bench/shf")
+	util.CheckCorset(t, true, "corset/bench/shf", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_Euc(t *testing.T) {
-	Check(t, true, "corset/bench/euc")
+	util.CheckCorset(t, true, "corset/bench/euc", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_Oob(t *testing.T) {
-	util.Check(t, true, "corset/bench/oob")
+	util.CheckCorset(t, true, "corset/bench/oob", field.BLS12_377)
 }
 
 func Test_Bench_Stp(t *testing.T) {
-	Check(t, true, "corset/bench/stp")
+	util.CheckCorset(t, true, "corset/bench/stp", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_Mmio(t *testing.T) {
-	util.Check(t, true, "corset/bench/mmio")
+	util.CheckCorset(t, true, "corset/bench/mmio", field.BLS12_377)
 }
 
 func Test_Bench_Rom(t *testing.T) {
-	Check(t, true, "corset/bench/rom")
+	util.CheckCorset(t, true, "corset/bench/rom", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_Gas(t *testing.T) {
-	Check(t, true, "corset/bench/gas")
+	util.CheckCorset(t, true, "corset/bench/gas", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_Exp(t *testing.T) {
-	Check(t, true, "corset/bench/exp")
+	util.CheckCorset(t, true, "corset/bench/exp", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_Mul(t *testing.T) {
-	Check(t, true, "corset/bench/mul")
+	util.CheckCorset(t, true, "corset/bench/mul", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Bench_Mod(t *testing.T) {
-	Check(t, true, "corset/bench/mod")
+	util.CheckCorset(t, true, "corset/bench/mod", field.BLS12_377, field.KOALABEAR_16)
 }
 
 //#834
 // func Test_Bench_TicTacToe(t *testing.T) {
-// 	util.Check(t, true, "corset/bench/tic_tac_toe")
+// 	util.Check(t, true, "corset/bench/tic_tac_toe", field.BLS12_377, field.KOALABEAR_16)
 // }

--- a/pkg/test/corset_valid_test.go
+++ b/pkg/test/corset_valid_test.go
@@ -19,163 +19,158 @@ import (
 	"github.com/consensys/go-corset/pkg/util/field"
 )
 
-func Check(t *testing.T, stdlib bool, test string) {
-	util.CheckWithFields(t, stdlib, test, util.CORSET_MAX_PADDING,
-		field.BLS12_377,
-		field.KOALABEAR_16,
-		//field.GF_8209,
-	)
-}
-
 // ===================================================================
 // Basic Tests
 // ===================================================================
 
 func Test_Valid_Basic_01(t *testing.T) {
-	Check(t, false, "corset/valid/basic_01")
+	util.CheckCorset(t, false, "corset/valid/basic_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Basic_02(t *testing.T) {
-	Check(t, false, "corset/valid/basic_02")
+	util.CheckCorset(t, false, "corset/valid/basic_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Basic_03(t *testing.T) {
-	Check(t, false, "corset/valid/basic_03")
+	util.CheckCorset(t, false, "corset/valid/basic_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Basic_04(t *testing.T) {
-	Check(t, false, "corset/valid/basic_04")
+	util.CheckCorset(t, false, "corset/valid/basic_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // Ignored because uses a negative constant.
 //
 // func Test_Valid_Basic_05(t *testing.T) {
-// 	util.Check(t, false, "corset/valid/basic_05")
+// 	util.Check(t, false, "corset/valid/basic_05", field.BLS12_377, field.KOALABEAR_16)
 // }
 
 func Test_Valid_Basic_06(t *testing.T) {
-	Check(t, false, "corset/valid/basic_06")
+	util.CheckCorset(t, false, "corset/valid/basic_06", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Basic_07(t *testing.T) {
-	Check(t, false, "corset/valid/basic_07")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/basic_07", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Basic_08(t *testing.T) {
-	Check(t, false, "corset/valid/basic_08")
+	util.CheckCorset(t, false, "corset/valid/basic_08", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Basic_09(t *testing.T) {
-	Check(t, false, "corset/valid/basic_09")
+	util.CheckCorset(t, false, "corset/valid/basic_09", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Basic_10(t *testing.T) {
-	Check(t, false, "corset/valid/basic_10")
+	util.CheckCorset(t, false, "corset/valid/basic_10", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Basic_11(t *testing.T) {
-	Check(t, false, "corset/valid/basic_11")
+	util.CheckCorset(t, false, "corset/valid/basic_11", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 func Test_Valid_Basic_12(t *testing.T) {
-	Check(t, false, "corset/valid/basic_12")
+	util.CheckCorset(t, false, "corset/valid/basic_12", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 func Test_Valid_Basic_13(t *testing.T) {
-	Check(t, false, "corset/valid/basic_13")
+	util.CheckCorset(t, false, "corset/valid/basic_13", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 func Test_Valid_Basic_14(t *testing.T) {
-	Check(t, false, "corset/valid/basic_14")
+	util.CheckCorset(t, false, "corset/valid/basic_14", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 func Test_Valid_Basic_15(t *testing.T) {
-	Check(t, false, "corset/valid/basic_15")
+	util.CheckCorset(t, false, "corset/valid/basic_15", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // ===================================================================
 // Constants Tests
 // ===================================================================
 func Test_Valid_Constant_01(t *testing.T) {
-	Check(t, false, "corset/valid/constant_01")
+	util.CheckCorset(t, false, "corset/valid/constant_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Constant_02(t *testing.T) {
-	Check(t, false, "corset/valid/constant_02")
+	util.CheckCorset(t, false, "corset/valid/constant_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Constant_03(t *testing.T) {
-	Check(t, false, "corset/valid/constant_03")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/constant_03", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Constant_04(t *testing.T) {
-	Check(t, false, "corset/valid/constant_04")
+	util.CheckCorset(t, false, "corset/valid/constant_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Constant_05(t *testing.T) {
-	Check(t, false, "corset/valid/constant_05")
+	util.CheckCorset(t, false, "corset/valid/constant_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Constant_06(t *testing.T) {
-	Check(t, false, "corset/valid/constant_06")
+	util.CheckCorset(t, false, "corset/valid/constant_06", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Constant_07(t *testing.T) {
-	Check(t, false, "corset/valid/constant_07")
+	util.CheckCorset(t, false, "corset/valid/constant_07", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Constant_08(t *testing.T) {
-	Check(t, false, "corset/valid/constant_08")
+	util.CheckCorset(t, false, "corset/valid/constant_08", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Constant_09(t *testing.T) {
-	Check(t, false, "corset/valid/constant_09")
+	util.CheckCorset(t, false, "corset/valid/constant_09", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Constant_10(t *testing.T) {
-	Check(t, false, "corset/valid/constant_10")
+	util.CheckCorset(t, false, "corset/valid/constant_10", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Constant_11(t *testing.T) {
-	Check(t, false, "corset/valid/constant_11")
+	util.CheckCorset(t, false, "corset/valid/constant_11", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Constant_12(t *testing.T) {
-	Check(t, false, "corset/valid/constant_12")
+	util.CheckCorset(t, false, "corset/valid/constant_12", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Constant_13(t *testing.T) {
-	Check(t, false, "corset/valid/constant_13")
+	util.CheckCorset(t, false, "corset/valid/constant_13", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Constant_14(t *testing.T) {
-	Check(t, false, "corset/valid/constant_14")
+	util.CheckCorset(t, false, "corset/valid/constant_14", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Constant_15(t *testing.T) {
-	Check(t, false, "corset/valid/constant_15")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/constant_15", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Constant_16(t *testing.T) {
-	Check(t, false, "corset/valid/constant_16")
+	util.CheckCorset(t, false, "corset/valid/constant_16", field.BLS12_377, field.KOALABEAR_16)
 }
 
 // ===================================================================
 // Alias Tests
 // ===================================================================
 func Test_Valid_Alias_01(t *testing.T) {
-	Check(t, false, "corset/valid/alias_01")
+	util.CheckCorset(t, false, "corset/valid/alias_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 func Test_Valid_Alias_02(t *testing.T) {
-	Check(t, false, "corset/valid/alias_02")
+	util.CheckCorset(t, false, "corset/valid/alias_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 func Test_Valid_Alias_03(t *testing.T) {
-	Check(t, false, "corset/valid/alias_03")
+	util.CheckCorset(t, false, "corset/valid/alias_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 func Test_Valid_Alias_04(t *testing.T) {
-	Check(t, false, "corset/valid/alias_04")
+	util.CheckCorset(t, false, "corset/valid/alias_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 func Test_Valid_Alias_05(t *testing.T) {
-	Check(t, false, "corset/valid/alias_05")
+	util.CheckCorset(t, false, "corset/valid/alias_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 func Test_Valid_Alias_06(t *testing.T) {
-	Check(t, false, "corset/valid/alias_06")
+	util.CheckCorset(t, false, "corset/valid/alias_06", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // ===================================================================
@@ -183,15 +178,15 @@ func Test_Valid_Alias_06(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Domain_01(t *testing.T) {
-	Check(t, false, "corset/valid/domain_01")
+	util.CheckCorset(t, false, "corset/valid/domain_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Domain_02(t *testing.T) {
-	Check(t, false, "corset/valid/domain_02")
+	util.CheckCorset(t, false, "corset/valid/domain_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Domain_03(t *testing.T) {
-	Check(t, false, "corset/valid/domain_03")
+	util.CheckCorset(t, false, "corset/valid/domain_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // ===================================================================
@@ -199,19 +194,20 @@ func Test_Valid_Domain_03(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Block_01(t *testing.T) {
-	Check(t, false, "corset/valid/block_01")
+	util.CheckCorset(t, false, "corset/valid/block_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Block_02(t *testing.T) {
-	Check(t, false, "corset/valid/block_02")
+	util.CheckCorset(t, false, "corset/valid/block_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Block_03(t *testing.T) {
-	Check(t, false, "corset/valid/block_03")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/block_03", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Block_04(t *testing.T) {
-	Check(t, false, "corset/valid/block_04")
+	util.CheckCorset(t, false, "corset/valid/block_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // ===================================================================
@@ -219,12 +215,12 @@ func Test_Valid_Block_04(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Logic_01(t *testing.T) {
-	Check(t, false, "corset/valid/logic_01")
+	util.CheckCorset(t, false, "corset/valid/logic_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Logic_02(t *testing.T) {
 	// Performance
-	Check(t, false, "corset/valid/logic_02")
+	util.CheckCorset(t, false, "corset/valid/logic_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // ===================================================================
@@ -232,18 +228,20 @@ func Test_Valid_Logic_02(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Property_01(t *testing.T) {
-	Check(t, false, "corset/valid/property_01")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/property_01", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Property_02(t *testing.T) {
-	Check(t, false, "corset/valid/property_02")
+	util.CheckCorset(t, false, "corset/valid/property_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Property_03(t *testing.T) {
-	Check(t, false, "corset/valid/property_03")
+	util.CheckCorset(t, false, "corset/valid/property_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 func Test_Valid_Property_04(t *testing.T) {
-	Check(t, false, "corset/valid/property_04")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/property_04", field.BLS12_377, field.KOALABEAR_16)
 }
 
 // ===================================================================
@@ -251,38 +249,38 @@ func Test_Valid_Property_04(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Shift_01(t *testing.T) {
-	Check(t, false, "corset/valid/shift_01")
+	util.CheckCorset(t, false, "corset/valid/shift_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Shift_02(t *testing.T) {
-	Check(t, false, "corset/valid/shift_02")
+	util.CheckCorset(t, false, "corset/valid/shift_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Shift_03(t *testing.T) {
-	Check(t, false, "corset/valid/shift_03")
+	util.CheckCorset(t, false, "corset/valid/shift_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Shift_04(t *testing.T) {
-	Check(t, false, "corset/valid/shift_04")
+	util.CheckCorset(t, false, "corset/valid/shift_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Shift_05(t *testing.T) {
-	Check(t, false, "corset/valid/shift_05")
+	util.CheckCorset(t, false, "corset/valid/shift_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Shift_06(t *testing.T) {
-	Check(t, false, "corset/valid/shift_06")
+	util.CheckCorset(t, false, "corset/valid/shift_06", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Shift_07(t *testing.T) {
-	Check(t, false, "corset/valid/shift_07")
+	util.CheckCorset(t, false, "corset/valid/shift_07", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Shift_08(t *testing.T) {
-	Check(t, false, "corset/valid/shift_08")
+	util.CheckCorset(t, false, "corset/valid/shift_08", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 func Test_Valid_Shift_09(t *testing.T) {
-	Check(t, false, "corset/valid/shift_09")
+	util.CheckCorset(t, false, "corset/valid/shift_09", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // ===================================================================
@@ -290,39 +288,39 @@ func Test_Valid_Shift_09(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Spillage_01(t *testing.T) {
-	Check(t, false, "corset/valid/spillage_01")
+	util.CheckCorset(t, false, "corset/valid/spillage_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Spillage_02(t *testing.T) {
-	Check(t, false, "corset/valid/spillage_02")
+	util.CheckCorset(t, false, "corset/valid/spillage_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Spillage_03(t *testing.T) {
-	Check(t, false, "corset/valid/spillage_03")
+	util.CheckCorset(t, false, "corset/valid/spillage_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Spillage_04(t *testing.T) {
-	Check(t, false, "corset/valid/spillage_04")
+	util.CheckCorset(t, false, "corset/valid/spillage_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Spillage_05(t *testing.T) {
-	Check(t, false, "corset/valid/spillage_05")
+	util.CheckCorset(t, false, "corset/valid/spillage_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Spillage_06(t *testing.T) {
-	Check(t, false, "corset/valid/spillage_06")
+	util.CheckCorset(t, false, "corset/valid/spillage_06", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Spillage_07(t *testing.T) {
-	Check(t, false, "corset/valid/spillage_07")
+	util.CheckCorset(t, false, "corset/valid/spillage_07", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Spillage_08(t *testing.T) {
-	Check(t, false, "corset/valid/spillage_08")
+	util.CheckCorset(t, false, "corset/valid/spillage_08", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Spillage_09(t *testing.T) {
-	Check(t, false, "corset/valid/spillage_09")
+	util.CheckCorset(t, false, "corset/valid/spillage_09", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // ===================================================================
@@ -330,31 +328,31 @@ func Test_Valid_Spillage_09(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Norm_01(t *testing.T) {
-	Check(t, false, "corset/valid/norm_01")
+	util.CheckCorset(t, false, "corset/valid/norm_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Norm_02(t *testing.T) {
-	Check(t, false, "corset/valid/norm_02")
+	util.CheckCorset(t, false, "corset/valid/norm_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Norm_03(t *testing.T) {
-	Check(t, false, "corset/valid/norm_03")
+	util.CheckCorset(t, false, "corset/valid/norm_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Norm_04(t *testing.T) {
-	Check(t, false, "corset/valid/norm_04")
+	util.CheckCorset(t, false, "corset/valid/norm_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Norm_05(t *testing.T) {
-	Check(t, false, "corset/valid/norm_05")
+	util.CheckCorset(t, false, "corset/valid/norm_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Norm_06(t *testing.T) {
-	Check(t, false, "corset/valid/norm_06")
+	util.CheckCorset(t, false, "corset/valid/norm_06", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Norm_07(t *testing.T) {
-	Check(t, false, "corset/valid/norm_07")
+	util.CheckCorset(t, false, "corset/valid/norm_07", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // ===================================================================
@@ -362,85 +360,85 @@ func Test_Valid_Norm_07(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_If_01(t *testing.T) {
-	Check(t, false, "corset/valid/if_01")
+	util.CheckCorset(t, false, "corset/valid/if_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_02(t *testing.T) {
-	Check(t, false, "corset/valid/if_02")
+	util.CheckCorset(t, false, "corset/valid/if_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_03(t *testing.T) {
-	Check(t, false, "corset/valid/if_03")
+	util.CheckCorset(t, false, "corset/valid/if_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_04(t *testing.T) {
-	Check(t, false, "corset/valid/if_04")
+	util.CheckCorset(t, false, "corset/valid/if_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_05(t *testing.T) {
-	Check(t, false, "corset/valid/if_05")
+	util.CheckCorset(t, false, "corset/valid/if_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_06(t *testing.T) {
-	Check(t, false, "corset/valid/if_06")
+	util.CheckCorset(t, false, "corset/valid/if_06", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_07(t *testing.T) {
-	Check(t, false, "corset/valid/if_07")
+	util.CheckCorset(t, false, "corset/valid/if_07", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_08(t *testing.T) {
-	Check(t, false, "corset/valid/if_08")
+	util.CheckCorset(t, false, "corset/valid/if_08", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_09(t *testing.T) {
-	Check(t, false, "corset/valid/if_09")
+	util.CheckCorset(t, false, "corset/valid/if_09", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_10(t *testing.T) {
-	Check(t, false, "corset/valid/if_10")
+	util.CheckCorset(t, false, "corset/valid/if_10", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_11(t *testing.T) {
-	Check(t, false, "corset/valid/if_11")
+	util.CheckCorset(t, false, "corset/valid/if_11", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 func Test_Valid_If_12(t *testing.T) {
-	Check(t, false, "corset/valid/if_12")
+	util.CheckCorset(t, false, "corset/valid/if_12", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 func Test_Valid_If_13(t *testing.T) {
-	Check(t, false, "corset/valid/if_13")
+	util.CheckCorset(t, false, "corset/valid/if_13", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_14(t *testing.T) {
-	Check(t, false, "corset/valid/if_14")
+	util.CheckCorset(t, false, "corset/valid/if_14", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_15(t *testing.T) {
-	Check(t, false, "corset/valid/if_15")
+	util.CheckCorset(t, false, "corset/valid/if_15", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_16(t *testing.T) {
-	Check(t, false, "corset/valid/if_16")
+	util.CheckCorset(t, false, "corset/valid/if_16", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_17(t *testing.T) {
-	Check(t, false, "corset/valid/if_17")
+	util.CheckCorset(t, false, "corset/valid/if_17", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_18(t *testing.T) {
-	Check(t, false, "corset/valid/if_18")
+	util.CheckCorset(t, false, "corset/valid/if_18", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_19(t *testing.T) {
-	Check(t, false, "corset/valid/if_19")
+	util.CheckCorset(t, false, "corset/valid/if_19", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_20(t *testing.T) {
-	Check(t, false, "corset/valid/if_20")
+	util.CheckCorset(t, false, "corset/valid/if_20", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_If_21(t *testing.T) {
-	Check(t, false, "corset/valid/if_21")
+	util.CheckCorset(t, false, "corset/valid/if_21", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // ===================================================================
@@ -448,23 +446,23 @@ func Test_Valid_If_21(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Guard_01(t *testing.T) {
-	Check(t, false, "corset/valid/guard_01")
+	util.CheckCorset(t, false, "corset/valid/guard_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Guard_02(t *testing.T) {
-	Check(t, false, "corset/valid/guard_02")
+	util.CheckCorset(t, false, "corset/valid/guard_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Guard_03(t *testing.T) {
-	Check(t, false, "corset/valid/guard_03")
+	util.CheckCorset(t, false, "corset/valid/guard_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Guard_04(t *testing.T) {
-	Check(t, false, "corset/valid/guard_04")
+	util.CheckCorset(t, false, "corset/valid/guard_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Guard_05(t *testing.T) {
-	Check(t, false, "corset/valid/guard_05")
+	util.CheckCorset(t, false, "corset/valid/guard_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // ===================================================================
@@ -472,55 +470,55 @@ func Test_Valid_Guard_05(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Type_01(t *testing.T) {
-	Check(t, false, "corset/valid/type_01")
+	util.CheckCorset(t, false, "corset/valid/type_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Type_02(t *testing.T) {
-	util.Check(t, false, "corset/valid/type_02")
+	util.CheckCorset(t, false, "corset/valid/type_02", field.BLS12_377)
 }
 
 func Test_Valid_Type_03(t *testing.T) {
-	Check(t, false, "corset/valid/type_03")
+	util.CheckCorset(t, false, "corset/valid/type_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Type_04(t *testing.T) {
-	Check(t, false, "corset/valid/type_04")
+	util.CheckCorset(t, false, "corset/valid/type_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Type_05(t *testing.T) {
-	Check(t, false, "corset/valid/type_05")
+	util.CheckCorset(t, false, "corset/valid/type_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Type_06(t *testing.T) {
-	Check(t, false, "corset/valid/type_06")
+	util.CheckCorset(t, false, "corset/valid/type_06", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Type_07(t *testing.T) {
-	Check(t, false, "corset/valid/type_07")
+	util.CheckCorset(t, false, "corset/valid/type_07", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Type_08(t *testing.T) {
-	Check(t, false, "corset/valid/type_08")
+	util.CheckCorset(t, false, "corset/valid/type_08", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Type_09(t *testing.T) {
-	Check(t, false, "corset/valid/type_09")
+	util.CheckCorset(t, false, "corset/valid/type_09", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Type_10(t *testing.T) {
-	Check(t, false, "corset/valid/type_10")
+	util.CheckCorset(t, false, "corset/valid/type_10", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Type_11(t *testing.T) {
-	util.Check(t, false, "corset/valid/type_11")
+	util.CheckCorset(t, false, "corset/valid/type_11", field.BLS12_377)
 }
 
 func Test_Valid_Type_12(t *testing.T) {
-	util.Check(t, false, "corset/valid/type_12")
+	util.CheckCorset(t, false, "corset/valid/type_12", field.BLS12_377)
 }
 
 func Test_Valid_Type_13(t *testing.T) {
-	util.Check(t, false, "corset/valid/type_13")
+	util.CheckCorset(t, false, "corset/valid/type_13", field.BLS12_377)
 }
 
 // ===================================================================
@@ -528,26 +526,28 @@ func Test_Valid_Type_13(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Range_01(t *testing.T) {
-	Check(t, false, "corset/valid/range_01")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/range_01", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Range_02(t *testing.T) {
-	util.Check(t, false, "corset/valid/range_02")
+	util.CheckCorset(t, false, "corset/valid/range_02", field.BLS12_377)
 }
 
 func Test_Valid_Range_03(t *testing.T) {
-	Check(t, false, "corset/valid/range_03")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/range_03", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Range_04(t *testing.T) {
-	Check(t, false, "corset/valid/range_04")
+	util.CheckCorset(t, false, "corset/valid/range_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // #1247 --- This is an issue as we have a potentially negative expression used
 // in a range constraint.
 //
 // func Test_Valid_Range_05(t *testing.T) {
-//  util.Check(t, false, "corset/valid/range_05")
+//  util.Check(t, false, "corset/valid/range_05", field.BLS12_377, field.KOALABEAR_16)
 // }
 
 // ===================================================================
@@ -555,23 +555,23 @@ func Test_Valid_Range_04(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_ConstExpr_01(t *testing.T) {
-	Check(t, false, "corset/valid/constexpr_01")
+	util.CheckCorset(t, false, "corset/valid/constexpr_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_ConstExpr_02(t *testing.T) {
-	Check(t, false, "corset/valid/constexpr_02")
+	util.CheckCorset(t, false, "corset/valid/constexpr_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_ConstExpr_03(t *testing.T) {
-	Check(t, false, "corset/valid/constexpr_03")
+	util.CheckCorset(t, false, "corset/valid/constexpr_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_ConstExpr_04(t *testing.T) {
-	Check(t, false, "corset/valid/constexpr_04")
+	util.CheckCorset(t, false, "corset/valid/constexpr_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_ConstExpr_05(t *testing.T) {
-	Check(t, false, "corset/valid/constexpr_05")
+	util.CheckCorset(t, false, "corset/valid/constexpr_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // ===================================================================
@@ -579,49 +579,51 @@ func Test_Valid_ConstExpr_05(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Module_01(t *testing.T) {
-	Check(t, false, "corset/valid/module_01")
+	util.CheckCorset(t, false, "corset/valid/module_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Module_02(t *testing.T) {
-	Check(t, false, "corset/valid/module_02")
+	util.CheckCorset(t, false, "corset/valid/module_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Module_03(t *testing.T) {
-	Check(t, false, "corset/valid/module_03")
+	util.CheckCorset(t, false, "corset/valid/module_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Module_04(t *testing.T) {
-	Check(t, false, "corset/valid/module_04")
+	util.CheckCorset(t, false, "corset/valid/module_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Module_05(t *testing.T) {
-	Check(t, false, "corset/valid/module_05")
+	util.CheckCorset(t, false, "corset/valid/module_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Module_06(t *testing.T) {
-	Check(t, false, "corset/valid/module_06")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/module_06", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Module_07(t *testing.T) {
-	Check(t, false, "corset/valid/module_07")
+	util.CheckCorset(t, false, "corset/valid/module_07", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Module_08(t *testing.T) {
-	Check(t, false, "corset/valid/module_08")
+	util.CheckCorset(t, false, "corset/valid/module_08", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Module_09(t *testing.T) {
-	Check(t, false, "corset/valid/module_09")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/module_09", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Module_10(t *testing.T) {
-	Check(t, false, "corset/valid/module_10")
+	util.CheckCorset(t, false, "corset/valid/module_10", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // NOTE: uses conditional module
 //
 // func Test_Valid_Module_11(t *testing.T) {
-// 	test_util.Check(t, false, "corset/valid/module_11")
+// 	test_util.Check(t, false, "corset/valid/module_11", field.BLS12_377, field.KOALABEAR_16)
 // }
 
 // ===================================================================
@@ -629,47 +631,47 @@ func Test_Valid_Module_10(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Permute_01(t *testing.T) {
-	util.Check(t, false, "corset/valid/permute_01")
+	util.CheckCorset(t, false, "corset/valid/permute_01", field.BLS12_377)
 }
 
 func Test_Valid_Permute_02(t *testing.T) {
-	util.Check(t, false, "corset/valid/permute_02")
+	util.CheckCorset(t, false, "corset/valid/permute_02", field.BLS12_377)
 }
 
 func Test_Valid_Permute_03(t *testing.T) {
-	util.Check(t, false, "corset/valid/permute_03")
+	util.CheckCorset(t, false, "corset/valid/permute_03", field.BLS12_377)
 }
 
 func Test_Valid_Permute_04(t *testing.T) {
-	util.Check(t, false, "corset/valid/permute_04")
+	util.CheckCorset(t, false, "corset/valid/permute_04", field.BLS12_377)
 }
 
 func Test_Valid_Permute_05(t *testing.T) {
-	util.Check(t, false, "corset/valid/permute_05")
+	util.CheckCorset(t, false, "corset/valid/permute_05", field.BLS12_377)
 }
 
 func Test_Valid_Permute_06(t *testing.T) {
-	util.Check(t, false, "corset/valid/permute_06")
+	util.CheckCorset(t, false, "corset/valid/permute_06", field.BLS12_377)
 }
 
 func Test_Valid_Permute_07(t *testing.T) {
-	util.Check(t, false, "corset/valid/permute_07")
+	util.CheckCorset(t, false, "corset/valid/permute_07", field.BLS12_377)
 }
 
 func Test_Valid_Permute_08(t *testing.T) {
-	util.Check(t, false, "corset/valid/permute_08")
+	util.CheckCorset(t, false, "corset/valid/permute_08", field.BLS12_377)
 }
 
 func Test_Valid_Permute_09(t *testing.T) {
-	util.Check(t, false, "corset/valid/permute_09")
+	util.CheckCorset(t, false, "corset/valid/permute_09", field.BLS12_377)
 }
 
 func Test_Valid_Permute_10(t *testing.T) {
-	util.Check(t, false, "corset/valid/permute_10")
+	util.CheckCorset(t, false, "corset/valid/permute_10", field.BLS12_377)
 }
 
 func Test_Valid_Permute_11(t *testing.T) {
-	util.Check(t, false, "corset/valid/permute_11")
+	util.CheckCorset(t, false, "corset/valid/permute_11", field.BLS12_377)
 }
 
 // ===================================================================
@@ -677,49 +679,49 @@ func Test_Valid_Permute_11(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Sorted_01(t *testing.T) {
-	util.Check(t, false, "corset/valid/sorted_01")
+	util.CheckCorset(t, false, "corset/valid/sorted_01", field.BLS12_377)
 }
 func Test_Valid_Sorted_02(t *testing.T) {
-	util.Check(t, false, "corset/valid/sorted_02")
+	util.CheckCorset(t, false, "corset/valid/sorted_02", field.BLS12_377)
 }
 func Test_Valid_Sorted_03(t *testing.T) {
-	util.Check(t, false, "corset/valid/sorted_03")
+	util.CheckCorset(t, false, "corset/valid/sorted_03", field.BLS12_377)
 }
 func Test_Valid_Sorted_04(t *testing.T) {
-	util.Check(t, false, "corset/valid/sorted_04")
+	util.CheckCorset(t, false, "corset/valid/sorted_04", field.BLS12_377)
 }
 func Test_Valid_Sorted_05(t *testing.T) {
-	util.Check(t, false, "corset/valid/sorted_05")
+	util.CheckCorset(t, false, "corset/valid/sorted_05", field.BLS12_377)
 }
 func Test_Valid_Sorted_06(t *testing.T) {
-	util.Check(t, false, "corset/valid/sorted_06")
+	util.CheckCorset(t, false, "corset/valid/sorted_06", field.BLS12_377)
 }
 
 func Test_Valid_Sorted_07(t *testing.T) {
-	util.Check(t, false, "corset/valid/sorted_07")
+	util.CheckCorset(t, false, "corset/valid/sorted_07", field.BLS12_377)
 }
 func Test_Valid_Sorted_08(t *testing.T) {
-	util.Check(t, false, "corset/valid/sorted_08")
+	util.CheckCorset(t, false, "corset/valid/sorted_08", field.BLS12_377)
 }
 
 func Test_Valid_StrictSorted_01(t *testing.T) {
-	util.Check(t, false, "corset/valid/strictsorted_01")
+	util.CheckCorset(t, false, "corset/valid/strictsorted_01", field.BLS12_377)
 }
 
 func Test_Valid_StrictSorted_02(t *testing.T) {
-	util.Check(t, false, "corset/valid/strictsorted_02")
+	util.CheckCorset(t, false, "corset/valid/strictsorted_02", field.BLS12_377)
 }
 
 func Test_Valid_StrictSorted_03(t *testing.T) {
-	util.Check(t, false, "corset/valid/strictsorted_03")
+	util.CheckCorset(t, false, "corset/valid/strictsorted_03", field.BLS12_377)
 }
 
 func Test_Valid_StrictSorted_04(t *testing.T) {
-	util.Check(t, false, "corset/valid/strictsorted_04")
+	util.CheckCorset(t, false, "corset/valid/strictsorted_04", field.BLS12_377)
 }
 
 func Test_Valid_StrictSorted_05(t *testing.T) {
-	util.Check(t, false, "corset/valid/strictsorted_05")
+	util.CheckCorset(t, false, "corset/valid/strictsorted_05", field.BLS12_377)
 }
 
 // ===================================================================
@@ -727,111 +729,111 @@ func Test_Valid_StrictSorted_05(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Lookup_01(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_01")
+	util.CheckCorset(t, false, "corset/valid/lookup_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Lookup_02(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_02")
+	util.CheckCorset(t, false, "corset/valid/lookup_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Lookup_03(t *testing.T) {
-	util.Check(t, false, "corset/valid/lookup_03")
+	util.CheckCorset(t, false, "corset/valid/lookup_03", field.BLS12_377)
 }
 
 func Test_Valid_Lookup_04(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_04")
+	util.CheckCorset(t, false, "corset/valid/lookup_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Lookup_05(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_05")
+	util.CheckCorset(t, false, "corset/valid/lookup_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Lookup_06(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_06")
+	util.CheckCorset(t, false, "corset/valid/lookup_06", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // #1247
 // func Test_Valid_Lookup_07(t *testing.T) {
-// 	util.Check(t, false, "corset/valid/lookup_07")
+// 	util.Check(t, false, "corset/valid/lookup_07", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 // }
 
 // #1247
 // func Test_Valid_Lookup_08(t *testing.T) {
-// 	util.Check(t, false, "corset/valid/lookup_08")
+// 	util.Check(t, false, "corset/valid/lookup_08", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 // }
 
 func Test_Valid_Lookup_09(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_09")
+	util.CheckCorset(t, false, "corset/valid/lookup_09", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Lookup_10(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_10")
+	util.CheckCorset(t, false, "corset/valid/lookup_10", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Lookup_11(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_11")
+	util.CheckCorset(t, false, "corset/valid/lookup_11", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Lookup_12(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_12")
+	util.CheckCorset(t, false, "corset/valid/lookup_12", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Lookup_13(t *testing.T) {
-	util.Check(t, false, "corset/valid/lookup_13")
+	util.CheckCorset(t, false, "corset/valid/lookup_13", field.BLS12_377)
 }
 
 func Test_Valid_Lookup_14(t *testing.T) {
-	util.Check(t, false, "corset/valid/lookup_14")
+	util.CheckCorset(t, false, "corset/valid/lookup_14", field.BLS12_377)
 }
 
 func Test_Valid_Lookup_15(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_15")
+	util.CheckCorset(t, false, "corset/valid/lookup_15", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Lookup_16(t *testing.T) {
-	util.Check(t, false, "corset/valid/lookup_16")
+	util.CheckCorset(t, false, "corset/valid/lookup_16", field.BLS12_377)
 }
 
 func Test_Valid_Lookup_17(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_17")
+	util.CheckCorset(t, false, "corset/valid/lookup_17", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Lookup_18(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_18")
+	util.CheckCorset(t, false, "corset/valid/lookup_18", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Lookup_19(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_19")
+	util.CheckCorset(t, false, "corset/valid/lookup_19", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Lookup_20(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_20")
+	util.CheckCorset(t, false, "corset/valid/lookup_20", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Lookup_21(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_21")
+	util.CheckCorset(t, false, "corset/valid/lookup_21", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Lookup_22(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_22")
+	util.CheckCorset(t, false, "corset/valid/lookup_22", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Lookup_23(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_23")
+	util.CheckCorset(t, false, "corset/valid/lookup_23", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Lookup_24(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_24")
+	util.CheckCorset(t, false, "corset/valid/lookup_24", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 func Test_Valid_Lookup_25(t *testing.T) {
-	Check(t, false, "corset/valid/lookup_25")
+	util.CheckCorset(t, false, "corset/valid/lookup_25", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Lookup_26(t *testing.T) {
-	util.Check(t, false, "corset/valid/lookup_26")
+	util.CheckCorset(t, false, "corset/valid/lookup_26", field.BLS12_377)
 }
 func Test_Valid_Lookup_27(t *testing.T) {
-	util.Check(t, false, "corset/valid/lookup_27")
+	util.CheckCorset(t, false, "corset/valid/lookup_27", field.BLS12_377)
 }
 
 // ===================================================================
@@ -839,29 +841,29 @@ func Test_Valid_Lookup_27(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Interleave_01(t *testing.T) {
-	util.Check(t, false, "corset/valid/interleave_01")
+	util.CheckCorset(t, false, "corset/valid/interleave_01", field.BLS12_377)
 }
 
 func Test_Valid_Interleave_02(t *testing.T) {
-	util.Check(t, false, "corset/valid/interleave_02")
+	util.CheckCorset(t, false, "corset/valid/interleave_02", field.BLS12_377)
 }
 
 func Test_Valid_Interleave_03(t *testing.T) {
-	util.Check(t, false, "corset/valid/interleave_03")
+	util.CheckCorset(t, false, "corset/valid/interleave_03", field.BLS12_377)
 }
 
 func Test_Valid_Interleave_04(t *testing.T) {
-	util.Check(t, false, "corset/valid/interleave_04")
+	util.CheckCorset(t, false, "corset/valid/interleave_04", field.BLS12_377)
 }
 
 func Test_Valid_Interleave_05(t *testing.T) {
-	util.Check(t, false, "corset/valid/interleave_05")
+	util.CheckCorset(t, false, "corset/valid/interleave_05", field.BLS12_377)
 }
 func Test_Valid_Interleave_06(t *testing.T) {
-	util.Check(t, false, "corset/valid/interleave_06")
+	util.CheckCorset(t, false, "corset/valid/interleave_06", field.BLS12_377)
 }
 func Test_Valid_Interleave_07(t *testing.T) {
-	util.Check(t, false, "corset/valid/interleave_07")
+	util.CheckCorset(t, false, "corset/valid/interleave_07", field.BLS12_377)
 }
 
 // ===================================================================
@@ -869,31 +871,31 @@ func Test_Valid_Interleave_07(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Fun_01(t *testing.T) {
-	Check(t, false, "corset/valid/fun_01")
+	util.CheckCorset(t, false, "corset/valid/fun_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Fun_02(t *testing.T) {
-	Check(t, false, "corset/valid/fun_02")
+	util.CheckCorset(t, false, "corset/valid/fun_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Fun_03(t *testing.T) {
-	Check(t, false, "corset/valid/fun_03")
+	util.CheckCorset(t, false, "corset/valid/fun_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Fun_04(t *testing.T) {
-	Check(t, false, "corset/valid/fun_04")
+	util.CheckCorset(t, false, "corset/valid/fun_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Fun_05(t *testing.T) {
-	Check(t, false, "corset/valid/fun_05")
+	util.CheckCorset(t, false, "corset/valid/fun_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Fun_06(t *testing.T) {
-	Check(t, false, "corset/valid/fun_06")
+	util.CheckCorset(t, false, "corset/valid/fun_06", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Fun_07(t *testing.T) {
-	util.Check(t, false, "corset/valid/fun_07")
+	util.CheckCorset(t, false, "corset/valid/fun_07", field.BLS12_377)
 }
 
 // ===================================================================
@@ -901,42 +903,43 @@ func Test_Valid_Fun_07(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_PureFun_01(t *testing.T) {
-	Check(t, false, "corset/valid/purefun_01")
+	util.CheckCorset(t, false, "corset/valid/purefun_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_PureFun_02(t *testing.T) {
-	Check(t, false, "corset/valid/purefun_02")
+	util.CheckCorset(t, false, "corset/valid/purefun_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_PureFun_03(t *testing.T) {
-	Check(t, false, "corset/valid/purefun_03")
+	util.CheckCorset(t, false, "corset/valid/purefun_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_PureFun_04(t *testing.T) {
-	Check(t, false, "corset/valid/purefun_04")
+	util.CheckCorset(t, false, "corset/valid/purefun_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_PureFun_05(t *testing.T) {
-	Check(t, false, "corset/valid/purefun_05")
+	util.CheckCorset(t, false, "corset/valid/purefun_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_PureFun_06(t *testing.T) {
-	Check(t, false, "corset/valid/purefun_06")
+	util.CheckCorset(t, false, "corset/valid/purefun_06", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_PureFun_07(t *testing.T) {
-	Check(t, false, "corset/valid/purefun_07")
+	util.CheckCorset(t, false, "corset/valid/purefun_07", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_PureFun_08(t *testing.T) {
-	Check(t, false, "corset/valid/purefun_08")
+	util.CheckCorset(t, false, "corset/valid/purefun_08", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_PureFun_09(t *testing.T) {
-	Check(t, false, "corset/valid/purefun_09")
+	util.CheckCorset(t, false, "corset/valid/purefun_09", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 func Test_Valid_PureFun_10(t *testing.T) {
-	Check(t, false, "corset/valid/purefun_10")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/purefun_10", field.BLS12_377, field.KOALABEAR_16)
 }
 
 // ===================================================================
@@ -944,27 +947,27 @@ func Test_Valid_PureFun_10(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_For_01(t *testing.T) {
-	Check(t, false, "corset/valid/for_01")
+	util.CheckCorset(t, false, "corset/valid/for_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_For_02(t *testing.T) {
-	Check(t, false, "corset/valid/for_02")
+	util.CheckCorset(t, false, "corset/valid/for_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_For_03(t *testing.T) {
-	Check(t, false, "corset/valid/for_03")
+	util.CheckCorset(t, false, "corset/valid/for_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_For_04(t *testing.T) {
-	Check(t, false, "corset/valid/for_04")
+	util.CheckCorset(t, false, "corset/valid/for_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_For_05(t *testing.T) {
-	Check(t, false, "corset/valid/for_05")
+	util.CheckCorset(t, false, "corset/valid/for_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_For_06(t *testing.T) {
-	Check(t, false, "corset/valid/for_06")
+	util.CheckCorset(t, false, "corset/valid/for_06", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // ===================================================================
@@ -972,35 +975,35 @@ func Test_Valid_For_06(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Array_01(t *testing.T) {
-	Check(t, false, "corset/valid/array_01")
+	util.CheckCorset(t, false, "corset/valid/array_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Array_02(t *testing.T) {
-	Check(t, false, "corset/valid/array_02")
+	util.CheckCorset(t, false, "corset/valid/array_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Array_03(t *testing.T) {
-	Check(t, false, "corset/valid/array_03")
+	util.CheckCorset(t, false, "corset/valid/array_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Array_04(t *testing.T) {
-	Check(t, false, "corset/valid/array_04")
+	util.CheckCorset(t, false, "corset/valid/array_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Array_05(t *testing.T) {
-	Check(t, false, "corset/valid/array_05")
+	util.CheckCorset(t, false, "corset/valid/array_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Array_06(t *testing.T) {
-	Check(t, false, "corset/valid/array_06")
+	util.CheckCorset(t, false, "corset/valid/array_06", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Array_07(t *testing.T) {
-	Check(t, false, "corset/valid/array_07")
+	util.CheckCorset(t, false, "corset/valid/array_07", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Array_08(t *testing.T) {
-	Check(t, false, "corset/valid/array_08")
+	util.CheckCorset(t, false, "corset/valid/array_08", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // ===================================================================
@@ -1008,23 +1011,23 @@ func Test_Valid_Array_08(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Reduce_01(t *testing.T) {
-	Check(t, false, "corset/valid/reduce_01")
+	util.CheckCorset(t, false, "corset/valid/reduce_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Reduce_02(t *testing.T) {
-	Check(t, false, "corset/valid/reduce_02")
+	util.CheckCorset(t, false, "corset/valid/reduce_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Reduce_03(t *testing.T) {
-	Check(t, false, "corset/valid/reduce_03")
+	util.CheckCorset(t, false, "corset/valid/reduce_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Reduce_04(t *testing.T) {
-	Check(t, false, "corset/valid/reduce_04")
+	util.CheckCorset(t, false, "corset/valid/reduce_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Reduce_05(t *testing.T) {
-	Check(t, false, "corset/valid/reduce_05")
+	util.CheckCorset(t, false, "corset/valid/reduce_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // ===================================================================
@@ -1032,15 +1035,15 @@ func Test_Valid_Reduce_05(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Debug_01(t *testing.T) {
-	Check(t, false, "corset/valid/debug_01")
+	util.CheckCorset(t, false, "corset/valid/debug_01", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Debug_02(t *testing.T) {
-	Check(t, false, "corset/valid/debug_02")
+	util.CheckCorset(t, false, "corset/valid/debug_02", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Debug_03(t *testing.T) {
-	Check(t, false, "corset/valid/debug_03")
+	util.CheckCorset(t, false, "corset/valid/debug_03", field.BLS12_377, field.KOALABEAR_16)
 }
 
 // ===================================================================
@@ -1048,123 +1051,133 @@ func Test_Valid_Debug_03(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Perspective_01(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_01")
+	util.CheckCorset(t, false, "corset/valid/perspective_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_02(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_02")
+	util.CheckCorset(t, false, "corset/valid/perspective_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_03(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_03")
+	util.CheckCorset(t, false, "corset/valid/perspective_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_04(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_04")
+	util.CheckCorset(t, false, "corset/valid/perspective_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_05(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_05")
+	util.CheckCorset(t, false, "corset/valid/perspective_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_06(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_06")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/perspective_06", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Perspective_07(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_07")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/perspective_07", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Perspective_08(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_08")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/perspective_08", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Perspective_09(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_09")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/perspective_09", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Perspective_10(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_10")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/perspective_10", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Perspective_11(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_11")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/perspective_11", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Perspective_12(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_12")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/perspective_12", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Perspective_13(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_13")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/perspective_13", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Perspective_14(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_14")
+	util.CheckCorset(t, false, "corset/valid/perspective_14", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_15(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_15")
+	util.CheckCorset(t, false, "corset/valid/perspective_15", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_16(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_16")
+	util.CheckCorset(t, false, "corset/valid/perspective_16", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_17(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_17")
+	util.CheckCorset(t, false, "corset/valid/perspective_17", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_18(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_18")
+	util.CheckCorset(t, false, "corset/valid/perspective_18", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_19(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_19")
+	util.CheckCorset(t, false, "corset/valid/perspective_19", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_20(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_20")
+	util.CheckCorset(t, false, "corset/valid/perspective_20", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_21(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_21")
+	util.CheckCorset(t, false, "corset/valid/perspective_21", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_22(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_22")
+	util.CheckCorset(t, false, "corset/valid/perspective_22", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_23(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_23")
+	util.CheckCorset(t, false, "corset/valid/perspective_23", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_24(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_24")
+	util.CheckCorset(t, false, "corset/valid/perspective_24", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_26(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_26")
+	util.CheckCorset(t, false, "corset/valid/perspective_26", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_27(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_27")
+	util.CheckCorset(t, false, "corset/valid/perspective_27", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_28(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_28")
+	util.CheckCorset(t, false, "corset/valid/perspective_28", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_29(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_29")
+	util.CheckCorset(t, false, "corset/valid/perspective_29", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Perspective_30(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_30")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/perspective_30", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Perspective_31(t *testing.T) {
-	Check(t, false, "corset/valid/perspective_31")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/perspective_31", field.BLS12_377, field.KOALABEAR_16)
 }
 
 // ===================================================================
@@ -1172,46 +1185,48 @@ func Test_Valid_Perspective_31(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Let_01(t *testing.T) {
-	Check(t, false, "corset/valid/let_01")
+	util.CheckCorset(t, false, "corset/valid/let_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Let_02(t *testing.T) {
-	Check(t, false, "corset/valid/let_02")
+	util.CheckCorset(t, false, "corset/valid/let_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Let_03(t *testing.T) {
-	Check(t, false, "corset/valid/let_03")
+	util.CheckCorset(t, false, "corset/valid/let_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Let_04(t *testing.T) {
-	Check(t, false, "corset/valid/let_04")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/let_04", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Let_05(t *testing.T) {
-	Check(t, false, "corset/valid/let_05")
+	util.CheckCorset(t, false, "corset/valid/let_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Let_06(t *testing.T) {
-	Check(t, false, "corset/valid/let_06")
+	// FIXME: GF_8209
+	util.CheckCorset(t, false, "corset/valid/let_06", field.BLS12_377, field.KOALABEAR_16)
 }
 
 func Test_Valid_Let_07(t *testing.T) {
-	Check(t, false, "corset/valid/let_07")
+	util.CheckCorset(t, false, "corset/valid/let_07", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Let_08(t *testing.T) {
-	Check(t, false, "corset/valid/let_08")
+	util.CheckCorset(t, false, "corset/valid/let_08", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 func Test_Valid_Let_09(t *testing.T) {
-	Check(t, false, "corset/valid/let_09")
+	util.CheckCorset(t, false, "corset/valid/let_09", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Let_10(t *testing.T) {
-	Check(t, false, "corset/valid/let_10")
+	util.CheckCorset(t, false, "corset/valid/let_10", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Let_11(t *testing.T) {
-	Check(t, false, "corset/valid/let_11")
+	util.CheckCorset(t, false, "corset/valid/let_11", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 // ===================================================================
@@ -1219,11 +1234,11 @@ func Test_Valid_Let_11(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Compute_01(t *testing.T) {
-	util.Check(t, false, "corset/valid/compute_01")
+	util.CheckCorset(t, false, "corset/valid/compute_01", field.BLS12_377)
 }
 
 func Test_Valid_Compute_02(t *testing.T) {
-	util.Check(t, false, "corset/valid/compute_02")
+	util.CheckCorset(t, false, "corset/valid/compute_02", field.BLS12_377)
 }
 
 // ===================================================================
@@ -1231,20 +1246,20 @@ func Test_Valid_Compute_02(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_ComputedColumn_01(t *testing.T) {
-	util.Check(t, false, "corset/valid/computedcolumn_01")
+	util.CheckCorset(t, false, "corset/valid/computedcolumn_01", field.BLS12_377)
 }
 func Test_Valid_ComputedColumn_02(t *testing.T) {
-	util.Check(t, false, "corset/valid/computedcolumn_02")
+	util.CheckCorset(t, false, "corset/valid/computedcolumn_02", field.BLS12_377)
 }
 func Test_Valid_ComputedColumn_03(t *testing.T) {
-	util.Check(t, false, "corset/valid/computedcolumn_03")
+	util.CheckCorset(t, false, "corset/valid/computedcolumn_03", field.BLS12_377)
 }
 
 //	func Test_Valid_ComputedColumn_04(t *testing.T) {
-//		test_util.Check(t, false, "corset/valid/computedcolumn_04")
+//		test_util.Check(t, false, "corset/valid/computedcolumn_04", field.BLS12_377, field.KOALABEAR_16)
 //	}
 func Test_Valid_ComputedColumn_05(t *testing.T) {
-	util.Check(t, false, "corset/valid/computedcolumn_05")
+	util.CheckCorset(t, false, "corset/valid/computedcolumn_05", field.BLS12_377)
 }
 
 // ===================================================================
@@ -1252,44 +1267,44 @@ func Test_Valid_ComputedColumn_05(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Native_01(t *testing.T) {
-	util.Check(t, false, "corset/valid/native_01")
+	util.CheckCorset(t, false, "corset/valid/native_01", field.BLS12_377)
 }
 func Test_Valid_Native_02(t *testing.T) {
-	util.Check(t, false, "corset/valid/native_02")
+	util.CheckCorset(t, false, "corset/valid/native_02", field.BLS12_377)
 }
 func Test_Valid_Native_03(t *testing.T) {
-	util.Check(t, false, "corset/valid/native_03")
+	util.CheckCorset(t, false, "corset/valid/native_03", field.BLS12_377)
 }
 func Test_Valid_Native_04(t *testing.T) {
-	util.Check(t, false, "corset/valid/native_04")
+	util.CheckCorset(t, false, "corset/valid/native_04", field.BLS12_377)
 }
 
 func Test_Valid_Native_05(t *testing.T) {
-	util.Check(t, false, "corset/valid/native_05")
+	util.CheckCorset(t, false, "corset/valid/native_05", field.BLS12_377)
 }
 
 func Test_Valid_Native_06(t *testing.T) {
-	util.Check(t, false, "corset/valid/native_06")
+	util.CheckCorset(t, false, "corset/valid/native_06", field.BLS12_377)
 }
 
 func Test_Valid_Native_07(t *testing.T) {
-	util.Check(t, false, "corset/valid/native_07")
+	util.CheckCorset(t, false, "corset/valid/native_07", field.BLS12_377)
 }
 
 func Test_Valid_Native_08(t *testing.T) {
-	util.Check(t, false, "corset/valid/native_08")
+	util.CheckCorset(t, false, "corset/valid/native_08", field.BLS12_377)
 }
 
 func Test_Valid_Native_09(t *testing.T) {
-	util.Check(t, false, "corset/valid/native_09")
+	util.CheckCorset(t, false, "corset/valid/native_09", field.BLS12_377)
 }
 
 func Test_Valid_Native_10(t *testing.T) {
-	util.Check(t, false, "corset/valid/native_10")
+	util.CheckCorset(t, false, "corset/valid/native_10", field.BLS12_377)
 }
 
 func Test_Valid_Native_11(t *testing.T) {
-	util.Check(t, false, "corset/valid/native_11")
+	util.CheckCorset(t, false, "corset/valid/native_11", field.BLS12_377)
 }
 
 // ===================================================================
@@ -1297,21 +1312,21 @@ func Test_Valid_Native_11(t *testing.T) {
 // ===================================================================
 
 func Test_Valid_Stdlib_01(t *testing.T) {
-	Check(t, true, "corset/valid/stdlib_01")
+	util.CheckCorset(t, true, "corset/valid/stdlib_01", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Stdlib_02(t *testing.T) {
-	Check(t, true, "corset/valid/stdlib_02")
+	util.CheckCorset(t, true, "corset/valid/stdlib_02", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Stdlib_03(t *testing.T) {
-	Check(t, true, "corset/valid/stdlib_03")
+	util.CheckCorset(t, true, "corset/valid/stdlib_03", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Stdlib_04(t *testing.T) {
-	Check(t, true, "corset/valid/stdlib_04")
+	util.CheckCorset(t, true, "corset/valid/stdlib_04", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }
 
 func Test_Valid_Stdlib_05(t *testing.T) {
-	Check(t, true, "corset/valid/stdlib_05")
+	util.CheckCorset(t, true, "corset/valid/stdlib_05", field.BLS12_377, field.KOALABEAR_16, field.GF_8209)
 }

--- a/pkg/test/util/check_valid.go
+++ b/pkg/test/util/check_valid.go
@@ -65,6 +65,13 @@ func Check(t *testing.T, stdlib bool, test string) {
 	CheckWithFields(t, stdlib, test, CORSET_MAX_PADDING, field.BLS12_377)
 }
 
+// CheckCorset checks that all traces which we expect to be accepted are
+// accepted by a given set of constraints, and all traces that we expect to be
+// rejected are rejected.  All fields provided are tested against.
+func CheckCorset(t *testing.T, stdlib bool, test string, fields ...field.Config) {
+	CheckWithFields(t, stdlib, test, CORSET_MAX_PADDING, fields...)
+}
+
 // CheckWithFields checks that all traces which we expect to be accepted are
 // accepted by a given set of constraints, and all traces that we expect to be
 // rejected are rejected.  All fields provided are tested against.


### PR DESCRIPTION
This enables this small field for two specific test suites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables GF_8209 across tests and CI by adding it to the workflow matrix and migrating tests to `util.CheckCorset` with explicit field sets.
> 
> - **Tests**:
>   - Migrate calls from `Check`/`util.Check` to `util.CheckCorset` with explicit fields in `pkg/test/corset_bench_test.go` and `pkg/test/corset_valid_test.go`.
>   - Enable `GF_8209` for many `corset/valid/*` cases; selectively omit with notes where not yet supported; keep some tests on `BLS12_377` only.
>   - Update bench tests to specify `field.BLS12_377` and `field.KOALABEAR_16` (and `BLS12_377`-only where applicable); add `field` import.
> - **Util**:
>   - Add `util.CheckCorset(t, stdlib, test, fields...)` wrapper around `CheckWithFields` in `pkg/test/util/check_valid.go`.
> - **CI** (`.github/workflows/test.yml`):
>   - Add `GF_8209` to the `matrix.field` list and explicitly exclude unsupported `test`/`field` combinations (including several for `GF_8209` and `KOALABEAR_16`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 606d4840707020476c7bd4bbd7264eb104b0b525. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->