### PR TITLE
fix: out-of-bounds array access

### DIFF
--- a/pkg/cmd/view/filter.go
+++ b/pkg/cmd/view/filter.go
@@ -181,10 +181,12 @@ func (p *traceCellFilter) addCell(cell tr.CellRef) {
 func (p *moduleCellFilter) Column(col SourceColumn) bool {
 	// Look to see whether any limb is in this column, or not.
 	for _, lid := range col.Limbs {
-		var bits bit.Set = p.columns[lid.Unwrap()]
-		//
-		if bits.Count() != 0 {
-			return true
+		if uint(len(p.columns)) > lid.Unwrap() {
+			var bits bit.Set = p.columns[lid.Unwrap()]
+			//
+			if bits.Count() != 0 {
+				return true
+			}
 		}
 	}
 	//


### PR DESCRIPTION
There was a simple logic error in the decision process regarding whether or not a column should be included in the report.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a bounds check when inspecting limb indices in `moduleCellFilter.Column` to prevent out-of-range access and correct column inclusion logic.
> 
> - **Bug Fix**
>   - Add bounds check in `pkg/cmd/view/filter.go` `moduleCellFilter.Column` to guard `p.columns[lid.Unwrap()]`, preventing out-of-bounds access when evaluating column limbs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ef467f778f738c672fcd40f6f9f7a3c8633c873b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->