### PR TITLE
fix: handling of UnsignedByte

### DIFF
--- a/pkg/cmd/generate/class.go
+++ b/pkg/cmd/generate/class.go
@@ -436,6 +436,8 @@ func generateJavaModuleColumnSetter[F any](className string, methodName string, 
 	switch {
 	case bitwidth == 1:
 		i1Builder.WriteIndentedString(fieldName, ".write(val);\n")
+	case bitwidth <= 8:
+		i1Builder.WriteIndentedString(fieldName, ".write((byte) val);\n")
 	case bitwidth <= 63:
 		i1Builder.WriteIndentedString(fieldName, ".write(val);\n")
 	default:

--- a/pkg/cmd/generate/snippets.go
+++ b/pkg/cmd/generate/snippets.go
@@ -75,6 +75,7 @@ const javaColumn string = `
     */
    public interface Column {
       public void write(boolean value);
+      public void write(byte value);
       public void write(long value);
       public void write(byte[] value);
    }


### PR DESCRIPTION
This tweaks the handling of UnsignedByte within the trace generator. Previously, it was not handling signed values correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Route 8-bit column writes through a new byte path and add `Column.write(byte)` to correctly handle UnsignedByte values.
> 
> - **Java generator (`pkg/cmd/generate/class.go`)**:
>   - Column setter: for `bitwidth <= 8` write as `byte` (`.write((byte) val)`); retain legacy `UnsignedByte` overload.
> - **Java snippets (`pkg/cmd/generate/snippets.go`)**:
>   - `Column` interface adds `write(byte value)` to support 8-bit writes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 235d6256c46ad858cc1c4d2007f25dd415000599. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->