### PR TITLE
feat: enforce register types on limbs and carries

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -147,6 +147,7 @@ func getSchemaStack[F field.Element[F]](cmd *cobra.Command, mode uint, filenames
 	corsetConfig.Debug = GetFlag(cmd, "debug")
 	corsetConfig.Legacy = GetFlag(cmd, "legacy")
 	corsetConfig.EnforceTypes = GetFlag(cmd, "enforce-types")
+	corsetConfig.EnforceLimbTypes = GetFlag(cmd, "enforce-limb-types")
 	corsetConfig.Field = *fieldConfig
 	// Assembly lowering config
 	asmConfig.Vectorize = GetFlag(cmd, "vectorize")
@@ -231,7 +232,8 @@ func init() {
 	rootCmd.PersistentFlags().Bool("debug", false, "enable debugging constraints")
 	rootCmd.PersistentFlags().Bool("legacy", true, "use legacy register allocator")
 	rootCmd.PersistentFlags().Bool("no-stdlib", false, "prevent standard library from being included")
-	rootCmd.PersistentFlags().Bool("enforce-types", false, "enforce types by default")
+	rootCmd.PersistentFlags().Bool("enforce-types", false, "enforce all register types")
+	rootCmd.PersistentFlags().Bool("enforce-limb-types", true, "enforce types for limbs arising from split registers")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "increase logging verbosity")
 	rootCmd.PersistentFlags().UintP("opt", "O", 1, "set optimisation level")
 	// Assembly lowering config

--- a/pkg/ir/module_builder.go
+++ b/pkg/ir/module_builder.go
@@ -57,7 +57,7 @@ type ModuleBuilder[F field.Element[F], C schema.Constraint[F], T term.Expr[F, T]
 	NewRegister(reg register.Register) register.Id
 	// NewRegisters declares zero or more new registers within the module being
 	// built.  This will panic if a register of the same name already exists.
-	NewRegisters(registers ...register.Register)
+	NewRegisters(registers ...register.Register) []register.Id
 	// ZeroRegister returns an ID for the "zero register".  That is, a register
 	// which is always zero.  If no such register exists already, one is
 	// created.
@@ -183,10 +183,14 @@ func (p *internalModuleBuilder[F, C, T]) NewRegister(reg register.Register) regi
 }
 
 // NewRegisters implementation for ModuleBuilder interface.
-func (p *internalModuleBuilder[F, C, T]) NewRegisters(registers ...register.Register) {
-	for _, r := range registers {
-		p.NewRegister(r)
+func (p *internalModuleBuilder[F, C, T]) NewRegisters(registers ...register.Register) []register.Id {
+	var ids = make([]register.Id, len(registers))
+	//
+	for i, r := range registers {
+		ids[i] = p.NewRegister(r)
 	}
+	//
+	return ids
 }
 
 // Register implementation for register.Map interface.
@@ -317,10 +321,14 @@ func (p *externalModuleBuilder[F, C, T]) NewRegister(reg register.Register) regi
 }
 
 // NewRegisters implementation for ModuleBuilder interface.
-func (p *externalModuleBuilder[F, C, T]) NewRegisters(registers ...register.Register) {
-	for _, r := range registers {
-		p.NewRegister(r)
+func (p *externalModuleBuilder[F, C, T]) NewRegisters(registers ...register.Register) []register.Id {
+	var ids = make([]register.Id, len(registers))
+	//
+	for i, r := range registers {
+		ids[i] = p.NewRegister(r)
 	}
+	//
+	return ids
 }
 
 // Register implementation for register.Map interface.


### PR DESCRIPTION
This adds support for register types on limbs and introduced carry lines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core compilation/IR-lowering paths and adds automatic constraints, which could change constraint sets and affect existing circuits; the changes are localized but correctness-sensitive.
> 
> **Overview**
> Adds a new compilation option `EnforceLimbTypes` (wired to CLI flag `--enforce-limb-types`, default on) to **automatically apply range/type constraints to limb registers created when a source register is split**.
> 
> Unifies Corset compilation configuration by aliasing `corset.CompilationConfig` to `compiler.Config` and threading the full config through parsing and translation; irregular-lookup limb sizing now uses `config.Field.RegisterWidth`.
> 
> Extends MIR subdivision so that **new registers allocated by the subdivider/allocator (e.g., carry lines)** are immediately constrained with per-register `ranged` constraints; this required changing `ModuleBuilder.NewRegisters` to return the created `register.Id`s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fdc1eed4a2c85f5d27e27d5dc1b719a3b550abe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->