### PR TITLE
feat: support variable title width in inspector

### DIFF
--- a/pkg/cmd/corset/inspect.go
+++ b/pkg/cmd/corset/inspect.go
@@ -14,7 +14,6 @@ package corset
 
 import (
 	"fmt"
-	"math"
 	"os"
 
 	"github.com/consensys/go-corset/pkg/asm"
@@ -69,6 +68,8 @@ func runInspectCmd[F field.Element[F]](cmd *cobra.Command, args []string) {
 	//
 	validate := GetFlag(cmd, "validate")
 	showLimbs := GetFlag(cmd, "show-limbs")
+	cellWidth := GetUint(cmd, "cell-width")
+	titleWidth := GetUint(cmd, "title-width")
 	// Read in constraint files
 	stacker := *getSchemaStack[F](cmd, SCHEMA_DEFAULT_AIR, args[1:]...)
 	stack := stacker.Build()
@@ -107,7 +108,7 @@ func runInspectCmd[F field.Element[F]](cmd *cobra.Command, args []string) {
 	//
 	if len(errors) == 0 {
 		// Run the inspector.
-		errors = inspect(stack.TraceBuilder().Mapping(), srcmap, trace, showLimbs)
+		errors = inspect(stack.TraceBuilder().Mapping(), srcmap, trace, showLimbs, cellWidth, titleWidth)
 	}
 	// Sanity check what happened
 	if len(errors) > 0 {
@@ -121,9 +122,9 @@ func runInspectCmd[F field.Element[F]](cmd *cobra.Command, args []string) {
 
 // Inspect a given trace using a given schema.
 func inspect[F field.Element[F]](mapping module.LimbsMap, srcmap *corset.SourceMap, trace tr.Trace[F],
-	limbs bool) []error {
+	limbs bool, cellWidth, titleWidth uint) []error {
 	// Construct inspector window
-	inspector := construct(mapping, trace, srcmap, limbs)
+	inspector := construct(mapping, trace, srcmap, limbs, cellWidth, titleWidth)
 	// Render inspector
 	if err := inspector.Render(); err != nil {
 		return []error{err}
@@ -133,14 +134,15 @@ func inspect[F field.Element[F]](mapping module.LimbsMap, srcmap *corset.SourceM
 }
 
 func construct[F field.Element[F]](mapping module.LimbsMap, trace tr.Trace[F], srcmap *corset.SourceMap, limbs bool,
-) *inspector.Inspector {
+	cellWidth, titleWidth uint) *inspector.Inspector {
 	//
 	term, err := termio.NewTerminal()
 	// Check whether successful
 	if err == nil {
 		window := view.NewBuilder[F](mapping).
 			WithSourceMap(*srcmap).
-			WithTitleWidth(math.MaxUint).
+			WithTitleWidth(titleWidth).
+			WithCellWidth(cellWidth).
 			WithFormatting(inspector.NewFormatter()).
 			WithLimbs(limbs).
 			WithComputed(true).
@@ -159,4 +161,6 @@ func construct[F field.Element[F]](mapping module.LimbsMap, trace tr.Trace[F], s
 func init() {
 	rootCmd.AddCommand(inspectCmd)
 	inspectCmd.Flags().Bool("show-limbs", false, "specify whether to show register limbs")
+	inspectCmd.Flags().Uint("cell-width", 32, "specify maximum display width for a cell")
+	inspectCmd.Flags().Uint("title-width", 128, "specify maximum display width for a column title")
 }

--- a/pkg/cmd/corset/inspector/inspect.go
+++ b/pkg/cmd/corset/inspector/inspect.go
@@ -230,6 +230,22 @@ func (p *Inspector) changeCellWidth(direction bool) {
 	p.SetStatus(termio.NewColouredText(fmt.Sprintf("Cell width now %d", width), termio.TERM_GREEN))
 }
 
+// change cell width in current module
+func (p *Inspector) changeTitleWidth(direction bool) {
+	// Action change
+	width := p.CurrentModule().view.Config().TitleWidth()
+	//
+	if direction {
+		width++
+	} else if width > 2 {
+		width--
+	}
+	//
+	p.CurrentModule().view.Config().SetTitleWidth(width)
+	//
+	p.SetStatus(termio.NewColouredText(fmt.Sprintf("Title width now %d", width), termio.TERM_GREEN))
+}
+
 // Actions goto row mode
 func (p *Inspector) gotoRow(row uint) termio.FormattedText {
 	// Action change

--- a/pkg/cmd/corset/inspector/nav_mode.go
+++ b/pkg/cmd/corset/inspector/nav_mode.go
@@ -120,6 +120,10 @@ func (p *NavigationMode) KeyPressed(parent *Inspector, key uint16) bool {
 		parent.changeCellWidth(true)
 	case '-':
 		parent.changeCellWidth(false)
+	case ']':
+		parent.changeTitleWidth(true)
+	case '[':
+		parent.changeTitleWidth(false)
 	}
 	//
 	return false

--- a/pkg/cmd/corset/trace.go
+++ b/pkg/cmd/corset/trace.go
@@ -86,7 +86,8 @@ func runTraceCmd[F field.Element[F]](cmd *cobra.Command, args []string) {
 	cfg.trace = GetFlag(cmd, "print")
 	cfg.stats = GetFlag(cmd, "stats")
 	cfg.includes = GetStringArray(cmd, "include")
-	cfg.maxCellWidth = GetUint(cmd, "max-width")
+	cfg.maxCellWidth = GetUint(cmd, "cell-width")
+	cfg.maxTitleWidth = GetUint(cmd, "title-width")
 	cfg.showLimbs = GetFlag(cmd, "show-limbs")
 	cfg.showComputed = GetFlag(cmd, "show-computed")
 	cfg.startRow = GetUint(cmd, "start")
@@ -172,7 +173,8 @@ func init() {
 	traceCmd.Flags().Uint("sort", 0, "sort table column")
 	traceCmd.Flags().Uint("start", 0, "filter out rows below this")
 	traceCmd.Flags().Uint("end", math.MaxUint, "filter out this and all following rows")
-	traceCmd.Flags().Uint("max-width", 32, "specify maximum display width for a column")
+	traceCmd.Flags().Uint("cell-width", 32, "specify maximum display width for a cell")
+	traceCmd.Flags().Uint("title-width", 32, "specify maximum display width for a column title")
 	traceCmd.Flags().Bool("show-computed", false, "show (low-level) computed registers")
 	traceCmd.Flags().BoolP("show-limbs", "l", false, "show register limbs")
 	traceCmd.Flags().Uint("padding", 0, "specify amount of (front) padding to apply")
@@ -319,6 +321,7 @@ func printTraceInfo[F field.Element[F]](cfg TraceConfig, trace tr.Trace[F]) {
 	// Construct trace window
 	view := view.NewBuilder[F](cfg.mapping).
 		WithCellWidth(cfg.maxCellWidth).
+		WithTitleWidth(cfg.maxTitleWidth).
 		WithLimbs(cfg.showLimbs).
 		WithComputed(cfg.showComputed)
 	// Add source map (if applicable)

--- a/pkg/cmd/corset/view/module_view.go
+++ b/pkg/cmd/corset/view/module_view.go
@@ -20,10 +20,14 @@ import (
 
 // ModuleConfig encapsulates various configuration settings for a ModuleView.
 type ModuleConfig interface {
-	// CellWidth reads the current maximum width of any cell in the table.
+	// CellWidth returns the current maximum width of any cell in the table.
 	CellWidth() uint
-	// SetCellWidth determines the maximum width of any cells in the table.
+	// TitleWidth returns the current maximum width of any title in the table.
+	TitleWidth() uint
+	// SetCellWidth sets the maximum width of any cells in the table.
 	SetCellWidth(cellWidth uint)
+	// SetTitleWidth set the maximum width of any title in the table.
+	SetTitleWidth(titleWidth uint)
 }
 
 // ModuleView abstracts an underlying trace module.  For example, it manages the
@@ -104,14 +108,24 @@ func (p *moduleView[F]) Window() Window {
 // ModuleConfig
 // ============================================================================
 
-// Offset returns the current offset position within module
+// CellWidth implementation for ModuleComfig interface
 func (p *moduleView[F]) CellWidth() uint {
 	return p.cellWidth
 }
 
-// SetCellWidth determines the maximum width of any cells in the table.
+// SetCellWidth implementation for ModuleConfig interface
 func (p *moduleView[F]) SetCellWidth(cellWidth uint) {
 	p.cellWidth = cellWidth
+}
+
+// CellWidth implementation for ModuleComfig interface
+func (p *moduleView[F]) TitleWidth() uint {
+	return p.titleWidth
+}
+
+// SetCellWidth implementation for ModuleComfig interface
+func (p *moduleView[F]) SetTitleWidth(titleWidth uint) {
+	p.titleWidth = titleWidth
 }
 
 // ============================================================================
@@ -129,7 +143,7 @@ func (p *moduleView[F]) CellAt(col uint, row uint) termio.FormattedText {
 		return termio.NewText("")
 	} else if col == 0 {
 		reg := p.window.Row(row - 1)
-		text := p.data.RowTitle(reg)
+		text := clipValue(p.data.RowTitle(reg), p.titleWidth)
 		formatted = p.formatting.RowTitle(reg, text)
 	} else if row == 0 {
 		text := p.data.ColumnTitle(col + x - 1)


### PR DESCRIPTION
This adds support for changing the title width in the inspector.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to CLI flag changes (renaming `--max-width` to `--cell-width` and adding `--title-width`) that may break existing scripts, plus new rendering logic that affects table layout.
> 
> **Overview**
> Adds configurable *title width* alongside existing cell-width control across the interactive inspector and `trace` output.
> 
> `inspect` now accepts `--cell-width`/`--title-width` and passes both into the view builder, while the inspector adds `[`/`]` keybindings to adjust title width at runtime. The view layer extends `ModuleConfig` with `TitleWidth` setters/getters and clips row titles based on this width.
> 
> `trace` renames `--max-width` to `--cell-width`, introduces `--title-width`, and threads the new width into table/view construction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59e34df25b4aa499f59123cb35a13c65060551fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->