### PR TITLE
fix: typing of arithmetic expressions

### DIFF
--- a/pkg/zkc/compiler/ast/data/uint.go
+++ b/pkg/zkc/compiler/ast/data/uint.go
@@ -52,6 +52,21 @@ func (p *UnsignedInt[S]) AsTuple(Environment[S]) *Tuple[S] {
 	return nil
 }
 
+// Join combines to uint types together
+func (p *UnsignedInt[S]) Join(q *UnsignedInt[S]) *UnsignedInt[S] {
+	if p.open && q.open {
+		return &UnsignedInt[S]{max(p.bitwidth, q.bitwidth), true}
+	} else if p.open {
+		return q
+	} else if q.open {
+		return p
+	} else if p.bitwidth != q.bitwidth {
+		panic(fmt.Sprintf("cannot join u%d ⊔ u%d", p.bitwidth, q.bitwidth))
+	}
+	//
+	return p
+}
+
 func (p *UnsignedInt[S]) String(_ Environment[S]) string {
 	if p.open {
 		return fmt.Sprintf("u%d+", p.bitwidth)

--- a/pkg/zkc/compiler/validate/typing.go
+++ b/pkg/zkc/compiler/validate/typing.go
@@ -336,25 +336,27 @@ func (p *TypeChecker) typeExpressions(exprs []expr.Resolved, env VariableMap) ([
 
 func (p *TypeChecker) typeArithmeticExpression(exprs []expr.Resolved, env VariableMap) (Type, []source.SyntaxError) {
 	var (
-		args, errs = p.typeExpressions(exprs, env)
-		res        Type
+		args, errors = p.typeExpressions(exprs, env)
+		res          *data.UnsignedInt[symbol.Resolved]
 	)
 	//
-	if len(errs) > 0 {
-		return nil, errs
+	if len(errors) > 0 {
+		return nil, errors
 	}
 	//
 	for i, t := range args {
 		if i == 0 && t.AsUint(p.env) == nil {
-			return nil, append(errs, *p.srcmaps.SyntaxError(exprs[i], "expected uint"))
+			return nil, append(errors, *p.srcmaps.SyntaxError(exprs[i], "expected uint"))
 		} else if i == 0 {
-			res = t
+			res = t.AsUint(p.env)
+		} else if errs := p.checkEquiTypes(t, res, exprs[i]); len(errs) > 0 {
+			errors = append(errors, errs...)
 		} else {
-			errs = append(errs, p.checkEquiTypes(t, res, exprs[i])...)
+			res = res.Join(exprs[i].Type().AsUint(p.env))
 		}
 	}
 	//
-	return res, errs
+	return res, errors
 }
 
 func (p *TypeChecker) typeCastExpression(e *expr.Cast[symbol.Resolved], env VariableMap) (Type, []source.SyntaxError) {


### PR DESCRIPTION
This was a situation where the type of an expression was calculated incorrectly.  Specifically, when a constant was the first operand of an arithmetic expression.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core type-checking for arithmetic expressions and introduces new uint type-join semantics; mistakes could cause incorrect inferred types or unexpected panics on mismatched widths.
> 
> **Overview**
> Fixes arithmetic expression typing so result `uint` types are inferred correctly when operands include *open* constant widths (e.g., a constant as the first operand).
> 
> This adds `UnsignedInt.Join()` to compute a combined `uint` type across operands (handling open vs closed widths), and updates `TypeChecker.typeArithmeticExpression` to accumulate the result type via `Join` instead of keeping the first operand’s raw type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfc5e2898da27ad49848405529723648db4fe681. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->