### PR TITLE
fix: delay branch always taken check

### DIFF
--- a/pkg/asm/assembler/parser.go
+++ b/pkg/asm/assembler/parser.go
@@ -474,12 +474,6 @@ func (p *Parser) parseIfGoto(env *Environment) (macro.Instruction, []source.Synt
 	if rhs, errs = p.parseAtomicExpr(env); len(errs) > 0 {
 		return nil, errs
 	}
-	// sanity check
-	if _, lhsConst := lhs.(*expr.Const); lhsConst {
-		if _, rhsConst := rhs.(*expr.Const); rhsConst {
-			return nil, p.syntaxErrors(p.tokens[p.index-1], "branch always (or never) taken")
-		}
-	}
 	// Parse "goto"
 	if errs = p.parseKeyword("goto"); len(errs) > 0 {
 		return nil, errs

--- a/pkg/asm/io/macro/IfGoto.go
+++ b/pkg/asm/io/macro/IfGoto.go
@@ -174,6 +174,12 @@ func (p *IfGoto) Validate(fieldWidth uint, fn register.Map) error {
 			return fmt.Errorf("never taken")
 		}
 	}
+	// sanity check
+	if _, lhsConst := p.Left.(*expr.Const); lhsConst {
+		if _, rhsConst := p.Right.(*expr.Const); rhsConst {
+			return fmt.Errorf("branch always (or never) taken")
+		}
+	}
 	//
 	return nil
 }


### PR DESCRIPTION
The check for whether or not a branch is always (or never) taken was happening in the parser, even before linking had occurred.  This meant that variables which were not known (i.e. did not exist) were assumed to be constants, leading to a mistaken error that a branch was always (or never) taken.

Delaying the check until after linking occurs means that it only triggers for the case of two constants being compared.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts branch determinism validation to post-link time.
> 
> - Removes constant–constant sanity check from `parser.parseIfGoto()`
> - Adds equivalent check in `macro.IfGoto.Validate()` to error when both sides are `expr.Const`
> 
> This ensures the check runs during validation (after linking), preventing pre-link misclassification of unknown identifiers as constants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5a7497b77b2f17d6b9cae5b4fa5a04b732bbda59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->