### PR TITLE
feat: prevent duplicate instruction inlinling

### DIFF
--- a/pkg/asm/compiler/state.go
+++ b/pkg/asm/compiler/state.go
@@ -273,7 +273,7 @@ func (p *StateTranslator[F, T, E, M]) WithGlobalConstancies(condition E) E {
 }
 
 func (p *StateTranslator[F, T, E, M]) translateCode(cc uint, codes []micro.Code) E {
-	switch codes[cc].(type) {
+	switch c := codes[cc].(type) {
 	case *micro.Assign:
 		return p.translateAssign(cc, codes)
 	case *micro.Division:
@@ -286,8 +286,10 @@ func (p *StateTranslator[F, T, E, M]) translateCode(cc uint, codes []micro.Code)
 		return p.translateJmp(cc, codes)
 	case *micro.Ret:
 		return p.translateRet()
-	case *micro.Skip:
+	case *micro.SkipIf:
 		return p.translateSkip(cc, codes)
+	case *micro.Skip:
+		return p.translateCode(cc+1+c.Skip, codes)
 	default:
 		panic("unreachable")
 	}

--- a/pkg/asm/io/macro/IfGoto.go
+++ b/pkg/asm/io/macro/IfGoto.go
@@ -110,13 +110,13 @@ func (p *IfGoto) Lower(pc uint) micro.Instruction {
 	switch p.Cond {
 	case EQ:
 		codes = []micro.Code{
-			&micro.Skip{Left: lhs, Right: rhs, Skip: 1},
+			&micro.SkipIf{Left: lhs, Right: rhs, Skip: 1},
 			&micro.Jmp{Target: p.Target},
 			&micro.Jmp{Target: pc + 1},
 		}
 	case NEQ:
 		codes = []micro.Code{
-			&micro.Skip{Left: lhs, Right: rhs, Skip: 1},
+			&micro.SkipIf{Left: lhs, Right: rhs, Skip: 1},
 			&micro.Jmp{Target: pc + 1},
 			&micro.Jmp{Target: p.Target},
 		}

--- a/pkg/asm/io/macro/divide.go
+++ b/pkg/asm/io/macro/divide.go
@@ -100,9 +100,9 @@ func (p *Division) Lower(pc uint) micro.Instruction {
 			Source:  p.Remainder.Polynomial().Add(p.Witness.Polynomial()).AddScalar(one),
 		},
 		// [assertion 1] if sum != dividend goto fail
-		&micro.Skip{Left: p.Sum.Register, Right: p.Dividend.ToMicroExpr(), Skip: 2},
+		&micro.SkipIf{Left: p.Sum.Register, Right: p.Dividend.ToMicroExpr(), Skip: 2},
 		// [assertion 2] if witsum != divisor goto fail
-		&micro.Skip{Left: p.WitSum.Register, Right: p.Divisor.ToMicroExpr(), Skip: 1},
+		&micro.SkipIf{Left: p.WitSum.Register, Right: p.Divisor.ToMicroExpr(), Skip: 1},
 		// Branch
 		&micro.Jmp{Target: pc + 1},
 		// fail

--- a/pkg/asm/io/macro/ite.go
+++ b/pkg/asm/io/macro/ite.go
@@ -89,7 +89,7 @@ func (p *IfThenElse) Lower(pc uint) micro.Instruction {
 	switch p.Cond {
 	case EQ:
 		codes = []micro.Code{
-			&micro.Skip{Left: lhs, Right: rhs, Skip: 2},
+			&micro.SkipIf{Left: lhs, Right: rhs, Skip: 2},
 			// Then branch
 			&micro.Assign{Targets: p.Targets, Source: thenBranch},
 			&micro.Jmp{Target: pc + 1},
@@ -99,7 +99,7 @@ func (p *IfThenElse) Lower(pc uint) micro.Instruction {
 		}
 	case NEQ:
 		codes = []micro.Code{
-			&micro.Skip{Left: lhs, Right: rhs, Skip: 2},
+			&micro.SkipIf{Left: lhs, Right: rhs, Skip: 2},
 			// Then branch
 			&micro.Assign{Targets: p.Targets, Source: elseBranch},
 			&micro.Jmp{Target: pc + 1},

--- a/pkg/asm/io/micro/skip_if.go
+++ b/pkg/asm/io/micro/skip_if.go
@@ -1,0 +1,160 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package micro
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/consensys/go-corset/pkg/asm/io"
+	"github.com/consensys/go-corset/pkg/schema/agnostic"
+	"github.com/consensys/go-corset/pkg/schema/register"
+)
+
+// SkipIf microcode performs a conditional skip over a given number of codes. The
+// condition is either that two registers are equal, or that they are not equal.
+// This has two variants: register-register; and, register-constant.  The latter
+// is indiciated when the right register is marked as UNUSED.
+type SkipIf struct {
+	// Left and right comparisons
+	Left io.RegisterId
+	//
+	Right Expr
+	// Skip
+	Skip uint
+}
+
+// Clone this micro code.
+func (p *SkipIf) Clone() Code {
+	//
+	return &SkipIf{
+		Left:  p.Left,
+		Right: p.Right,
+		Skip:  p.Skip,
+	}
+}
+
+// MicroExecute a given micro-code, using a given local state.  This may update
+// the register values, and returns either the number of micro-codes to "skip
+// over" when executing the enclosing instruction or, if skip==0, a destination
+// program counter (which can signal return of enclosing function).
+func (p *SkipIf) MicroExecute(state io.State) (uint, uint) {
+	var (
+		lhs = state.Load(p.Left)
+		rhs = p.Right.Eval(state)
+	)
+	//
+	if lhs.Cmp(rhs) != 0 {
+		return 1 + p.Skip, 0
+	} else {
+		return 1, 0
+	}
+}
+
+// RegistersRead returns the set of registers read by this instruction.
+func (p *SkipIf) RegistersRead() []io.RegisterId {
+	if p.Right.HasFirst() {
+		return []io.RegisterId{p.Left, p.Right.First()}
+	}
+	//
+	return []io.RegisterId{p.Left}
+}
+
+// RegistersWritten returns the set of registers written by this instruction.
+func (p *SkipIf) RegistersWritten() []io.RegisterId {
+	return nil
+}
+
+// Split this micro code using registers of arbirary width into one or more
+// micro codes using registers of a fixed maximum width.
+func (p *SkipIf) Split(mapping register.LimbsMap, _ agnostic.RegisterAllocator) []Code {
+	//
+	if p.Right.HasSecond() {
+		return splitRegConst(p.Left, p.Right.Second(), p.Skip, mapping)
+	}
+	//
+	return splitRegReg(p.Left, p.Right.First(), p.Skip, mapping)
+}
+
+func (p *SkipIf) String(fn register.Map) string {
+	var (
+		l = fn.Register(p.Left).Name()
+		r = p.Right.String(fn)
+	)
+	//
+	return fmt.Sprintf("skip %s!=%s %d", l, r, p.Skip)
+}
+
+// Validate checks whether or not this instruction is correctly balanced.
+func (p *SkipIf) Validate(fieldWidth uint, fn register.Map) error {
+	var (
+		lw = fn.Register(p.Left).Width()
+		rw = p.Right.Bitwidth(fn)
+	)
+	//
+	if p.Right.HasSecond() {
+		//
+		if lw < rw {
+			return fmt.Errorf("bit overflow (u%d into u%d)", lw, rw)
+		}
+	}
+	//
+	return nil
+}
+
+func splitRegConst(left register.Id, right big.Int, skip uint, mapping register.LimbsMap) []Code {
+	var (
+		lhsLimbs = mapping.LimbIds(left)
+		ncodes   []Code
+		n        = uint(len(lhsLimbs))
+	)
+	//
+	skip = skip + n - 1
+	//
+	lhsLimbWidths := register.WidthsOfLimbs(mapping, lhsLimbs)
+	constantLimbs := register.SplitConstant(right, lhsLimbWidths...)
+	//
+	for i := range n {
+		ncode := &SkipIf{lhsLimbs[i], NewConstant(constantLimbs[i]), skip - i}
+		ncodes = append(ncodes, ncode)
+	}
+	//
+	return ncodes
+}
+
+func splitRegReg(left, right register.Id, skip uint, mapping register.LimbsMap) []Code {
+	var (
+		lhsLimbs   = mapping.LimbIds(left)
+		rhsLimbs   = mapping.LimbIds(right)
+		ncodes     []Code
+		nLhs, nRhs = uint(len(lhsLimbs)), uint(len(rhsLimbs))
+		n          = max(nLhs, nRhs)
+	)
+	//
+	skip = skip + n - 1
+	//
+	for i := range n {
+		var ncode Code
+		if i < nLhs && i < nRhs {
+			ncode = &SkipIf{lhsLimbs[i], NewRegister(rhsLimbs[i]), skip - i}
+		} else if i < nLhs {
+			ncode = &SkipIf{lhsLimbs[i], NewConstant64(0), skip - i}
+		} else {
+			ncode = &SkipIf{rhsLimbs[i], NewConstant64(0), skip - i}
+		}
+		//
+		ncodes = append(ncodes, ncode)
+	}
+	//
+	return ncodes
+}


### PR DESCRIPTION
This puts in place a mechanism to prevent inlining the same branch target more than once.  Instead, a branch target is inlined and then any subsequent calls to it simply exploit a skip.  This reduces the width of the instruction and (hopefully) will help with branch table optimisation.  Key to this mechanism was the introduction of an unconditional skip instruction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates microcode control-flow and vectorisation/inlining logic, which can affect generated instruction streams and constraint translation. Risk is moderate because changes touch branch handling (`SkipIf`/`Skip`) and jump retargeting during lowering.
> 
> **Overview**
> Separates conditional skipping into a new `micro.SkipIf` while redefining `micro.Skip` as an **unconditional** skip, and updates all macro lowering sites (`IfGoto`, `ite`, `divide`) plus compiler translation to use the correct variant.
> 
> Enhances vectorisation/inlining in `lower.go` to **avoid inlining the same jump target multiple times**: tracks previously-inlined targets and replaces subsequent `jmp`s with an unconditional `Skip` to the earlier inlined micro-offset, using the new `Instruction.LastJump()` helper and updated skip retargeting/validation logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8910c8b0ba1a4077587900398e3f2a322c03cde3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->