### PR TITLE
fix: address workaround in assembly tests

### DIFF
--- a/testdata/asm/unit/bit_shift.zkasm
+++ b/testdata/asm/unit/bit_shift.zkasm
@@ -23,36 +23,36 @@ base:
 ;; n bits, this operation makes n calls.  Since this is used in
 ;; conjunction with the byte_shr, it only supports n <= 7.
 fn bit_shr256(word u256, n u3) -> (res u256) {
-  var hi, lo u127
-  var b0,b1,b2 u1
+  var head u255
+  var tail u1
+  var b u1
   var m u3
   ;; check for base case
   if n == 0 goto base
-  ;; FIXME: workaround for register splitting issue
-  hi, b1, lo, b0 = word
+  head, tail = word
   ;; decrement counter
-  b2,m = n - 1
-  res = bit_shr256((hi * 2^128) + (b1 * 2^127) + lo, m)
+  b,m = n - 1
+  res = bit_shr256(head, m)
   return
 base:
   res = word
- return
+  return
 }
 
 fn bit_sar256(word u256, n u3) -> (res u256) {
-  var lo u127
-  var hi u126
+  var head u254
+  var tail u1
+  var b, sign u1
   var m u3
-  var sign, b0, b1, b2 u1
   ;; check for base case
   if n == 0 goto base
-  ;; split of trailing bit
-  sign, hi, b1, lo, b0 = word
+  ;; split of sign + head
+  sign, head, tail = word
   ;; decrement counter
-  b2, m = n - 1
-  res = bit_sar256((sign * (2^255 + 2^254)) + (hi * 2^128) + (b1 * 2^127) + lo, m)
+  b,m = n - 1
+  res = bit_sar256((sign * 0b11*2^254) + head, m)
   return
 base:
   res = word
- return
+  return
 }

--- a/testdata/asm/util/bit_sar.zkasm
+++ b/testdata/asm/util/bit_sar.zkasm
@@ -101,10 +101,10 @@ apply:
 }
 
 fn bit_sar256_u2(word u256, n u2) -> (res u256) {
-  var b u1
-  var m u1
-  var msw u256
+  var msw u253
   var lsw u2
+  var m u1
+  var sign, b u1
   ;; decompoise shift
   b,m = n
   ;;
@@ -112,33 +112,22 @@ fn bit_sar256_u2(word u256, n u2) -> (res u256) {
   res = bit_sar256_u1(word,m)
   return
 apply:
-  ;; >>> START: workaround #1176
-  var hi u125
-  var lo u126
-  var mid u2
-  var sign u1
-  sign, hi, mid, lo, lsw = word
-  msw = (sign*0b111*2^253) + (hi*2^128) + (mid*2^126) + lo
-  ;; <<< END
-  res = bit_sar256_u1(msw,m)
+  sign, msw, lsw = word
+  res = bit_sar256_u1((sign*0b111*2^253)+msw, m)
   return
 }
 
 fn bit_sar256_u1(word u256, n u1) -> (res u256) {
+  var msw u254
   var lsw u1
+  var m u1
+  var sign, b u1
   ;;
   if n!=0 goto apply
   res = word
   return
 apply:
-  ;; >>> START: workaround #1176
-  var hi u247
-  var lo u7
-  var sign, b u1
-  ;;
-  sign, hi, lo, b = word
-  ;;
-  res = (sign*0b11*2^254) + (hi * 2^7) + lo
-  ;; <<< END
+  sign, msw, lsw = word
+  res = (sign*0b11*2^254)+msw
   return
 }

--- a/testdata/asm/util/bit_shr.zkasm
+++ b/testdata/asm/util/bit_shr.zkasm
@@ -4,7 +4,7 @@
 fn bit_shr256(word u256, n u8) -> (res u256) {
   var b u1
   var m u7
-  var msw u256
+  var msw u128
   var lsw u128
   ;; decompoise shift
   b,m = n
@@ -21,7 +21,7 @@ apply:
 fn bit_shr256_u7(word u256, n u7) -> (res u256) {
   var b u1
   var m u6
-  var msw u256
+  var msw u192
   var lsw u64
   ;; decompoise shift
   b,m = n
@@ -38,7 +38,7 @@ apply:
 fn bit_shr256_u6(word u256, n u6) -> (res u256) {
   var b u1
   var m u5
-  var msw u256
+  var msw u224
   var lsw u32
   ;; decompoise shift
   b,m = n
@@ -55,7 +55,7 @@ apply:
 fn bit_shr256_u5(word u256, n u5) -> (res u256) {
   var b u1
   var m u4
-  var msw u256
+  var msw u240
   var lsw u16
   ;; decompoise shift
   b,m = n
@@ -72,7 +72,7 @@ apply:
 fn bit_shr256_u4(word u256, n u4) -> (res u256) {
   var b u1
   var m u3
-  var msw u256
+  var msw u248
   var lsw u8
   ;; decompoise shift
   b,m = n
@@ -89,7 +89,7 @@ apply:
 fn bit_shr256_u3(word u256, n u3) -> (res u256) {
   var b u1
   var m u2
-  var msw u256
+  var msw u252
   var lsw u4
   ;; decompoise shift
   b,m = n
@@ -106,7 +106,7 @@ apply:
 fn bit_shr256_u2(word u256, n u2) -> (res u256) {
   var b u1
   var m u1
-  var msw u256
+  var msw u254
   var lsw u2
   ;; decompoise shift
   b,m = n
@@ -115,13 +115,7 @@ fn bit_shr256_u2(word u256, n u2) -> (res u256) {
   res = bit_shr256_u1(word,m)
   return
 apply:
-  ;; >>> START: workaround #1176
-  var hi u126
-  var lo u126
-  var mid u2
-  hi, mid, lo, lsw = word
-  msw = (hi * 2^128) + (mid * 2^126) + lo
-  ;; <<< END
+  msw, lsw = word
   res = bit_shr256_u1(msw,m)
   return
 }
@@ -133,14 +127,6 @@ fn bit_shr256_u1(word u256, n u1) -> (res u256) {
   res = word
   return
 apply:
-  ;; >>> START: workaround #1176
-  var hi u248
-  var lo u7
-  var b u1
-  ;;
-  hi, lo, b = word
-  ;;
-  res = (hi * 2^7) + lo
-  ;; <<< END
+  res,lsw = word
   return
 }


### PR DESCRIPTION
This undoes a number of workarounds applied to certain assembly tests which were working around a limitation of the register splitting algorithm.  Since this limitation is now lifted, we don't need the workarounds :)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies 256-bit logical/arithmetic right shifts by removing register-splitting workarounds and tightening intermediate widths across unit and util bit shift assembly.
> 
> - **Assembly (bit shifts)**:
>   - **Unit tests (`testdata/asm/unit/bit_shift.zkasm`)**:
>     - Refactor `bit_shr256` and `bit_sar256` to split `word` into `head/tail` (and `sign`) and recurse without composing large intermediates.
>   - **Utilities**:
>     - `testdata/asm/util/bit_shr.zkasm`: Narrow `msw` widths at each stage (`u128/u192/u224/u240/u248/u252/u254`), remove workaround blocks, and simplify by direct `msw, lsw = word` and tail drops.
>     - `testdata/asm/util/bit_sar.zkasm`: Narrow `msw` widths at each stage, remove workaround blocks, and compute sign-extended `msw` via masks (e.g., `(sign*...)+msw`) for each decomposition step; simplify `bit_sar256_u1/u2` similarly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 606e078a3ab41edc2d86576a0520c5febea974c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->