### PR TITLE
fix: check --report panic (#1286)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ "v1.1-line" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     strategy:

--- a/pkg/cmd/view/filter.go
+++ b/pkg/cmd/view/filter.go
@@ -114,7 +114,7 @@ type moduleCellFilter struct {
 }
 
 func (p *traceCellFilter) Module(mid sc.ModuleId) ModuleFilter {
-	var n = uint(len(p.modules[mid].columns))
+	var n = uint(len(p.modules))
 	//
 	if n <= mid || len(p.modules[mid].columns) == 0 {
 		return nil


### PR DESCRIPTION
* fix: check --report panic

The "check --report" command was causing a panic when printing out the report due to a simple logic error.

* enable cancelling CI tasks on subsequent push

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a panic in view filtering by correcting a module bounds check and enables CI concurrency cancellation for PR runs.
> 
> - **Core (view filtering)**:
>   - Fix bounds check in `traceCellFilter.Module()` (`pkg/cmd/view/filter.go`) by using `len(p.modules)` instead of `len(p.modules[mid].columns)` to prevent out-of-range access and panic.
> - **CI**:
>   - Add GitHub Actions `concurrency` config to cancel in-progress runs for the same ref.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 870b03f330e82e035cff9bc64e93943e2692200a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->