### PR TITLE
chore: restore hosted github runners

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-large
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b #v5.4.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           - { field: GF_8209,      test: corset-racer }
           - { field: GF_8209,      test: unit-test }
       fail-fast: false
-    runs-on: ubuntu-latest #gha-runner-scale-set-ubuntu-22.04-amd64-large
+    runs-on: gha-runner-scale-set-ubuntu-22.04-amd64-large
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b #v5.4.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switch CI lint and test workflows to run on `gha-runner-scale-set-ubuntu-22.04-amd64-large` instead of GitHub-hosted `ubuntu-latest`.
> 
> - **CI / GitHub Actions**:
>   - Update runner in `/.github/workflows/lint.yml` to `gha-runner-scale-set-ubuntu-22.04-amd64-large`.
>   - Update runner in `/.github/workflows/test.yml` to `gha-runner-scale-set-ubuntu-22.04-amd64-large`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 123cb904d123f0147720fef6254c63e539b2d507. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->