### PR TITLE
fix: usages of NumberOfLimbs

### DIFF
--- a/pkg/schema/register/limb.go
+++ b/pkg/schema/register/limb.go
@@ -31,21 +31,20 @@ type LimbId = Id
 // bits than the maximum allowed.
 func SplitIntoLimbs(maxWidth uint, r Register) []Register {
 	var (
-		nlimbs     = NumberOfLimbs(maxWidth, r.Width())
-		limbs      = make([]Register, nlimbs)
 		limbWidths = LimbWidths(maxWidth, r.Width())
+		limbs      = make([]Register, len(limbWidths))
 		// Split padding value
 		padding = SplitConstant(*r.Padding(), limbWidths...)
 	)
 	// Special case when register doesn't require splitting.  This is useful
 	// because we want to retain the original register name exactly.
-	if nlimbs <= 1 {
+	if len(limbs) <= 1 {
 		return []Register{r}
 	}
 	//
-	for i := range nlimbs {
+	for i, limbWidth := range limbWidths {
 		ith_name := fmt.Sprintf("%s'%d", r.Name(), i)
-		limbs[i] = New(r.Kind(), ith_name, limbWidths[i], padding[i])
+		limbs[i] = New(r.Kind(), ith_name, limbWidth, padding[i])
 	}
 	//
 	return limbs
@@ -54,13 +53,12 @@ func SplitIntoLimbs(maxWidth uint, r Register) []Register {
 // LimbWidths determines the limb widths for any register of the given size.
 func LimbWidths(maxWidth, regWidth uint) []uint {
 	var (
-		nlimbs       = NumberOfLimbs(maxWidth, regWidth)
+		commonWidth  = commonLimbWidth(maxWidth, regWidth)
+		nlimbs       = minNumberOfLimbs(commonWidth, regWidth)
 		limbWidths   = make([]uint, nlimbs)
 		bitsLeft     = regWidth
 		accLimbWidth uint
 	)
-	//
-	commonWidth := commonLimbWidth(maxWidth, regWidth)
 	//
 	for i := range nlimbs {
 		if i+1 != nlimbs {
@@ -88,22 +86,6 @@ func LimbWidths(maxWidth, regWidth uint) []uint {
 	return limbWidths
 }
 
-// NumberOfLimbs determines the number of register limbs required for a given
-// bitwidth. For example, a 64bit register splits into two limbs for a maximum
-// register width of 32bits. Observe that an e.g. 60bit register also splits
-// into two limbs here as well, where the most significant limb is 28bits wide
-// and the least significant is 32bits width.
-func NumberOfLimbs(maxRegisterWidth uint, registerWidth uint) uint {
-	n := registerWidth / maxRegisterWidth
-	m := registerWidth % maxRegisterWidth
-	// Check for uneven split
-	if m != 0 {
-		return n + 1
-	}
-	//
-	return n
-}
-
 // commonLimbWidth returns the "common" limb width when splitting a given
 // register for a given maximum width.  Assume a given register splits into n
 // limbs.  Assuming n > 1, then n-1 of these will have the same "common" width.
@@ -112,7 +94,7 @@ func NumberOfLimbs(maxRegisterWidth uint, registerWidth uint) uint {
 func commonLimbWidth(maxRegisterWidth uint, registerWidth uint) uint {
 	var (
 		// Determine how many limbs required
-		n = NumberOfLimbs(maxRegisterWidth, registerWidth)
+		n = minNumberOfLimbs(maxRegisterWidth, registerWidth)
 		//
 		avgWidth = uint(1)
 	)
@@ -122,4 +104,20 @@ func commonLimbWidth(maxRegisterWidth uint, registerWidth uint) uint {
 	}
 	//
 	return avgWidth
+}
+
+// minNumberOfLimbs determines the minimum number of register limbs required for
+// a given bitwidth. For example, a 64bit register splits into two limbs for a
+// maximum register width of 32bits. Observe that an e.g. 60bit register also
+// splits into two limbs here as well, where the most significant limb is 28bits
+// wide and the least significant is 32bits width.
+func minNumberOfLimbs(maxRegisterWidth uint, registerWidth uint) uint {
+	n := registerWidth / maxRegisterWidth
+	m := registerWidth % maxRegisterWidth
+	// Check for uneven split
+	if m != 0 {
+		return n + 1
+	}
+	//
+	return n
 }


### PR DESCRIPTION
In some places, this function was being used incorrectly.  This is because it doesn't calculate correctly the number of limbs required. Rather it calculates a lower bound on the number of limbs required.  The problem is that it doesn't determine the common limb width during its calculation.

To resolve this, the LimbWidths() function now becomes the primary source of information about the number of limbs required for a given register.  This makes use of commonWidths to determine the right number of limbs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes register limb-splitting math, which can affect column/constraint geometry and serialization of split registers; mistakes would surface as mis-sized limbs or panics during compilation.
> 
> **Overview**
> Fixes limb splitting to derive the number of limbs from `LimbWidths()` (using the computed common limb width) rather than from a naive division-based count.
> 
> This updates `SplitIntoLimbs`/`LimbWidths`/`commonLimbWidth` to use `minNumberOfLimbs` and removes the old `NumberOfLimbs` helper, preventing under-allocation when the preferred power-of-two common width is smaller than the max width.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 097056e7177398ab70da5e4122ec21ab8781079b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->