### PR TITLE
feat: update language reference

### DIFF
--- a/ZKC_LANGUAGE.md
+++ b/ZKC_LANGUAGE.md
@@ -1,83 +1,232 @@
 # ZkC Language
 
-ZkC is a simple imperative language for writing zero-knowledge programs. It provides
-a C-like syntax with fixed-width unsigned integer types and explicit memory
-declarations. ZkC programs are compiled and executed by the `zkc` toolchain, which
-is part of the `go-corset` repository.
+ZkC is a simple imperative language designed primarily for writing
+programs whose executions can be proved (e.g. using a [zero-knowledge
+proof system](https://en.wikipedia.org/wiki/Zero-knowledge_proof) or
+similar). ZkC provides a simple syntax with fixed-width unsigned
+integer types and explicit memory declarations. ZkC programs are
+compiled and executed by the `zkc` toolchain.
 
-## Functions
+The overall model of a ZkC program is that it reads some number of
+_inputs_, performs a _computation_ and writes some number of
+_outputs_. The computation may additionally fail (e.g. if the inputs
+were malformed). A ZkC program cannot perform other forms of I/O and
+cannot, for example, interact with the operating system (e.g. to read
+files, etc).
 
-Functions are the fundamental building blocks of ZkC programs:
+## QuickSort Example
+
+To introduce the ZkC language, we consider a straightforward example
+which showcases various features: namely, the classical
+[quicksort](https://en.wikipedia.org/wiki/Quicksort) algorithm. This
+program _reads in_ a set of zero or more bytes, _sorts_ them and then
+_writes out_ the sorted bytes.
+
+### Memory
+
+The first aspect of our quicksort implementation is to define the
+various forms of _memory_ required:
 
 ```zkc
-fn max(x:u16, y:u16) -> (res:u16) {
-  // body
-  if x > y {
-    res = x
-  } else {
-    res = y
-  }
-  //
+// Input which identifies how many bytes to sort
+input data_len(address:u1)->(len:u32)
+
+// Input which holds bytes to be sorted
+input data_in(address:u32)->(bytes:u8)
+
+// Output where sorted bytes are written
+output data_out(address:u32)->(bytes:u8)
+
+// Scratch buffer where sorting occurrs
+memory buffer(address:u32)->(bytes:u8)
+```
+
+Here, `input data_len` indicates `data_len` is an _input memory_.
+This is a form of _read-only memory_ which cannot be written during
+execution. Likewise, `output data_out` indicates that `data_out` is a
+_write once_ output memory. This means two things: firstly, each
+location of an output memory can only be written once; secondly,
+locations of an output memory must be written _consecutively_
+(i.e. location `0` is written first, then location `1`, etc). In
+contrast, `memory buffer` indicates that `buffer` is a read-write
+(i.e. random access) memory. A read-write memory can be read and
+written in any order, with all locations initialised to `0` as
+default. Furthermore, observe that data written into a read/write
+memory is lost once execution completes. Hence, read/write memories
+are typically used as a form of scratch space during the computation.
+
+The _geometry_ of a memory determines its maximum size and
+organisation. For `data_len` the _address space_ is a `u1` whilst the
+_data space_ is a `u32`. This means we can have at most two entries
+of `u32` (i.e. four byte) data values. In our example, we'll assume
+there is always exactly one entry for `data_len` and that this
+determines the length of `data_in` (i.e. the number of bytes to be
+sorted).
+
+### Functions
+
+Functions are the fundamental building blocks of any ZkC program as
+they define what computation is being performed. Every ZkC program
+starts executing from the designated `main()` function which accepts
+no inputs, and returns no outputs. Here is the `main` function for
+our example:
+
+```zkc
+fn main() {
+  var len:u32 = data_len[0]
+  // write input bytes into buffer
+  read_input(len)
+  // sort buffer
+  sort_slice(0, len)
+  // write buffer to output bytes
+  write_output(len)
   return
 }
 ```
 
-In the above, parameters `x` and `y` are declared to be `u16`. In
-fact, unlike many other languages, ZkC supports unsigned integer types
-of arbitrary bitwidth, such as: `u2`, `u3`, `u11`, `u15`, `u48`,
-`u160`, etc.
+This function begins by simply copying the bytes to be sorted into the
+scratch `buffer`. This is because, to actually do the sort, will
+require an arbitrary mix of reads / writes to the data. Once the sort
+is completed, the sorted bytes are written from `buffer` into the
+output memory. **This is a typical structure for ZkC programs**.
 
-There are some restrictions imposed upon functions. For example,
-parameters cannot be assigned and are immutable for the duration of a
-function. Likewise, return values and local variables must be defined
-being used --- there are no default values in ZkC.
-
-## Inputs
-
-Input memories provide the means for the communicating input data from
-the external environment to be used within an executing ZkC program.
+The implementation of `read_input()` and `write_output()` is simple
+enough:
 
 ```zkc
-pub input rom(address:u8) -> (value:u8)
-    input cfg(address:u16) -> (value:u32)
+// Read n bytes of input data into buffer.
+fn read_input(n:u32) {
+  for i:u32 = 0; i < n; i=i+1 {
+    buffer[i] = data_in[i]
+  }
+}
+
+// Write n bytes from buffer into output data.
+fn write_output(m:u32) {
+  for i:u32 = 0; i < m; i=i+1 {
+    data_out[i] = buffer[i]
+  }
+}
 ```
 
-Input memories are a form of _read-only memory_ and cannot be written
-during execution. Inputs can optionally be marked `pub`; unmarked
-inputs are private by default. The distinction is determined by the
-proving system in use: `pub` inputs are committed to whilst private
-inputs form part of the witness.
+At this point, we can see that ZkC roughly resembles a simple
+programming language like C. However, there are notable differences.
+For example, parameters `n` and `m` are declared to be `u32` --- but,
+unlike many languages, ZkC supports types of arbitrary bitwidth
+(e.g. `u2`, `u3`, `u11`, `u15`, `u48`, `u160`, etc). Also, parameters
+cannot be assigned and are immutable throughout a function. Finally,
+unlike C, return values and local variables must be _defined_ before
+being _used_ (i.e. ZkC enforces [definite
+assignment](https://en.wikipedia.org/wiki/Definite_assignment_analysis)).
 
-## Outputs
-
-Output memories provide the means for the communicating data generated
-whilst executing a ZkC program back to the external environment.
+Functions can be _recursive_ and this provides an efficient way to
+encode unbounded computation. For example, the `sort_slice()`
+function is defined like so:
 
 ```zkc
-pub output result(address:u8) -> (value:u8)
-    output log(address:u16) -> (value:u32)
+// Sort buffer slice between offsets m (inclusive) and n (exclusive)
+fn sort_slice(m:u32, n:u32)
+// PRE: m <= n
+{
+  var pivot:u32
+  //
+  if (m + 1) < n {
+    // partition slice
+    pivot = partition(m,n)
+    // sort lower slice
+    sort_slice(m,pivot)
+    // sort upper slice
+    sort_slice(pivot+1,n)
+  }
+}
 ```
 
-Output memories are a form of _write-once memory_ meaning that each
-location must be written exactly once. As with input memories, the
-`pub` modifier makes an output public; outputs are private by default.
+In general, ZkC differs from a typical CPU-based programming language
+in that loops are not always the most efficient way to implement
+unbounded computation. Roughly speaking, the reason for this is that
+function calls are translated into lookup constraints and this enables
+reuse of identical calls to the same function (more on this later).
 
-## Read / Write Memory
+### Expressions
 
-Read/Write Memory (a.k.a Random-Access Memory) provides a form of
-unbound internal storage. Multiple read/write memories can be defined
-with different types as part of a ZkC program.
+Finally, expressions in ZkC are fairly general as the following
+illustrates:
 
 ```zkc
-memory buf(address:u8) -> (value:u8)
+fn partition(m:u32, n:u32) -> (p:u32) {
+  // identify last element
+  var last:u32 = n - 1
+  // first element is pivot
+  var pivot:u8 = buffer[last]
+  // set pivot
+  p = m
+  //
+  for i:u32=m; i < last; i=i+1 {
+    var ith:u8 = buffer[i]
+    //
+    if ith <= pivot {
+      swap(i,p)
+      p = p + 1
+    }
+  }
+  // Swap last
+  swap(p,last)
+}
+
+fn swap(i:u32,j:u32) {
+  var tmp:u8 = buffer[j]
+  buffer[j] = buffer[i]
+  buffer[i] = tmp
+}
 ```
 
-Observe that any data written into a read/write memory is not
-available to the external environment once execution has completed.
-As such, any important data needing to be communicated back must be
-written into an output memory before execution terminates.
+One aspect of an expression, such as `a + b`, is that ZkC is strict
+around argument types and does not support
+[subtyping](https://en.wikipedia.org/wiki/Subtyping). For example, in
+this case, `a` and `b` must have the same type (and, if not, a cast is
+required to ensure the expression is well formed).
 
-## Constants
+## Language Reference
+
+We now provide a more detailed language reference which covers
+subtleties not highlighted by the example above.
+
+### Memory
+
+Input / output memories can optionally be marked `pub` and, if not,
+are considered private by default. The distinction is determined by
+the proving system in use: `pub` inputs are committed to whilst
+private inputs form part of [the
+witness](https://en.wikipedia.org/wiki/Zero-knowledge_proof). For
+example, consider a computation over some array of data. To avoid
+committing to the entire set of data, we may prefer to commit only to
+a _hash_ of the data which, consequently, would be a public input.
+However, to open the hash (i.e. access its contents), we would need
+one or more [Merkle proofs](https://en.wikipedia.org/wiki/Merkle_tree)
+to establish that values of interest are indeed contained within.
+Such proofs could be provided as private inputs and, hence, would be
+part of.
+
+_Static inputs_ are a form of memory whose contents is fixed in the
+program source. For example, one can implement the input vectors for
+the [BLAKE2 hashing
+algorithm](<https://en.wikipedia.org/wiki/BLAKE_(hash_function)#BLAKE2>)
+using a static input as follows:
+
+```
+static IV(address:u3) -> (iv:u64) {
+  0x6a09e667f3bcc908, // IV0
+  0xbb67ae8584caa73b, // IV1
+  0x3c6ef372fe94f82b, // IV2
+  0xa54ff53a5f1d36f1, // IV3
+  0x510e527fade682d1, // IV4
+  0x9b05688c2b3e6c1f, // IV5
+  0x1f83d9abfb41bd6b, // IV6
+  0x5be0cd19137e2179  // IV7
+}
+```
+
+### Constants
 
 Named constants can be declared at the top level and used in expressions:
 
@@ -91,7 +240,7 @@ const SIZE:u16     = 2^10
 Numeric literals may be written in decimal, hexadecimal (`0x…`), or binary
 (`0b…`), and may use `_` as a visual separator (e.g. `0xFF_FF`).
 
-## Variable Declarations
+### Variable Declarations
 
 Local variables are declared inside a function body with an optional initialiser:
 
@@ -105,16 +254,30 @@ Only a single variable may carry an initialiser per declaration statement.
 ### Assignments
 
 ```zkc
-target = expression
+target(s) = expression
 ```
 
-A single expression result can be split across multiple targets listed on the
-left-hand side. The result is distributed big-endian across the targets, which
-is useful for capturing carry bits:
+Expressions have a notion called their _arity_ which determine how
+many values they produce. In most cases, the arity of an expression
+is `1` --- meaning it produces exactly one value. For example, the
+expression `a + b` has arity `1`. In contrast, a function call has an
+arity which corresponds to the number of return values the called
+function produces. The following illustrates:
 
 ```zkc
-carry, lo = lo + 1   // lo gets the low bits; carry gets the overflow bit
+fn main() {
+  ...
+  val, err = compute()
+  ...
+}
+
+fn compute() -> (val u32, err u1) {
+  ...
+}
 ```
+
+Here we see that, since `compute()` has two returns the corresponding
+function call requires two target variables.
 
 ### Loops
 
@@ -144,11 +307,10 @@ more efficient (in terms of generated constraints) to use recursion.
 
 ### Exceptions
 
-ZkC supports a `fail` instruction which is similar to a `panic` in
-other languages. If executed, this immediately terminates the
-machine. More importantly, however, is that the generated constraints
-cannot hold for any execution which reaches a `fail`. The following
-illustrates:
+ZkC supports a `fail` instruction (similar to a `panic` in other
+languages). If executed, this immediately terminates the program. More
+importantly, however, is that the generated constraints cannot hold
+for any execution which reaches a `fail`. The following illustrates:
 
 ```zkc
 fn divide(x:u16, y:u16) -> (r:u16) {
@@ -215,7 +377,7 @@ Comparison operators (used in conditions only):
 | `a > b`  | greater than          |
 | `a >= b` | greater than or equal |
 
-## Type Aliases
+### Type Aliases
 
 Type aliases introduce a new name for an existing type. They are useful
 for improving readability and for defining domain-specific names (e.g.
@@ -251,7 +413,7 @@ include "path/to/other.zkc"
 Included files are processed as if their declarations appeared at the include
 site.
 
-### Constraint Compilation
+## Constraint Generation
 
 The ultimate goal of ZkC is to compile programs down to the arithmetic
 constraint systems used by ZK provers which consist of: **vanishing


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes with no impact on runtime or compiler behavior, though inaccuracies could mislead users.
> 
> **Overview**
> Rewrites `ZKC_LANGUAGE.md` to shift from a brief overview into a tutorial-style doc centered on a full QuickSort example (memories, I/O model, recursion, and expressions).
> 
> Expands the reference sections with clearer explanations and new/updated material on memory types (including `static` inputs and `pub`), assignment *arity* / multi-target assignment, and renames the compilation section to **Constraint Generation**.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c3f277393dcc4cd74e8feebde41119a69626872. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->