### PR TITLE
fix: filter row reset

### DIFF
--- a/pkg/cmd/inspector/inspect.go
+++ b/pkg/cmd/inspector/inspect.go
@@ -229,23 +229,27 @@ func (p *Inspector) gotoRow(row uint) termio.FormattedText {
 
 // filter columns based on a regex
 func (p *Inspector) filterColumns(regex *regexp.Regexp) termio.FormattedText {
+	row, _ := p.CurrentModule().view.Offset()
 	filter := p.CurrentModule().columnFilter
 	filter.Regex = regex
 	p.CurrentModule().applyColumnFilter(filter, true)
 	// Success
-	return termio.NewText("")
+	return p.gotoRow(row)
 }
 
 func (p *Inspector) clearColumnFilter() bool {
+	row, _ := p.CurrentModule().view.Offset()
 	filter := p.CurrentModule().columnFilter
 	filter.Regex = nil
 	p.CurrentModule().applyColumnFilter(filter, false)
+	p.gotoRow(row)
 	// Success
 	return true
 }
 
 func (p *Inspector) toggleColumnFilter() bool {
 	var (
+		row, _ = p.CurrentModule().view.Offset()
 		filter = p.CurrentModule().columnFilter
 		msg    string
 	)
@@ -264,6 +268,7 @@ func (p *Inspector) toggleColumnFilter() bool {
 	}
 	//
 	p.CurrentModule().applyColumnFilter(filter, false)
+	p.CurrentModule().gotoRow(row)
 	p.SetStatus(termio.NewColouredText(msg, termio.TERM_GREEN))
 	// Success
 	return true


### PR DESCRIPTION
This fixes an issue with the filter command, and also the computed column toggle.  Specifically, when they were used they automatically reset the current row back to zero.  This was not very helpful, and is fixed now.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Keeps the current row position when column filters are applied, cleared, or toggled, and updates the status accordingly.
> 
> - **Inspector (`pkg/cmd/inspector/inspect.go`)**:
>   - Preserve current row across column filter operations:
>     - `filterColumns(...)`: capture current row via `view.Offset()` and return `gotoRow(row)` after applying filter.
>     - `clearColumnFilter()`: capture row and call `gotoRow(row)` after clearing filter.
>     - `toggleColumnFilter()`: capture row and call `gotoRow(row)` after updating computed/user-defined flags; set status message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dedcc72b78b1ce239c10f7a42b7549add5c0c469. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->