### PR TITLE
feat: support showing low-level computed registers

### DIFF
--- a/pkg/cmd/debug/module_stats.go
+++ b/pkg/cmd/debug/module_stats.go
@@ -26,7 +26,7 @@ import (
 func PrintModuleStats[F field.Element[F]](stack cmd_util.SchemaStack[F], maxCellWidth uint, sorter uint) {
 	var (
 		//
-		schema      = stack.UniqueConcreteSchema()
+		schema      = stack.ConcreteSchema()
 		summarisers = getModuleSummarisers[F]()
 		m           = 1 + uint(len(summarisers))
 		n           = schema.Width()

--- a/pkg/cmd/debug/schema.go
+++ b/pkg/cmd/debug/schema.go
@@ -36,9 +36,7 @@ func PrintSchemas[F field.Element[F]](stack cmd_util.SchemaStack[F], textwidth u
 		printSchema(schema, textwidth)
 	}
 	//
-	for _, schema := range stack.ConcreteSchemas() {
-		printSchema(schema, textwidth)
-	}
+	printSchema(stack.ConcreteSchema(), textwidth)
 }
 
 // Print out all declarations included in a given

--- a/pkg/cmd/debug/stats.go
+++ b/pkg/cmd/debug/stats.go
@@ -31,23 +31,20 @@ import (
 // such as the number and type of constraints, etc.
 func PrintStats[F field.Element[F]](stack cmd_util.SchemaStack[F]) {
 	var (
-		schemas     = stack.ConcreteSchemas()
+		schema      = stack.ConcreteSchema()
 		summarisers = getSummerisers[F]()
 		//
-		n   = 1 + uint(len(schemas))
 		m   = uint(len(summarisers))
-		tbl = termio.NewFormattedTable(n, m)
+		tbl = termio.NewFormattedTable(2, m)
 	)
 	// Go!
 	for i := uint(0); i < m; i++ {
 		ith := summarisers[i]
-		row := make([]termio.FormattedText, n)
+		row := make([]termio.FormattedText, 2)
 		row[0] = termio.NewText(ith.name)
 
-		for j := 0; j < len(schemas); j++ {
-			count := ith.summary(schemas[j])
-			row[j+1] = termio.NewText(fmt.Sprintf("%d", count))
-		}
+		count := ith.summary(schema)
+		row[1] = termio.NewText(fmt.Sprintf("%d", count))
 
 		tbl.SetRow(i, row...)
 	}

--- a/pkg/cmd/generate.go
+++ b/pkg/cmd/generate.go
@@ -95,7 +95,7 @@ func runGenerateCmd[F field.Element[F]](cmd *cobra.Command, args []string) {
 		// build schema stack
 		stack := stacker.Build()
 		// NOTE: assume defensive padding is enabled.
-		spillage := determineSpillage(stack.LowestConcreteSchema(), true)
+		spillage := determineSpillage(stack.ConcreteSchema(), true)
 		// Generate appropriate Java source
 		source, err = generate.JavaTraceClass(filename, pkgname, super, spillage, binf)
 		// check for errors

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -151,10 +151,12 @@ func getSchemaStack[F field.Element[F]](cmd *cobra.Command, mode uint, filenames
 	// Assembly lowering config
 	asmConfig.Vectorize = GetFlag(cmd, "vectorize")
 	asmConfig.Field = *fieldConfig
-	//
 	// Sanity check MIR optimisation level
 	if optimisation >= uint(len(mir.OPTIMISATION_LEVELS)) {
 		fmt.Printf("invalid optimisation level %d\n", optimisation)
+		os.Exit(2)
+	} else if countFlags(asmEnable, uasmEnable, nasmEnable, mirEnable, airEnable) > 1 {
+		fmt.Printf("cannot specify more than one of --asm/uasm/nasm/mir/air\n")
 		os.Exit(2)
 	}
 	// If no IR was specified, set a default
@@ -210,6 +212,16 @@ func getSchemaStack[F field.Element[F]](cmd *cobra.Command, mode uint, filenames
 	stacker = stacker.WithTraceBuilder(builder)
 	// Done
 	return &stacker
+}
+
+func countFlags(flags ...bool) (r uint) {
+	for _, f := range flags {
+		if f {
+			r++
+		}
+	}
+	//
+	return r
 }
 
 func init() {

--- a/pkg/cmd/util/schema_stack.go
+++ b/pkg/cmd/util/schema_stack.go
@@ -56,10 +56,11 @@ func (p *SchemaStack[F]) BinaryFile() *binfile.BinaryFile {
 	return &bf
 }
 
-// ConcreteSchemas returns the stack of concrete schemas according to the selected
+// ConcreteSchema returns the stack of concrete schemas according to the selected
 // layers, where higher-level layers come first.
-func (p *SchemaStack[F]) ConcreteSchemas() []schema.AnySchema[F] {
-	return p.concreteSchemas
+func (p *SchemaStack[F]) ConcreteSchema() schema.AnySchema[F] {
+	var n = len(p.concreteSchemas) - 1
+	return p.concreteSchemas[n]
 }
 
 // ConcreteSchemaOf returns the schema associated with the given IR representation.  If
@@ -76,33 +77,17 @@ func (p *SchemaStack[F]) ConcreteSchemaOf(ir string) schema.AnySchema[F] {
 	panic(fmt.Sprintf("schema for %s not found", ir))
 }
 
-// HasUniqueSchema determines whether or not we have exactly one schema.
-func (p *SchemaStack[F]) HasUniqueSchema() bool {
-	return len(p.concreteSchemas) == 1
-}
-
 // RegisterMapping returns the register mapping used to split registers
 // according to the given field configuration.
 func (p *SchemaStack[F]) RegisterMapping() module.LimbsMap {
 	return p.mapping
 }
 
-// UniqueConcreteSchema returns the first schema on the stack which, when
-// HasUniqueSchema() holds, means the uniquely specified schema.
-func (p *SchemaStack[F]) UniqueConcreteSchema() schema.AnySchema[F] {
-	return p.concreteSchemas[0]
-}
-
-// LowestConcreteSchema returns the last (i.e. lowest) schema on the stack.
-func (p *SchemaStack[F]) LowestConcreteSchema() schema.AnySchema[F] {
-	n := len(p.concreteSchemas) - 1
-	return p.concreteSchemas[n]
-}
-
 // ConcreteIrName returns a human-readable anacronym of the IR used to generate the
 // corresponding SCHEMA.
-func (p *SchemaStack[F]) ConcreteIrName(index uint) string {
-	return p.names[len(p.abstractSchemas)+int(index)]
+func (p *SchemaStack[F]) ConcreteIrName() string {
+	var n = len(p.concreteSchemas) - 1
+	return p.names[len(p.abstractSchemas)+n]
 }
 
 // TraceBuilder returns a configured trace builder.

--- a/pkg/cmd/view/builder.go
+++ b/pkg/cmd/view/builder.go
@@ -35,6 +35,8 @@ type Builder[F field.Element[F]] struct {
 	// Limbs indicates whether or not to show the raw limbs, or the combined
 	// source-level register.
 	limbs bool
+	// Computed indicates whether or not to show (low-level) computed registers
+	computed bool
 	// Default cell width to use
 	cellWidth uint
 	// Default title width to use
@@ -51,7 +53,7 @@ type Builder[F field.Element[F]] struct {
 
 // NewBuilder constructs a default builder.
 func NewBuilder[F field.Element[F]](mapping module.LimbsMap) Builder[F] {
-	return Builder[F]{util.None[CellRefSet](), false, 16, 16, mapping,
+	return Builder[F]{util.None[CellRefSet](), false, false, 16, 16, mapping,
 		DefaultFormatter(), util.None[corset.SourceMap]()}
 }
 
@@ -79,6 +81,15 @@ func (p Builder[F]) WithLimbs(limbs bool) Builder[F] {
 	var builder = p
 	//
 	builder.limbs = limbs
+	//
+	return builder
+}
+
+// WithComputed determines whether to show low-level computed registers.
+func (p Builder[F]) WithComputed(computed bool) Builder[F] {
+	var builder = p
+	//
+	builder.computed = computed
 	//
 	return builder
 }
@@ -112,7 +123,7 @@ func (p Builder[F]) Build(trace tr.Trace[F]) TraceView {
 		trMod := trace.Module(i)
 		scMod := p.mapping.Module(i)
 		//
-		public, columns := extractSourceMapData(trMod.Name(), p.limbs, srcmap, scMod)
+		public, columns := extractSourceMapData(trMod, p.limbs, p.computed, srcmap, scMod)
 		//
 		data := newModuleData(i, scMod, trMod, public, enums, columns)
 		// construct initial module view
@@ -148,13 +159,14 @@ func extractSourceMap(optSrcmap util.Option[corset.SourceMap]) (map[string]corse
 	return mapping, enums
 }
 
-func extractSourceMapData(name module.Name, limbs bool, srcmap map[string]corset.SourceModule,
-	mapping register.LimbsMap) (bool, []SourceColumn) {
+func extractSourceMapData[F field.Element[F]](trMod tr.Module[F], limbs bool, computed bool,
+	srcmap map[string]corset.SourceModule, mapping register.LimbsMap) (bool, []SourceColumn) {
 	//
 	var (
 		public  = true
 		columns []SourceColumn
 		seen    = make(map[uint]bool)
+		name    = trMod.Name()
 	)
 	//
 	if m, ok := srcmap[name.Name]; ok {
@@ -163,23 +175,30 @@ func extractSourceMapData(name module.Name, limbs bool, srcmap map[string]corset
 		columns = extractSourceColumns(file.NewAbsolutePath(""),
 			name.Multiplier, m.Selector, limbs, m.Columns, m.Submodules, mapping)
 		// Mark all as seen
-		for _, c := range columns {
-			seen[c.Register.Unwrap()] = true
+		for _, column := range columns {
+			for _, limb := range column.Limbs {
+				seen[limb.Unwrap()] = true
+			}
 		}
 	}
-	// Add any registers not already seen
-	for i, reg := range mapping.Registers() {
-		if _, ok := seen[uint(i)]; !ok {
-			rid := register.NewId(uint(i))
+	//
+	if computed {
+		// Add any registers not already seen
+		for i := range trMod.Width() {
+			ith := trMod.Column(i)
 			//
-			columns = append(columns, SourceColumn{
-				Name:     reg.Name(),
-				Display:  0,
-				Computed: reg.IsComputed(),
-				Selector: util.None[string](),
-				Register: rid,
-				Limbs:    mapping.LimbIds(rid),
-			})
+			if _, ok := seen[i]; !ok {
+				rid := register.NewId(i)
+				//
+				columns = append(columns, SourceColumn{
+					Name:     ith.Name(),
+					Display:  0,
+					Computed: true,
+					Selector: util.None[string](),
+					Register: rid,
+					Limbs:    []register.Id{rid},
+				})
+			}
 		}
 	}
 	//

--- a/pkg/cmd/view/register_view.go
+++ b/pkg/cmd/view/register_view.go
@@ -54,15 +54,21 @@ func (p *registerView[F]) Get(row uint) big.Int {
 		var (
 			data    = p.trace.Column(lid.Unwrap()).Data()
 			element = data.Get(row)
-			limb    = p.mapping.Limb(lid)
 			val     big.Int
 		)
 		// Construct value from field element
 		val.SetBytes(element.Bytes())
 		// Shift and add
 		value.Add(&value, val.Mul(&val, math.Pow2(bits)))
-		//
-		bits += limb.Width()
+		// Shift value for multi-limb registers.  This specifically does nothing
+		// in the case of single limb registers, since they include computed
+		// registers which may not be present in the limbs map.
+		if len(p.limbs) > 1 {
+			// Extract limb information
+			limb := p.mapping.Limb(lid)
+			//
+			bits += limb.Width()
+		}
 	}
 	//
 	return value


### PR DESCRIPTION
This adds support for showing low-level computed registers in the commands: trace;check;inspect.  Here, low-level computed registers are defined as those computed registers which are not visible at the source level (i.e. they are added during translation down through the schema stack).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to changed schema-selection semantics and trace rendering paths (including new column enumeration for computed registers), which could affect CLI output correctness and expansion/check behavior.
> 
> **Overview**
> Adds a new trace-view option to include *low-level computed registers* (those not present in the source map) across `trace`, `check` failure reports, and the interactive `inspect` UI via `view.Builder.WithComputed` and new `--show-computed`/`--show-limbs` flags.
> 
> Simplifies schema selection throughout the CLI by treating the *lowest concrete schema* as canonical (`ConcreteSchema()`/`ConcreteIrName()`), removing multi-concrete iteration paths, and adds a root-level validation that at most one of `--asm/--uasm/--nasm/--mir/--air` is specified.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6da31c5405c3210bb98d5969f5fdb9a1aad36fe0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->