### PR TITLE
feat: move stacker.build() outwards

### DIFF
--- a/pkg/test/util/check_valid.go
+++ b/pkg/test/util/check_valid.go
@@ -220,6 +220,8 @@ func checkTraces[F field.Element[F]](t *testing.T, test string, maxPadding uint,
 	if !cfg.expand {
 		maxPadding = 0
 	}
+	// Configure stack.
+	stack := stacker.Build()
 	// Run through all configurations.
 	for padding := uint(0); padding <= maxPadding; padding++ {
 		// Fork trace
@@ -234,9 +236,6 @@ func checkTraces[F field.Element[F]](t *testing.T, test string, maxPadding uint,
 					// However, we still want to test the pipeline (i.e. since that is used
 					// in production); therefore, we just restrict how much its used.
 					var parallel = (i == 0)
-					// Configure stack.  This ensures true separation between
-					// runs (e.g. for the io.Executor).
-					stack := stacker.Build()
 					//
 					if tf.RawModules() != nil {
 						// Construct trace identifier


### PR DESCRIPTION
This moves a specific call within the checkTraces() function into a more outward position in order to prevent a full recompilation for each unique trace.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only performance refactor that reuses a built stack; main risk is unintended shared state across iterations if `Build()` had been relied on for isolation.
> 
> **Overview**
> `checkTraces()` now calls `stacker.Build()` once up front and reuses the resulting `stack` across all trace/IR/padding iterations, instead of rebuilding it for each trace.
> 
> This reduces redundant recompilation/stack setup during test runs while keeping the rest of the trace checking flow unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93a637e43b3be5d4b73dd2645d34f723e13c1da1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->