### PR TITLE
feat: support reading of compressed trace files

### DIFF
--- a/pkg/cmd/util.go
+++ b/pkg/cmd/util.go
@@ -174,7 +174,7 @@ func ReadTraceFile(filename string) lt.TraceFile {
 		tracefile lt.TraceFile
 	)
 	// Read data file
-	data, err := os.ReadFile(filename)
+	filename, data, err := file.ReadAndUncompress(filename)
 	// Check success
 	if err == nil {
 		// Check file extension
@@ -220,7 +220,7 @@ func ReadTraceFile(filename string) lt.TraceFile {
 func ReadBatchedTraceFile(filename string) []lt.TraceFile {
 	var (
 		stats  = util.NewPerfStats()
-		lines  = file.ReadInputFile(filename)
+		lines  = file.ReadInputFileAsLines(filename)
 		traces = make([]lt.TraceFile, 0)
 	)
 	// Read constraints line by line

--- a/pkg/test/util/check_valid.go
+++ b/pkg/test/util/check_valid.go
@@ -378,7 +378,7 @@ func (p *traceId) String() string {
 // ReadTracesFile reads a file containing zero or more traces expressed as JSON, where
 // each trace is on a separate line.
 func ReadTracesFile(filename string) []lt.TraceFile {
-	lines := file.ReadInputFile(filename)
+	lines := file.ReadInputFileAsLines(filename)
 	traces := make([]lt.TraceFile, len(lines))
 	// Read constraints line by line
 	for i, line := range lines {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds transparent decompression for .gz/.bz2 trace files and updates readers to parse compressed inputs and line-based JSON batches.
> 
> - **Utilities**:
>   - Add `file.ReadAndUncompress` to open and transparently decompress `.gz`/`.bz2` files, returning stripped `filename` and raw `data`.
>   - Introduce `file.ReadInputFileAsLines` (with `.bz2` support) for efficient line-by-line reading.
> - **Trace IO**:
>   - Update `cmd.ReadTraceFile` to use `ReadAndUncompress` and resolve format based on the decompressed `filename` extension.
>   - Update `cmd.ReadBatchedTraceFile` and tests (`pkg/test/util/check_valid.go`) to use `ReadInputFileAsLines` for batched JSON traces.
> - **Dependencies**:
>   - Import `compress/gzip` to support `.gz` decompression.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b236c6f2f1633d2ee3aacb55d54adf337618f3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->