### PR TITLE
feat: sanity check lookups into multi line functions

### DIFF
--- a/pkg/cmd/compile.go
+++ b/pkg/cmd/compile.go
@@ -54,7 +54,11 @@ func runCompileCmd[F field.Element[F]](cmd *cobra.Command, args []string) {
 	output := GetString(cmd, "output")
 	defines := GetStringArray(cmd, "define")
 	// Parse constraints
-	binfile := getSchemaStack[F](cmd, SCHEMA_DEFAULT_MIR, args...).BinaryFile()
+	stacker := getSchemaStack[F](cmd, SCHEMA_DEFAULT_MIR, args...)
+	// Sanity check it can be build
+	_ = stacker.Build()
+	// Extract binfile
+	binfile := stacker.BinaryFile()
 	// Write metadata
 	if err := binfile.Header.SetMetaData(buildMetadata(defines)); err != nil {
 		fmt.Printf("error writing metadata: %s\n", err.Error())

--- a/pkg/schema/agnostic/assignment.go
+++ b/pkg/schema/agnostic/assignment.go
@@ -321,7 +321,7 @@ func determineRhsChunks(p StaticPolynomial, chunks []LhsChunk, field field.Confi
 		// Check whether chunk fits
 		if chunkWidth > field.BandWidth {
 			// No, it does not.
-			vars.Union(RegisterReadSet(remainder))
+			vars.Union(NonLinearReadSet(remainder))
 		} else if !last && chunkWidth > chunk.bitwidth {
 			// Overflow case.
 			p, chunk = propagateCarry(chunk, overflow, p, mapping)

--- a/pkg/schema/agnostic/equation.go
+++ b/pkg/schema/agnostic/equation.go
@@ -267,7 +267,7 @@ func splitNonLinearTerms(regWidth uint, field field.Config, p DynamicPolynomial,
 			width = WidthOfMonomial(term, env)
 		)
 		//
-		if width > field.BandWidth {
+		if term.Len() > 1 && width > field.BandWidth {
 			for _, v := range term.Vars() {
 				// Check whether register is above threshold or not.
 				if mapping.Register(v.Id()).Width() > regWidth {
@@ -365,7 +365,12 @@ func balancePolynomial(poly DynamicPolynomial) (pos, neg DynamicPolynomial) {
 
 // DynamicPoly2String provides a convenient helper function for debugging polynomials.
 func DynamicPoly2String(p DynamicPolynomial, env register.Map) string {
-	return poly.String(p, func(r register.AccessId) string {
+	return poly.String(p, RegAccess2String(env))
+}
+
+// RegAccess2String provides a convenient helper function for debugging polynomials.
+func RegAccess2String(env register.Map) func(r register.AccessId) string {
+	return func(r register.AccessId) string {
 		var (
 			name  = env.Register(r.Id()).Name()
 			shift = r.RelativeShift()
@@ -379,5 +384,5 @@ func DynamicPoly2String(p DynamicPolynomial, env register.Map) string {
 		default:
 			return fmt.Sprintf("%s[i%d]", name, shift)
 		}
-	})
+	}
 }

--- a/pkg/schema/agnostic/equation.go
+++ b/pkg/schema/agnostic/equation.go
@@ -189,8 +189,13 @@ func (p *Equation) chunkUp(field field.Config, mapping RegisterAllocator) (targe
 		mapping.Reset(n)
 	}
 	// Reconstruct target equations
-	for i := range len(lhs) {
-		if lhs[i].Len() > 0 || rhs[i].Len() > 0 {
+	for i := range max(len(lhs), len(rhs)) {
+		var zero DynamicPolynomial
+		if len(lhs) <= i {
+			targets = append(targets, NewEquation(zero, rhs[i]))
+		} else if len(rhs) <= i {
+			targets = append(targets, NewEquation(lhs[i], zero))
+		} else {
 			targets = append(targets, NewEquation(lhs[i], rhs[i]))
 		}
 	}
@@ -293,8 +298,10 @@ func chunkPolynomial(p DynamicPolynomial, chunkWidths []uint, field field.Config
 		var remainder DynamicPolynomial
 		// Chunk the polynomials
 		p, remainder = p.Shr(chunkWidth)
-		// Include remainder as chunk
-		chunks = append(chunks, remainder)
+		// Include remainder as chunk (if non-zero)
+		if p.Len() != 0 || remainder.Len() != 0 {
+			chunks = append(chunks, remainder)
+		}
 	}
 	// Add carry lines as necessary
 	for i := 0; i < len(chunks); i++ {

--- a/pkg/schema/agnostic/polynomial.go
+++ b/pkg/schema/agnostic/polynomial.go
@@ -258,6 +258,24 @@ func RegisterReadSet[T RegisterIdentifier[T]](p Polynomial[T]) bit.Set {
 	return regs
 }
 
+// NonLinearReadSet returns the set of registers read by this instruction.
+func NonLinearReadSet[T RegisterIdentifier[T]](p Polynomial[T]) bit.Set {
+	var regs bit.Set
+	//
+	for i := range p.Len() {
+		ith := p.Term(i)
+		// Check for non-linea term
+		if ith.Len() > 1 {
+			for _, ident := range p.Term(i).Vars() {
+				rid := ident.Id()
+				regs.Insert(rid.Unwrap())
+			}
+		}
+	}
+	//
+	return regs
+}
+
 // SubstitutePolynomial replaces all occurrences of a given variable with a set
 // of (zero or more) variables (e.g. typically used for substituting limbs).
 func SubstitutePolynomial[T RegisterIdentifier[T]](p Polynomial[T], mapping func(T) Polynomial[T]) (r Polynomial[T]) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces new panic-based validation during lowering/compile that can break previously-accepted schemas and changes constraint splitting/chunking behavior, which could affect generated constraints and compilation outcomes.
> 
> **Overview**
> Adds a post-lowering sanity pass in `LowerMixedMacroProgram` that **rejects unsupported interactions with multi-line (non-atomic) functions**: lookups into such functions must provide explicit source/target selectors, and `hir.FunctionCall` into multi-line functions now panics early.
> 
> Tightens schema splitting/chunking: assignment overflow tracking now considers only *non-linear* reads (`NonLinearReadSet`), equation reconstruction now pads missing LHS/RHS chunks with zero, chunking skips appending trailing zero chunks, and non-linear-term splitting only triggers for genuinely non-linear terms. Also factors out `RegAccess2String` for reuse in polynomial debug formatting.
> 
> The `compile` command now forces a `Build()` of the schema stack before emitting the binary to fail fast on invalid inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7300c2e3ec4aa8be282be7d7801ef33bbe8581f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->