### PR TITLE
fix: top-level source files being included twice

### DIFF
--- a/pkg/asm/assemble.go
+++ b/pkg/asm/assemble.go
@@ -78,6 +78,10 @@ func Assemble(files ...source.File) (
 		srcmaps    source.Maps[any]
 		visited    map[string]bool = make(map[string]bool)
 	)
+	// Initialise visited map with all top-level files
+	for _, sf := range files {
+		visited[sf.Filename()] = true
+	}
 	// Parse each file in turn.
 	for len(files) > 0 {
 		var (


### PR DESCRIPTION
It was possible for top-level source files to be included twice. Specifically, when a top-level file was also included by some other top-level file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures top-level source files are not processed twice when they are also included by other files.
> 
> - Initialize `visited` with all input files in `Assemble`, so includes of these files are skipped
> - `readIncludedFiles` continues to guard on `visited` to prevent duplicate loads
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59c97dbfa7260c0f061b7967f4dcb8f4c3908764. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->