### PR TITLE
fix: CommonLimbWidth calculation

### DIFF
--- a/pkg/schema/register/limb.go
+++ b/pkg/schema/register/limb.go
@@ -103,7 +103,7 @@ func CommonLimbWidth(maxRegisterWidth uint, registerWidth uint) uint {
 	)
 	// Now, round up our average limb width to the nearest power of two.  This
 	// is because we "prefer" widths to be powers of two.
-	for ; (avgWidth * n) < registerWidth; avgWidth = avgWidth * 2 {
+	for ; (avgWidth*n) < registerWidth && (avgWidth*2 <= maxRegisterWidth); avgWidth = avgWidth * 2 {
 	}
 	//
 	return avgWidth


### PR DESCRIPTION
This was not guaranteeing to return a common limb width which was below the maximum limb width.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `CommonLimbWidth` never exceeds the maximum register width by capping power-of-two growth in its loop condition.
> 
> - **Register splitting**:
>   - Update `CommonLimbWidth` in `pkg/schema/register/limb.go` to cap power-of-two widening using `avgWidth*2 <= maxRegisterWidth`, preventing limb widths from exceeding the configured maximum.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 62cea7dbb32756459cda246f1eabe22b106e4e5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->