### PR TITLE
feat: improve error messages

### DIFF
--- a/pkg/cmd/check.go
+++ b/pkg/cmd/check.go
@@ -297,7 +297,7 @@ func reportFailure[F field.Element[F]](failure sc.Failure, trace tr.Trace[F], ma
 		reportRelevantCells(cells, trace, mapping, cfg)
 	} else if f, ok := failure.(*constraint.InternalFailure[F]); ok {
 		cells := f.RequiredCells(trace)
-		fmt.Printf("%s in %s:\n", f.Error, f.Handle)
+		fmt.Printf("%s:\n", f.Message())
 		reportRelevantCells(cells, trace, mapping, cfg)
 	}
 }

--- a/pkg/ir/assignment/computed_register.go
+++ b/pkg/ir/assignment/computed_register.go
@@ -21,6 +21,7 @@ import (
 	"github.com/consensys/go-corset/pkg/ir/term"
 	"github.com/consensys/go-corset/pkg/schema"
 	sc "github.com/consensys/go-corset/pkg/schema"
+	"github.com/consensys/go-corset/pkg/schema/constraint"
 	"github.com/consensys/go-corset/pkg/schema/module"
 	"github.com/consensys/go-corset/pkg/schema/register"
 	"github.com/consensys/go-corset/pkg/trace"
@@ -102,20 +103,20 @@ func (p *ComputedRegister[F]) Compute(tr trace.Trace[F], schema schema.AnySchema
 	// Expand the trace
 	if !p.IsRecursive() {
 		// Non-recursive computation
-		err = fwdComputation(height, wrapper.data, bitwidths, p.Expr, trModule, scModule)
+		err = fwdComputation(height, wrapper.data, bitwidths, p.Expr, trModule, scModule, p.Module)
 	} else if p.Direction {
 		// Forwards recursive computation
-		err = fwdComputation(height, wrapper.data, bitwidths, p.Expr, &wrapper, scModule)
+		err = fwdComputation(height, wrapper.data, bitwidths, p.Expr, &wrapper, scModule, p.Module)
 	} else {
 		// Backwards recursive computation
-		err = bwdComputation(height, wrapper.data, bitwidths, p.Expr, &wrapper, scModule)
+		err = bwdComputation(height, wrapper.data, bitwidths, p.Expr, &wrapper, scModule, p.Module)
 	}
 	// Sanity check
 	if err != nil {
 		return nil, err
 	}
 	// Done
-	return concretizeColumns[F](wrapper.data, tr), err
+	return concretizeColumns(wrapper.data, tr), err
 }
 
 func concretizeColumns[F field.Element[F]](data [][]word.BigEndian, tr trace.Trace[F]) []array.MutArray[F] {
@@ -258,13 +259,14 @@ func (p *ComputedRegister[F]) Lisp(schema sc.AnySchema[F]) sexp.SExp {
 }
 
 func fwdComputation(height uint, data [][]word.BigEndian, widths []uint, expr term.Evaluable[word.BigEndian],
-	trMod trace.Module[word.BigEndian], scMod register.Map) error {
+	trMod trace.Module[word.BigEndian], scMod register.Map, ctx schema.ModuleId) error {
 	// Forwards computation
 	for i := range height {
 		val, err := expr.EvalAt(int(i), trMod, scMod)
 		// error check
 		if err != nil {
-			return err
+			e := fmt.Sprintf("%s for %s", err.Error(), expr.Lisp(false, scMod).String(true))
+			return constraint.NewInternalFailure[word.BigEndian](scMod.Name().String(), ctx, i, expr, e)
 		}
 		// Write data across limbs
 		if !write(i, val, data, widths) {
@@ -278,13 +280,14 @@ func fwdComputation(height uint, data [][]word.BigEndian, widths []uint, expr te
 }
 
 func bwdComputation(height uint, data [][]word.BigEndian, widths []uint, expr term.Evaluable[word.BigEndian],
-	trMod trace.Module[word.BigEndian], scMod register.Map) error {
+	trMod trace.Module[word.BigEndian], scMod register.Map, ctx schema.ModuleId) error {
 	// Backwards computation
 	for i := height; i > 0; i-- {
 		val, err := expr.EvalAt(int(i-1), trMod, scMod)
 		// error check
 		if err != nil {
-			return err
+			e := fmt.Sprintf("%s for %s", err.Error(), expr.Lisp(false, scMod).String(true))
+			return constraint.NewInternalFailure[word.BigEndian](scMod.Name().String(), ctx, i, expr, e)
 		}
 		// Write data across limbs
 		if !write(i-1, val, data, widths) {

--- a/pkg/schema/constraint/assertion.go
+++ b/pkg/schema/constraint/assertion.go
@@ -197,7 +197,7 @@ func (p Assertion[F]) acceptRange(start, end uint, tr trace.Trace[F], sc schema.
 		// Check whether property holds (or was undefined)
 		if ok, id, err := p.Property.TestAt(int(k), trModule, scModule); err != nil {
 			// Evaluation failure
-			return coverage, &InternalFailure[F]{Handle: p.Handle, Context: p.Context, Row: k, Error: err.Error()}
+			return coverage, NewInternalFailure[F](p.Handle, p.Context, k, nil, err.Error())
 		} else if !ok {
 			return coverage, &AssertionFailure[F]{p.Handle, p.Context, p.Property, k}
 		} else {

--- a/pkg/schema/constraint/interleaving/constraint.go
+++ b/pkg/schema/constraint/interleaving/constraint.go
@@ -101,21 +101,11 @@ func (p Constraint[F, E]) Accepts(tr trace.Trace[F], sc schema.AnySchema[F]) (bi
 		s, s_err := p.Sources[row%n].EvalAt(row/n, srcTrMod, srcScMod)
 		// Checks
 		if t_err != nil {
-			return coverage, &constraint.InternalFailure[F]{
-				Handle:  p.Handle,
-				Context: p.TargetContext,
-				Row:     uint(row),
-				Term:    p.Target,
-				Error:   t_err.Error(),
-			}
+			return coverage, constraint.NewInternalFailure[F](p.Handle, p.TargetContext, uint(row),
+				p.Target, t_err.Error())
 		} else if s_err != nil {
-			return coverage, &constraint.InternalFailure[F]{
-				Handle:  p.Handle,
-				Context: p.SourceContext,
-				Row:     uint(row / n),
-				Term:    p.Sources[row%n],
-				Error:   s_err.Error(),
-			}
+			return coverage, constraint.NewInternalFailure[F](p.Handle, p.SourceContext, uint(row/n),
+				p.Sources[row%n], s_err.Error())
 		} else if t.Cmp(s) != 0 {
 			// Evaluation failure
 			return coverage, &Failure[F]{

--- a/pkg/schema/constraint/lookup/constraint.go
+++ b/pkg/schema/constraint/lookup/constraint.go
@@ -288,13 +288,7 @@ func (p *State[F, E]) insertFilteredVector(k int, vec Vector[F, E], trMod trace.
 		)
 		//
 		if err != nil {
-			return &constraint.InternalFailure[F]{
-				Handle:  p.handle,
-				Context: vec.Module,
-				Row:     uint(k),
-				Term:    vec.Selector.Unwrap(),
-				Error:   err.Error(),
-			}
+			return constraint.NewInternalFailure[F](p.handle, vec.Module, uint(k), vec.Selector.Unwrap(), err.Error())
 		}
 		// Selected when non-zero
 		selected = !ith.IsZero()
@@ -336,13 +330,7 @@ func (p *State[F, E]) checkFilteredSourceVector(k int, vec Vector[F, E], trModul
 		)
 		//
 		if err != nil {
-			return &constraint.InternalFailure[F]{
-				Handle:  p.handle,
-				Context: vec.Module,
-				Row:     uint(k),
-				Term:    vec.Selector.Unwrap(),
-				Error:   err.Error(),
-			}
+			return constraint.NewInternalFailure[F](p.handle, vec.Module, uint(k), vec.Selector.Unwrap(), err.Error())
 		}
 		// Selected when non-zero
 		selected = !ith.IsZero()
@@ -383,13 +371,7 @@ func (p *State[F, E]) evalExprsArray(k int, vec Vector[F, E], trModule trace.Mod
 		p.buffer[i], err = vec.Ith(i).EvalAt(k, trModule, scModule)
 		// error check
 		if err != nil {
-			return &constraint.InternalFailure[F]{
-				Handle:  p.handle,
-				Context: vec.Module,
-				Row:     uint(k),
-				Term:    vec.Ith(i),
-				Error:   err.Error(),
-			}
+			return constraint.NewInternalFailure[F](p.handle, vec.Module, uint(k), vec.Ith(i), err.Error())
 		}
 	}
 	// Done

--- a/pkg/schema/constraint/ranged/constraint.go
+++ b/pkg/schema/constraint/ranged/constraint.go
@@ -171,13 +171,7 @@ func (p Constraint[F, E]) accepts(i int, tr trace.Trace[F], sc schema.AnySchema[
 		kth, err := expr.EvalAt(k, trModule, scModule)
 		// Perform the range check
 		if err != nil {
-			return coverage, &constraint.InternalFailure[F]{
-				Handle:  p.Handle,
-				Context: p.Context,
-				Row:     uint(k),
-				Term:    expr,
-				Error:   err.Error(),
-			}
+			return coverage, constraint.NewInternalFailure[F](p.Handle, p.Context, uint(k), expr, err.Error())
 		} else if kth.Cmp(bound) >= 0 {
 			// Evaluation failure
 			return coverage, &Failure[F]{handle, p.Context, expr, bitwidth, uint(k)}

--- a/pkg/schema/constraint/sorted/constraint.go
+++ b/pkg/schema/constraint/sorted/constraint.go
@@ -125,19 +125,14 @@ func (p Constraint[F, E]) Accepts(tr trace.Trace[F], sc schema.AnySchema[F]) (bi
 				val, err := selector.EvalAt(int(k), trModule, scModule)
 				// Check whether active (or not)
 				if err != nil {
-					return coverage, &constraint.InternalFailure[F]{
-						Handle:  p.Handle,
-						Context: p.Context,
-						Row:     k,
-						Term:    selector,
-						Error:   err.Error()}
+					return coverage, constraint.NewInternalFailure[F](p.Handle, p.Context, k, selector, err.Error())
 				} else if val.IsZero() {
 					continue
 				}
 			}
 			// Check sorting between rows k-1 and k
 			if ok, err := sorted(k-1, k, deltaBound, p.Sources, p.Signs, p.Strict, trModule, scModule, lhs, rhs); err != nil {
-				return coverage, &constraint.InternalFailure[F]{Handle: p.Handle, Context: p.Context, Row: k, Error: err.Error()}
+				return coverage, constraint.NewInternalFailure[F](p.Handle, p.Context, k, nil, err.Error())
 			} else if !ok {
 				return coverage, &Failure{fmt.Sprintf("sorted constraint \"%s\" failed (rows %d ~ %d)", p.Handle, k-1, k)}
 			}

--- a/pkg/schema/constraint/vanishing/constraint.go
+++ b/pkg/schema/constraint/vanishing/constraint.go
@@ -166,12 +166,7 @@ func HoldsLocally[F field.Element[F], T term.Testable[F]](k uint, handle string,
 	ok, id, err := term.TestAt(int(k), trMod, scMod)
 	// Check for errors
 	if err != nil {
-		return &constraint.InternalFailure[F]{
-			Handle:  handle,
-			Context: ctx,
-			Row:     k,
-			Term:    term,
-			Error:   err.Error()}, id
+		return constraint.NewInternalFailure[F](handle, ctx, k, term, err.Error()), id
 	} else if !ok {
 		// Evaluation failure
 		return &Failure[F]{handle, term, ctx, k}, id


### PR DESCRIPTION
This improves the error messages repoted when a computed register encounters an error arising during evaluation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies InternalFailure with a constructor and richer messages (including handle/row), updates all constraints and computed register evaluation to use it, and adjusts CLI reporting to print the new message.
> 
> - **Error handling**:
>   - Introduce `constraint.NewInternalFailure()` and make `InternalFailure` fields private; `Message()` now formats as ``<handle> (row <n>) - <error>``.
>   - Switch all constraint types to use `NewInternalFailure()` (in `vanishing`, `ranged`, `sorted`, `lookup`, `interleaving`, and `assertion`).
> - **Computed registers**:
>   - Wrap evaluation errors in `NewInternalFailure()` with module context/row in `fwdComputation`/`bwdComputation` (now accept `ctx schema.ModuleId`).
>   - Minor: `concretizeColumns` no longer generic in return call site.
> - **CLI reporting (`pkg/cmd/check.go`)**:
>   - Print internal failures using `f.Message()` (removes custom handle/error formatting).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 07ff6c01ee6591647c2a616394f7a4c7dadc0244. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->