### PR TITLE
fix: computed register substitute

### DIFF
--- a/pkg/ir/assignment/computed_register.go
+++ b/pkg/ir/assignment/computed_register.go
@@ -216,8 +216,15 @@ func (p *ComputedRegister[F]) RegistersWritten() []register.Ref {
 
 // Substitute any matchined labelled constants within this assignment
 func (p *ComputedRegister[F]) Substitute(mapping map[string]F) {
-	//p.Expr.Substitute(mapping)
-	panic("todo")
+	var tmp any = mapping
+	// NOTE: this is the only scenario under which this method can be called.
+	w, ok := tmp.(map[string]word.BigEndian)
+	// sanity check
+	if !ok {
+		panic("unreachable")
+	}
+	//
+	p.Expr.Substitute(w)
 }
 
 // Lisp converts this constraint into an S-Expression.


### PR DESCRIPTION
This function was not implemented; now it is.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements `ComputedRegister.Substitute` to forward mapped constants (`map[string]word.BigEndian`) into `Expr.Substitute` instead of panicking.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c91127f8fb02ee57a8256de7c8d734afc7122c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->