### PR TITLE
fix: oob failures

### DIFF
--- a/testdata/asm/bench/oob_prc.zkasm
+++ b/testdata/asm/bench/oob_prc.zkasm
@@ -218,9 +218,9 @@ fn oob_cds_valid(INST=0xFF01 u16, call_data_size u32) -> (cds_valid=1 u1) {
   if INST == OOB_INST_BLS_G2_ADD goto cds_512
   if INST == OOB_INST_BLS_MAP_FP_TO_G1 goto cds_64
   if INST == OOB_INST_BLS_MAP_FP2_TO_G2 goto cds_128
-  if INST == OOB_INST_BLS_G1_MSM goto cds_mod160
-  if INST == OOB_INST_BLS_G2_MSM goto cds_mod288
-  if INST == OOB_INST_BLS_PAIRING_CHECK goto cds_mod384
+  if INST == OOB_INST_BLS_G1_MSM goto cds_mod160nz
+  if INST == OOB_INST_BLS_G2_MSM goto cds_mod288nz
+  if INST == OOB_INST_BLS_PAIRING_CHECK goto cds_mod384nz
   ;; default case
   goto exit_s
 cds_64:
@@ -241,26 +241,29 @@ cds_256:
 cds_512:
   if call_data_size == 512 goto exit_s
   goto exit_f
-cds_mod160:
-  ;; check cds%160==0
+cds_mod160nz:
+  ;; check cds%160==0 ∧ cds!=0
   divisor = 160
-  goto cds_mod
+  goto cds_mod_nz
 cds_mod192:
   ;; check cds%192==0
   divisor = 192
   goto cds_mod
-cds_mod288:
-  ;; check cds%288==0
+cds_mod288nz:
+  ;; check cds%288==0 ∧ cds!=0
   divisor = 288
-  goto cds_mod
-cds_mod384:
-  ;; check cds%384==0
+  goto cds_mod_nz
+cds_mod384nz:
+  ;; check cds%384==0 ∧ cds!=0
   divisor = 384
-  goto cds_mod
+  goto cds_mod_nz
+cds_mod_nz:
+  ;; ensure cds != 0
+  if call_data_size == 0 goto exit_f
 cds_mod:
-  ;; compute cds%288
+  ;; compute cds%n
   quot,rem,wit,sum,witsum = call_data_size / divisor
-  ;; check cds%288==0
+  ;; check cds%n==0
   if rem==0 goto exit_s
   goto exit_f
 exit_f:


### PR DESCRIPTION
Fixes two failures related to missing checks in `oob_prc` for `P256_VERIFY` and `BLS_PAIRING_CHECK`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Addresses missing validations in OOB precompile checks.
> 
> - Special-cases `OOB_INST_P256_VERIFY` in `oob_prc_pricing`: sets `empty_call_data=0`, and `extract_call_data` is `1` only when `cds==160` (bypasses generic `cds_valid`).
> - Tightens `oob_cds_valid` for BLS ops: `BLS_G1_MSM`, `BLS_G2_MSM`, and `BLS_PAIRING_CHECK` now require `cds%160/288/384==0` and `cds!=0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e10db5f0cc53d1acff21825990d9fff36e6f1ccc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->