### PR TITLE
feat: simplify expansion for direct casts

### DIFF
--- a/pkg/ir/term/term.go
+++ b/pkg/ir/term/term.go
@@ -288,7 +288,7 @@ func SubdivideLogicals[F field.Element[F], S Logical[F, S], T Expr[F, T]](cs []S
 // ============================================================================
 
 // IsUnsafeExpr determines whether or not a given expression contains an unsafe
-// operation (i.e. a runtime case).  Specifically, something which could fail at
+// operation (i.e. a runtime cast).  Specifically, something which could fail at
 // runtime.
 func IsUnsafeExpr[F field.Element[F], S Logical[F, S], T Expr[F, T]](c T) bool {
 	var f Expr[F, T] = any(c).(Expr[F, T])


### PR DESCRIPTION
This simplifies the expansion needed for a cast on a direct register. Specifically, the cast no longer results in a computed column being created.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies lowering by recognizing direct register accesses (including casts) and bypassing computed column expansion.
> 
> - `expandTerm` now short-circuits via new `isRegisterAccess` to return a masked `RawRegisterAccess` for `RegisterAccess` and `Cast` over a direct register; constants 0/1 unchanged
> - Adds `isRegisterAccess` with sanity check for out-of-bounds casts; propagates mask/shift
> - Updates comments/messages to refer to runtime “cast” (not “case”) and applies unsafe-expression guarding in lookup vector lowering
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3367ff86c555b60a0b6c979bcd318226715c035e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->