### PR TITLE
feat: support "nano" assembly layer

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -117,6 +117,7 @@ func getSchemaStack[F field.Element[F]](cmd *cobra.Command, mode uint, filenames
 		airEnable    = GetFlag(cmd, "air")
 		asmEnable    = GetFlag(cmd, "asm")
 		uasmEnable   = GetFlag(cmd, "uasm")
+		nasmEnable   = GetFlag(cmd, "nasm")
 		optimisation = GetUint(cmd, "opt")
 		externs      = GetStringArray(cmd, "set")
 		//
@@ -156,7 +157,7 @@ func getSchemaStack[F field.Element[F]](cmd *cobra.Command, mode uint, filenames
 		os.Exit(2)
 	}
 	// If no IR was specified, set a default
-	if !airEnable && !mirEnable && !uasmEnable && !asmEnable {
+	if !airEnable && !mirEnable && !uasmEnable && !asmEnable && !nasmEnable {
 		switch mode {
 		case SCHEMA_DEFAULT_MIR:
 			mirEnable = true
@@ -184,6 +185,10 @@ func getSchemaStack[F field.Element[F]](cmd *cobra.Command, mode uint, filenames
 	//
 	if uasmEnable {
 		stacker = stacker.WithLayer(cmd_util.MICRO_ASM_LAYER)
+	}
+	//
+	if nasmEnable {
+		stacker = stacker.WithLayer(cmd_util.NANO_ASM_LAYER)
 	}
 	//
 	if mirEnable {
@@ -226,6 +231,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("asm", false, "include constraints at ASM level")
 	rootCmd.PersistentFlags().Bool("mir", false, "include constraints at MIR level")
 	rootCmd.PersistentFlags().Bool("uasm", false, "include constraints at micro ASM level")
+	rootCmd.PersistentFlags().Bool("nasm", false, "include constraints at nano ASM level")
 	// Trace expansion
 	rootCmd.PersistentFlags().Bool("raw", false, "assume input trace already expanded")
 	rootCmd.PersistentFlags().Bool("sequential", false, "perform sequential trace expansion")


### PR DESCRIPTION
This provides the ability to look at the assembly instructions after they have been split.  This is primarily useful for debugging the register splitting algorithm, and perhaps not that useful for general usage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a NASM layer with a new CLI flag and schema stacking, and refactors concretization to return a mixed program plus a separate Compile step to produce MIR.
> 
> - **CLI**
>   - Add `--nasm` flag and default handling; enable stacking NASM via `NANO_ASM_LAYER`.
> - **Schema Stacker**
>   - Introduce `NANO_ASM_LAYER`; shift layer ordinals; include NASM in `names`/schemas.
>   - Build flow: `LowerMixedMacroProgram` → `Concretize` → `Compile` → optional `LowerToAir`; propagate `mapping` to trace builder.
> - **ASM**
>   - `Concretize(...)` now lowers HIR, splits registers, and returns `MicroMirProgram[F]` + `LimbsMap`.
>   - New `Compile(...)` converts mixed micro program to uniform MIR schema; extern MIR modules copied from `p.Externs()`.
>   - Remove old `lowerHirProgram`; refactor subdivision and MIR concretization usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0df5e5b95cfd785540b833b35bd42e1dc73fba23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->