### PR TITLE
feat: support in memory trace generation

### DIFF
--- a/pkg/cmd/generate/interface.go
+++ b/pkg/cmd/generate/interface.go
@@ -106,6 +106,7 @@ func generateInterfaceContents(className string, mod corset.SourceModule, builde
 	//
 	if mod.Name == "" {
 		builder.WriteString(javaColumnHeader)
+		builder.WriteString(javaColumn)
 		builder.WriteString(javaAddMetadataSignature)
 		builder.WriteString(javaOpenSignature)
 	}

--- a/pkg/cmd/generate/snippets.go
+++ b/pkg/cmd/generate/snippets.go
@@ -62,205 +62,36 @@ const javaColumnHeader string = `
     * ColumnHeader contains information about a given column in the resulting trace file.
     *
     * @param name Name of the column, as found in the trace file.
-    * @param bytesPerElement Bytes required for each element in the column.
+    * @param bitwidth Max number of bits required for any element in the column.
     */
-   public record ColumnHeader(String name, int register, long bytesPerElement, long length) { }
+   public record ColumnHeader(String name, int register, int bitwidth, int length) { }
+`
+
+// nolint
+const javaColumn string = `
+   /**
+    * Column provides an interface for writing column data into the resulting trace file.
+    *
+    */
+   public interface Column {
+      public void write(boolean value);
+      public void write(long value);
+      public void write(byte[] value);
+   }
 `
 
 // nolint
 const javaAddMetadataSignature string = `
   /**
-   * Add an item of metadata to this trace.
+   * Get static metadata stored within this trace during compilation.
    */
-  public void addMetadata(String key, Object value);
+  public Map<String,Object> getMetaData();
 `
 
 // nolint
 const javaOpenSignature string = `
   /**
-   * Construct a new trace which will be written to a given file.
-   *
-   * @param file File into which the trace will be written.  Observe any previous contents of this file will be lost.
-   * @return Trace object to use for writing column data.
-   *
-   * @throws IOException If an I/O error occurs.
+   * Open this trace file for the given set of columns.
    */
-  public void open(RandomAccessFile file, List<ColumnHeader> rawHeaders) throws IOException;
-`
-
-// nolint
-const javaTraceOpen string = `
-   /**
-    * Construct a new trace which will be written to a given file.
-    *
-    * @param file File into which the trace will be written.  Observe any previous contents of this file will be lost.
-    * @return Trace object to use for writing column data.
-    *
-    * @throws IOException If an I/O error occurs.
-    */
-   public void open(RandomAccessFile file, List<ColumnHeader> rawHeaders) throws IOException {
-      // Convert metadata into JSON bytes
-      byte[] metadataBytes = getMetadataBytes(metadata);
-      // Construct trace file header bytes
-      byte[] header = constructTraceFileHeader(metadataBytes);
-      // Align headers according to register indices.
-      ColumnHeader[] columnHeaders = alignHeaders(rawHeaders);
-      // Determine file size
-      long headerSize = determineColumnHeadersSize(columnHeaders) + header.length;
-      long dataSize = determineColumnDataSize(columnHeaders);
-      file.setLength(headerSize + dataSize);
-      // Write headers
-      writeHeaders(file,header,columnHeaders,headerSize);
-      // Initialise buffers
-      MappedByteBuffer[] buffers = initialiseByteBuffers(file,columnHeaders,headerSize);
-      // Done
-      this.open(buffers);
-   }
-
-  /**
-   * Construct trace file header containing the given metadata bytes.
-   *
-   * @param metadata Metadata bytes to be embedded in the trace file.
-   *
-   * @return bytes making up the header.
-   */
-   private static byte[] constructTraceFileHeader(byte[] metadata) {
-     ByteBuffer buffer = ByteBuffer.allocate(16 + metadata.length);
-	 // File identifier
-     buffer.put(new byte[]{'z','k','t','r','a','c','e','r'});
-     // Major version
-     buffer.putShort((short) 1);
-     // Minor version
-     buffer.putShort((short) 0);
-     // Metadata length
-     buffer.putInt(metadata.length);
-     // Metadata
-     buffer.put(metadata);
-     // Done
-     return buffer.array();
-   }
-
-  /**
-   * Align headers ensures that the order in which columns are seen matches the order found in the trace schema.
-   *
-   * @param headers The headers to be aligned.
-   * @return The aligned headers.
-   */
-   private static ColumnHeader[] alignHeaders(List<ColumnHeader> headers) {
-     ColumnHeader[] alignedHeaders = new ColumnHeader[{ninputs}];
-     //
-     for(ColumnHeader header : headers) {
-       alignedHeaders[header.register()] = header;
-     }
-     //
-     return alignedHeaders;
-   }
-
-   /**
-    * Precompute the size of the trace file in order to memory map the buffers.
-    *
-    * @param headers Set of headers for the columns being written.
-    * @return Number of bytes requires for the trace file header.
-    */
-   private static long determineColumnHeadersSize(ColumnHeader[] headers) {
-      long nBytes = 4; // column count
-
-      for (ColumnHeader header : headers) {
-	    if(header != null) {
-          nBytes += 2; // name length
-          nBytes += header.name().length();
-          nBytes += 1; // byte per element
-          nBytes += 4; // element count
-        }
-      }
-
-      return nBytes;
-   }
-
-   /**
-    * Precompute the size of the trace file in order to memory map the buffers.
-    *
-    * @param headers Set of headers for the columns being written.
-    * @return Number of bytes required for storing all column data, excluding the header.
-    */
-   private static long determineColumnDataSize(ColumnHeader[] headers) {
-      long nBytes = 0;
-
-      for (ColumnHeader header : headers) {
-	    if(header != null) {
-           nBytes += header.length() * header.bytesPerElement();
-        }
-      }
-
-      return nBytes;
-   }
-
-   /**
-    * Write header information for the trace file.
-    *
-    * @param file Trace file being written.
-    * @param header Trace file header
-    * @param headers Column headers.
-    * @param size Overall size of the header.
-    */
-   private static void writeHeaders(RandomAccessFile file, byte[] header, ColumnHeader[] headers, long size) throws IOException {
-      final var buffer = file.getChannel().map(FileChannel.MapMode.READ_WRITE, 0, size);
-      // Write trace file header
-      buffer.put(header);
-      // Write column count as uint32
-      buffer.putInt(countHeaders(headers));
-      // Write column headers one-by-one
-      for(ColumnHeader h : headers) {
-	    if(h != null) {
-          buffer.putShort((short) h.name().length());
-          buffer.put(h.name().getBytes());
-          buffer.put((byte) h.bytesPerElement());
-          buffer.putInt((int) h.length());
-        }
-      }
-   }
-
-   /**
-    * Initialise one memory mapped byte buffer for each column to be written in the trace.
-    * @param headers Set of headers for the columns being written.
-    * @param headerSize Space required at start of trace file for header.
-    * @return Buffer array with one entry per header.
-    */
-   private static MappedByteBuffer[] initialiseByteBuffers(RandomAccessFile file, ColumnHeader[] headers,
-    long headerSize) throws IOException {
-      MappedByteBuffer[] buffers = new MappedByteBuffer[{ninputs}];
-      long offset = headerSize;
-      for(int i=0;i<headers.length;i++) {
-	    if(headers[i] != null) {
-          // Determine size (in bytes) required to store all elements of this column.
-          long length = headers[i].length() * headers[i].bytesPerElement();
-          // Preallocate space for this column.
-          buffers[i] = file.getChannel().map(FileChannel.MapMode.READ_WRITE, offset, length);
-          //
-          offset += length;
-        }
-      }
-      return buffers;
-   }
-
-   /**
-    * Counter number of active (i.e. non-null) headers.  A header can be null if
-    * it represents a column in a module which is not activated for this trace.
-	*/
-   private static int countHeaders(ColumnHeader[] headers) throws IOException {
-     int count = 0;
-	 for(ColumnHeader h : headers) {
-	    if(h != null) { count++; }
-	 }
-     return count;
-   }
-
-  /**
-   * Object writer is used for generating JSON byte strings.
-   */
-   private static final ObjectWriter objectWriter = new ObjectMapper().writer();
-
-   public static byte[] getMetadataBytes(Map<String, Object> metadata) throws IOException {
-     return objectWriter.writeValueAsBytes(metadata);
-   }
+  public void open(Column[] columns);
 `

--- a/pkg/cmd/generate/util.go
+++ b/pkg/cmd/generate/util.go
@@ -15,22 +15,11 @@ package generate
 import (
 	"fmt"
 	"math"
-	"math/big"
 	"strings"
 	"unicode"
 
-	sc "github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/schema/register"
 )
-
-// Get a string representing the bound of all values in a given bitwidth.  For
-// example, for bitwidth 8 we get "256", etc.
-func maxValueStr(bitwidth uint) string {
-	val := big.NewInt(2)
-	val.Exp(val, big.NewInt(int64(bitwidth)), nil)
-	//
-	return val.String()
-}
 
 // Get a suitable string representing a Java type which safely contains all
 // values of the given bitwidth.
@@ -54,18 +43,6 @@ func normaliseBitwidth(bitwidth uint) uint {
 	default:
 		return math.MaxUint
 	}
-}
-
-// Determine total number of registers, including those for computed columns, in
-// this schema.
-func getMaxRegisterIndex[F any](schema sc.AnySchema[F]) uint {
-	mx := uint(0)
-	// Write register initialisers
-	for mid := range schema.Width() {
-		mx = max(mx, schema.Module(mid).Width())
-	}
-	//
-	return mx * schema.Width()
 }
 
 func toRegisterName(register register.Ref, name string) string {
@@ -154,17 +131,6 @@ func splitCaseChange(word string) []string {
 	words = append(words, string(runes[start:]))
 	//
 	return words
-}
-
-// Determine number of bytes the given bitwidth represents.
-func byteWidth(bitwidth uint) uint {
-	n := bitwidth / 8
-	// roung up bitwidth if necessary
-	if bitwidth%8 != 0 {
-		return n + 1
-	}
-	//
-	return n
 }
 
 // A string builder which supports indentation.


### PR DESCRIPTION
This separates the mechanism for representing columns from trace generation itself, such that the representation can support different implementations and (critically) writing can be performed in memory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces file-mapped buffer writing with a pluggable Column interface and bitwidth-based headers, updating open/metadata APIs, generated fields, and setters to support in-memory trace generation.
> 
> - **Java API and data model**
>   - Replace `bytesPerElement` with `bitwidth` in `ColumnHeader` and its construction.
>   - Introduce `Column` interface (`write(boolean|long|byte[])`).
>   - Change `open(...)` to `open(Column[] columns)`; remove file/ByteBuffer-based open path.
>   - Replace register fields from `MappedByteBuffer` to `Column`.
>   - Replace `addMetadata(...)` with `getMetaData()` accessor.
> - **Code generation changes**
>   - Column setters now call `Column.write(...)`; remove custom byte/long putters and ByteBuffer position math.
>   - `fillAndValidateRow()` writes default values via `Column.write(...)` instead of advancing by byte width.
>   - Remove generation of file/IO header-writing logic and related helpers; simplify utilities (drop byte-width/register-count helpers).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 922c1cf0b08a9fac275c779e3639803ce1d7cdb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->