### PR TITLE
fix: improve error reporting

### DIFF
--- a/pkg/ir/module_builder.go
+++ b/pkg/ir/module_builder.go
@@ -248,12 +248,12 @@ type externalModuleBuilder[F field.Element[F], C schema.Constraint[F], T term.Ex
 
 // AddAssignment implementation for ModuleBuilder interface.
 func (p *externalModuleBuilder[F, C, T]) AddAssignment(assignment schema.Assignment[F]) {
-	panic("cannot add assignment to external module")
+	panic(fmt.Sprintf("cannot add assignment to external module (%s)", p.module.Name()))
 }
 
 // AddConstraint implementation for ModuleBuilder interface.
 func (p *externalModuleBuilder[F, C, T]) AddConstraint(constraint C) {
-	panic("cannot add constraint to external module")
+	panic(fmt.Sprintf("cannot add constraint (%s) to external module (%s)", constraint.Name(), p.module.Name()))
 }
 
 // Assignments implementation for ModuleBuilder interface.
@@ -313,7 +313,7 @@ func (p *externalModuleBuilder[F, C, T]) Name() module.Name {
 
 // NewRegister implementation for ModuleBuilder interface.
 func (p *externalModuleBuilder[F, C, T]) NewRegister(reg register.Register) register.Id {
-	panic("cannot add register to external module")
+	panic(fmt.Sprintf("cannot add register (%s) to external module (%s)", reg.Name(), p.module.Name()))
 }
 
 // NewRegisters implementation for ModuleBuilder interface.


### PR DESCRIPTION
This improves error reporting when attempting to add constraints, assignments or registers into "external modules".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only panic message formatting when invalid operations are performed on external modules, with no impact to normal control flow.
> 
> **Overview**
> Improves error reporting when code mistakenly tries to mutate an external module: `AddAssignment`, `AddConstraint`, and `NewRegister` now panic with the target external module name (and the constraint/register name where applicable) instead of a generic message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d9bd82f39e097ab4f3640619425dc95c555b233. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->