### PR TITLE
feat: support printf statement in zkc

### DIFF
--- a/pkg/test/zkc_invalid_test.go
+++ b/pkg/test/zkc_invalid_test.go
@@ -460,6 +460,26 @@ func Test_ZkcInvalid_Type_07(t *testing.T) {
 }
 
 // ===================================================================
+// Printf Tests
+// ===================================================================
+
+func Test_ZkcInvalid_Printf_01(t *testing.T) {
+	checkZkcInvalid(t, "zkc/invalid/printf_01")
+}
+
+func Test_ZkcInvalid_Printf_02(t *testing.T) {
+	checkZkcInvalid(t, "zkc/invalid/printf_02")
+}
+
+func Test_ZkcInvalid_Printf_03(t *testing.T) {
+	checkZkcInvalid(t, "zkc/invalid/printf_03")
+}
+
+func Test_ZkcInvalid_Printf_04(t *testing.T) {
+	checkZkcInvalid(t, "zkc/invalid/printf_04")
+}
+
+// ===================================================================
 // Test Helpers
 // ===================================================================
 

--- a/pkg/test/zkc_unit_test.go
+++ b/pkg/test/zkc_unit_test.go
@@ -321,6 +321,18 @@ func Test_ZkcUnit_Call_02(t *testing.T) {
 }
 
 // ===================================================================
+// Printg Tests
+// ===================================================================
+
+func Test_ZkcUnit_Printf_01(t *testing.T) {
+	checkZkcUnit(t, "zkc/unit/printf_01")
+}
+
+func Test_ZkcUnit_Printf_02(t *testing.T) {
+	checkZkcUnit(t, "zkc/unit/printf_02")
+}
+
+// ===================================================================
 // Test Helpers
 // ===================================================================
 

--- a/pkg/zkc/compiler/ast/stmt/printf.go
+++ b/pkg/zkc/compiler/ast/stmt/printf.go
@@ -1,0 +1,74 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package stmt
+
+import (
+	"strings"
+
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/expr"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/symbol"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/variable"
+	"github.com/consensys/go-corset/pkg/zkc/util"
+)
+
+// FormattedChunk represents a chunk of a printf string which consists of some
+// text, followed by an optional argument format.
+type FormattedChunk struct {
+	Text   string
+	Format util.Format
+}
+
+// Printf provides a simple mechanism for debugging ZkC programs.  It allows one
+// to print out the contents of variables at specific points, using a fairly
+// standard syntax.
+type Printf[S symbol.Symbol[S]] struct {
+	Chunks    []FormattedChunk
+	Arguments []expr.Expr[S]
+}
+
+// Buses implementation for Instruction interface
+func (p *Printf[S]) Buses() []S {
+	return nil
+}
+
+// Uses implementation for Instruction interface.
+func (p *Printf[S]) Uses() []variable.Id {
+	return expr.Uses(p.Arguments...)
+}
+
+// Definitions implementation for Instruction interface.
+func (p *Printf[S]) Definitions() []variable.Id {
+	return nil
+}
+
+func (p *Printf[S]) String(env variable.Map[S]) string {
+	var builder strings.Builder
+	builder.WriteString("printf \"")
+	//
+	for _, chunk := range p.Chunks {
+		builder.WriteString(util.EscapeFormattedText(chunk.Text))
+		//
+		if chunk.Format.HasFormat() {
+			builder.WriteString(chunk.Format.String())
+		}
+	}
+	//
+	builder.WriteString("\"")
+	//
+	for _, e := range p.Arguments {
+		builder.WriteString(",")
+		builder.WriteString(e.String(env))
+	}
+	//
+	return builder.String()
+}

--- a/pkg/zkc/compiler/codegen/statement.go
+++ b/pkg/zkc/compiler/codegen/statement.go
@@ -21,6 +21,7 @@ import (
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/lval"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/stmt"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/symbol"
+	"github.com/consensys/go-corset/pkg/zkc/util"
 	"github.com/consensys/go-corset/pkg/zkc/vm/instruction"
 	"github.com/consensys/go-corset/pkg/zkc/vm/word"
 )
@@ -63,6 +64,8 @@ func (p *Compiler) compileStatement(pc uint, mapping []uint, s Stmt) Instruction
 		return &instruction.Jmp{Target: s.Target}
 	case *stmt.Fail[symbol.Resolved]:
 		return &instruction.Fail{}
+	case *stmt.Printf[symbol.Resolved]:
+		return p.compilePrintf(mapping, s.Chunks, s.Arguments)
 	case *stmt.Return[symbol.Resolved]:
 		return &instruction.Return{}
 	default:
@@ -112,6 +115,34 @@ func (p *Compiler) mapLVals(mapping []uint, lvals []LVal) ([]register.Id, []Micr
 	}
 	//
 	return regs, preInsns, postInsns
+}
+
+func (p *Compiler) compilePrintf(mapping []uint, chunks []stmt.FormattedChunk, args []Expr) Instruction {
+	var (
+		nchunks     []instruction.FormattedChunk
+		regs, insns = p.compileArgs(mapping, args...)
+		index       uint
+	)
+	//
+
+	// Manage all chunks
+	for _, chunk := range chunks {
+		if chunk.Format.HasFormat() {
+			nchunks = append(nchunks, instruction.FormattedChunk{
+				Text: chunk.Text, Format: chunk.Format, Argument: regs[index],
+			})
+			//
+			index++
+		} else {
+			nchunks = append(nchunks, instruction.FormattedChunk{
+				Text: chunk.Text, Format: util.EMPTY_FORMAT, Argument: register.UnusedId(),
+			})
+		}
+	}
+	//
+	insns = append(insns, &instruction.Debug{Chunks: nchunks})
+	//
+	return instruction.NewVector[word.Uint](insns...)
 }
 
 func (p *Compiler) compileCondition(pc uint, e Condition, mapping []uint, target uint) Instruction {

--- a/pkg/zkc/compiler/linker.go
+++ b/pkg/zkc/compiler/linker.go
@@ -249,6 +249,12 @@ func (p *Linker) linkInstruction(insn stmt.Unresolved) (stmt.Resolved, []source.
 		cond, errors = p.linkCondition(insn.Cond)
 		//
 		ninsn = &stmt.IfGoto[symbol.Resolved]{Cond: cond, Target: insn.Target}
+	case *stmt.Printf[symbol.Unresolved]:
+		var args []expr.Expr[symbol.Resolved]
+		//
+		args, errors = p.linkExprs(insn.Arguments...)
+		//
+		ninsn = &stmt.Printf[symbol.Resolved]{Chunks: insn.Chunks, Arguments: args}
 	case *stmt.Return[symbol.Unresolved]:
 		ninsn = &stmt.Return[symbol.Resolved]{}
 	default:

--- a/pkg/zkc/compiler/parser/lexer.go
+++ b/pkg/zkc/compiler/parser/lexer.go
@@ -18,176 +18,124 @@ import (
 	"github.com/consensys/go-corset/pkg/util/source/lex"
 )
 
-// END_OF signals "end of file"
-const END_OF uint = 0
-
-// WHITESPACE signals whitespace
-const WHITESPACE uint = 1
-
-// COMMENT signals "// ... \n"
-const COMMENT uint = 2
-
-// LBRACE signals "("
-const LBRACE uint = 3
-
-// RBRACE signals ")"
-const RBRACE uint = 4
-
-// LCURLY signals "{"
-const LCURLY uint = 5
-
-// RCURLY signals "}"
-const RCURLY uint = 6
-
-// LSQUARE signals "["
-const LSQUARE uint = 7
-
-// RSQUARE signals "]"
-const RSQUARE uint = 8
-
-// COMMA signals ","
-const COMMA uint = 9
-
-// COLON signals ":"
-const COLON uint = 10
-
-// SEMICOLON signals ":"
-const SEMICOLON uint = 11
-
-// NUMBER signals an integer number
-const NUMBER uint = 12
-
-// STRING signals a quoted string
-const STRING uint = 13
-
-// IDENTIFIER signals a column variable
-const IDENTIFIER uint = 20
-
-// KEYWORD_CONST signals a constant declaration
-const KEYWORD_CONST uint = 21
-
-// KEYWORD_INCLUDE signals an include declaration
-const KEYWORD_INCLUDE uint = 22
-
-// KEYWORD_FN signals a function declaration
-const KEYWORD_FN uint = 23
-
-// KEYWORD_MEMORY signals a random-access memory declaration
-const KEYWORD_MEMORY uint = 24
-
-// KEYWORD_STATIC signals a static read-only memory
-const KEYWORD_STATIC uint = 25
-
-// KEYWORD_INPUT signals a read-only memory
-const KEYWORD_INPUT uint = 26
-
-// KEYWORD_OUTPUT signals a write-once memory
-const KEYWORD_OUTPUT uint = 27
-
-// KEYWORD_RETURN signals a return statement
-const KEYWORD_RETURN uint = 28
-
-// KEYWORD_FAIL signals a return statement
-const KEYWORD_FAIL uint = 29
-
-// KEYWORD_IF signals a return statement
-const KEYWORD_IF uint = 30
-
-// KEYWORD_ELSE signals an else branch
-const KEYWORD_ELSE uint = 31
-
-// KEYWORD_PUB signals a public input / output
-const KEYWORD_PUB uint = 32
-
-// KEYWORD_WHILE signals a while loop
-const KEYWORD_WHILE uint = 34
-
-// KEYWORD_FOR signals a for loop
-const KEYWORD_FOR uint = 35
-
-// KEYWORD_VAR signals a local variable declaration
-const KEYWORD_VAR uint = 36
-
-// KEYWORD_BREAK signals a break statement
-const KEYWORD_BREAK uint = 37
-
-// KEYWORD_CONTINUE signals a continue statement
-const KEYWORD_CONTINUE uint = 38
-
-// KEYWORD_AS signals a type cast expression (e.g. "x as u8")
-const KEYWORD_AS uint = 39
-
-// KEYWORD_TYPE_ALIAS signals a type alias declaration
-const KEYWORD_TYPE_ALIAS uint = 40
-
-// RIGHTARROW signals "->"
-const RIGHTARROW uint = 60
-
-// EQUALS signals "="
-const EQUALS uint = 61
-
-// EQUALS_EQUALS signals "=="
-const EQUALS_EQUALS uint = 62
-
-// NOT_EQUALS signals "!="
-const NOT_EQUALS uint = 63
-
-// LESS_THAN signals "<"
-const LESS_THAN uint = 64
-
-// LESS_THAN_EQUALS signals "<="
-const LESS_THAN_EQUALS uint = 65
-
-// GREATER_THAN signals ">"
-const GREATER_THAN uint = 66
-
-// GREATER_THAN_EQUALS signals ">="
-const GREATER_THAN_EQUALS uint = 67
-
-// LOGICAL_AND signals "&&"
-const LOGICAL_AND uint = 68
-
-// LOGICAL_OR signals "||"
-const LOGICAL_OR uint = 69
-
-// LOGICAL_NOT signals "!"
-const LOGICAL_NOT uint = 70
-
-// ADD signals "+"
-const ADD uint = 80
-
-// SUB signals "-"
-const SUB uint = 81
-
-// MUL signals "*"
-const MUL uint = 82
-
-// DIV signals "/"
-const DIV uint = 83
-
-// BTIWISE_AND signals "&"
-const BTIWISE_AND uint = 84
-
-// BITWISE_OR signals "|"
-const BITWISE_OR uint = 85
-
-// BITWISE_XOR signals "^"
-const BITWISE_XOR uint = 86
-
-// BITWISE_NOT signals "~"
-const BITWISE_NOT uint = 87
-
-// BITWISE_SHL signals "<<"
-const BITWISE_SHL uint = 88
-
-// BITWISE_SHR signals ">>"
-const BITWISE_SHR uint = 89
-
-// REM signals "%"
-const REM uint = 90
-
-// QMARK signals "?"
-const QMARK uint = 91
+const (
+	// END_OF signals "end of file"
+	END_OF uint = iota
+	// WHITESPACE signals whitespace
+	WHITESPACE
+	// COMMENT signals "// ... \n"
+	COMMENT
+	// LBRACE signals "("
+	LBRACE
+	// RBRACE signals ")"
+	RBRACE
+	// LCURLY signals "{"
+	LCURLY
+	// RCURLY signals "}"
+	RCURLY
+	// LSQUARE signals "["
+	LSQUARE
+	// RSQUARE signals "]"
+	RSQUARE
+	// COMMA signals ","
+	COMMA
+	// COLON signals ":"
+	COLON
+	// SEMICOLON signals ":"
+	SEMICOLON
+	// NUMBER signals an integer number
+	NUMBER
+	// STRING signals a quoted string
+	STRING
+	// IDENTIFIER signals a column variable
+	IDENTIFIER
+	// KEYWORD_AS signals a type cast expression (e.g. "x as u8")
+	KEYWORD_AS
+	// KEYWORD_BREAK signals a break statement
+	KEYWORD_BREAK
+	// KEYWORD_CONTINUE signals a continue statement
+	KEYWORD_CONTINUE
+	// KEYWORD_CONST signals a constant declaration
+	KEYWORD_CONST
+	// KEYWORD_ELSE signals an else branch
+	KEYWORD_ELSE
+	// KEYWORD_FAIL signals a return statement
+	KEYWORD_FAIL
+	// KEYWORD_FN signals a function declaration
+	KEYWORD_FN
+	// KEYWORD_FOR signals a for loop
+	KEYWORD_FOR
+	// KEYWORD_IF signals a return statement
+	KEYWORD_IF
+	// KEYWORD_INCLUDE signals an include declaration
+	KEYWORD_INCLUDE
+	// KEYWORD_INPUT signals a read-only memory
+	KEYWORD_INPUT
+	// KEYWORD_MEMORY signals a random-access memory declaration
+	KEYWORD_MEMORY
+	// KEYWORD_RETURN signals a return statement
+	KEYWORD_RETURN
+	// KEYWORD_STATIC signals a static read-only memory
+	KEYWORD_STATIC
+	// KEYWORD_OUTPUT signals a write-once memory
+	KEYWORD_OUTPUT
+	// KEYWORD_PRINTF signals a printf statement
+	KEYWORD_PRINTF
+	// KEYWORD_PUB signals a public input / output
+	KEYWORD_PUB
+	// KEYWORD_WHILE signals a while loop
+	KEYWORD_WHILE
+	// KEYWORD_VAR signals a local variable declaration
+	KEYWORD_VAR
+	// KEYWORD_TYPE signals a type alias declaration
+	KEYWORD_TYPE
+	// RIGHTARROW signals "->"
+	RIGHTARROW
+	// EQUALS signals "="
+	EQUALS
+	// EQUALS_EQUALS signals "=="
+	EQUALS_EQUALS
+	// NOT_EQUALS signals "!="
+	NOT_EQUALS
+	// LESS_THAN signals "<"
+	LESS_THAN
+	// LESS_THAN_EQUALS signals "<="
+	LESS_THAN_EQUALS
+	// GREATER_THAN signals ">"
+	GREATER_THAN
+	// GREATER_THAN_EQUALS signals ">="
+	GREATER_THAN_EQUALS
+	// LOGICAL_AND signals "&&"
+	LOGICAL_AND
+	// LOGICAL_OR signals "||"
+	LOGICAL_OR
+	// LOGICAL_NOT signals "!"
+	LOGICAL_NOT
+	// ADD signals "+"
+	ADD
+	// SUB signals "-"
+	SUB
+	// MUL signals "*"
+	MUL
+	// DIV signals "/"
+	DIV
+	// BTIWISE_AND signals "&"
+	BTIWISE_AND
+	// BITWISE_OR signals "|"
+	BITWISE_OR
+	// BITWISE_XOR signals "^"
+	BITWISE_XOR
+	// BITWISE_NOT signals "~"
+	BITWISE_NOT
+	// BITWISE_SHL signals "<<"
+	BITWISE_SHL
+	// BITWISE_SHR signals ">>"
+	BITWISE_SHR
+	// REM signals "%"
+	REM
+	// QMARK signals "?"
+	QMARK
+)
 
 // Rule for describing whitespace
 var whitespace lex.Scanner[rune] = lex.Many(lex.Or(lex.Unit(' '), lex.Unit('\t'), lex.Unit('\n')))
@@ -276,25 +224,26 @@ var rules []lex.LexRule[rune] = []lex.LexRule[rune]{
 	lex.Rule(whitespace, WHITESPACE),
 	lex.Rule(number, NUMBER),
 	lex.Rule(strung, STRING),
+	lex.Rule(lex.String("as"), KEYWORD_AS),
+	lex.Rule(lex.String("break"), KEYWORD_BREAK),
 	lex.Rule(lex.String("const"), KEYWORD_CONST),
+	lex.Rule(lex.String("continue"), KEYWORD_CONTINUE),
 	lex.Rule(lex.String("else"), KEYWORD_ELSE),
 	lex.Rule(lex.String("fail"), KEYWORD_FAIL),
+	lex.Rule(lex.String("for"), KEYWORD_FOR),
 	lex.Rule(lex.String("fn"), KEYWORD_FN),
 	lex.Rule(lex.String("if"), KEYWORD_IF),
 	lex.Rule(lex.String("include"), KEYWORD_INCLUDE),
 	lex.Rule(lex.String("input"), KEYWORD_INPUT),
+	lex.Rule(lex.String("memory"), KEYWORD_MEMORY),
 	lex.Rule(lex.String("output"), KEYWORD_OUTPUT),
+	lex.Rule(lex.String("printf"), KEYWORD_PRINTF),
 	lex.Rule(lex.String("pub"), KEYWORD_PUB),
 	lex.Rule(lex.String("return"), KEYWORD_RETURN),
 	lex.Rule(lex.String("static"), KEYWORD_STATIC),
-	lex.Rule(lex.String("memory"), KEYWORD_MEMORY),
-	lex.Rule(lex.String("for"), KEYWORD_FOR),
+	lex.Rule(lex.String("type"), KEYWORD_TYPE),
 	lex.Rule(lex.String("var"), KEYWORD_VAR),
 	lex.Rule(lex.String("while"), KEYWORD_WHILE),
-	lex.Rule(lex.String("as"), KEYWORD_AS),
-	lex.Rule(lex.String("type"), KEYWORD_TYPE_ALIAS),
-	lex.Rule(lex.String("break"), KEYWORD_BREAK),
-	lex.Rule(lex.String("continue"), KEYWORD_CONTINUE),
 	lex.Rule(identifier, IDENTIFIER),
 	lex.Rule(lex.Eof[rune](), END_OF),
 }

--- a/pkg/zkc/compiler/parser/parser.go
+++ b/pkg/zkc/compiler/parser/parser.go
@@ -29,6 +29,7 @@ import (
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/stmt"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/symbol"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/variable"
+	zkc_util "github.com/consensys/go-corset/pkg/zkc/util"
 )
 
 // Condition is a convenient alias
@@ -137,7 +138,7 @@ func (p *Parser) Parse() (UnlinkedSourceFile, []source.SyntaxError) {
 			component, errors = p.parseInputOutputMemory()
 		case KEYWORD_MEMORY:
 			component, errors = p.parseReadWriteMemory()
-		case KEYWORD_TYPE_ALIAS:
+		case KEYWORD_TYPE:
 			component, errors = p.parseTypeAlias()
 		default:
 			errors = p.syntaxErrors(lookahead, "unknown declaration")
@@ -482,7 +483,7 @@ func (p *Parser) parseTypeAlias() (decl.Unresolved, []source.SyntaxError) {
 		name     string
 	)
 	// Parse type declaration
-	if _, errs := p.expect(KEYWORD_TYPE_ALIAS); len(errs) > 0 {
+	if _, errs := p.expect(KEYWORD_TYPE); len(errs) > 0 {
 		return nil, errs
 	} else if name, errs = p.parseIdentifier(); len(errs) > 0 {
 		return nil, errs
@@ -628,14 +629,16 @@ func (p *Parser) parseStatement(pc uint, env Environment,
 		returned, insn, errs = p.parseContinue(env)
 	case KEYWORD_FAIL:
 		returned, insn, errs = p.parseFail()
-	case KEYWORD_IF:
-		returned, insns, errs = p.parseIfElse(pc, env)
 	case KEYWORD_FOR:
 		returned, insns, errs = p.parseFor(pc, env)
-	case KEYWORD_WHILE:
-		returned, insns, errs = p.parseWhile(pc, env)
+	case KEYWORD_IF:
+		returned, insns, errs = p.parseIfElse(pc, env)
+	case KEYWORD_PRINTF:
+		returned, insn, errs = p.parsePrintf(env)
 	case KEYWORD_RETURN:
 		returned, insn, errs = p.parseReturn()
+	case KEYWORD_WHILE:
+		returned, insns, errs = p.parseWhile(pc, env)
 	case KEYWORD_VAR:
 		insns, errs = p.parseVar(env)
 	case IDENTIFIER:
@@ -914,6 +917,119 @@ func (p *Parser) parseFail() (bool, stmt.Unresolved, []source.SyntaxError) {
 	//
 	return true, &stmt.Fail[symbol.Unresolved]{}, nil
 }
+
+func (p *Parser) parsePrintf(env Environment) (bool, stmt.Unresolved, []source.SyntaxError) {
+	var (
+		token  lex.Token
+		chunks []stmt.FormattedChunk
+	)
+	//
+	if _, errs := p.expect(KEYWORD_PRINTF); len(errs) > 0 {
+		return false, nil, errs
+	} else if token, errs = p.expect(STRING); len(errs) > 0 {
+		return false, nil, errs
+	}
+	// Process string
+	var (
+		str    = p.string(token)
+		runes  = []rune(str[1 : len(str)-1])
+		nrunes []rune
+		args   []Expr
+		nargs  int
+	)
+	//
+	for i := 0; i < len(runes); {
+		switch runes[i] {
+		case '%':
+			var (
+				f  zkc_util.Format
+				ok bool
+			)
+			if i, f, ok = parseFormatting(i+1, runes); !ok {
+				return false, nil, p.syntaxErrors(token, "invalid formatting")
+			}
+			//
+			nargs++
+			// append new chunkformat
+			chunks = append(chunks, stmt.FormattedChunk{Text: string(nrunes), Format: f})
+			// reset to build next chunk
+			nrunes = nil
+		case '\\':
+			if i+1 == len(runes) {
+				return false, nil, p.syntaxErrors(token, "invalid escape")
+			}
+			// Attempt to parse escape character
+			c, ok := escapeCharacter(runes[i+1])
+			//
+			if !ok {
+				return false, nil, p.syntaxErrors(token, "invalid escape")
+			}
+			// Continue
+			nrunes = append(nrunes, c)
+			i = i + 2
+		default:
+			nrunes = append(nrunes, runes[i])
+			i = i + 1
+		}
+	}
+	//
+	if len(nrunes) > 0 {
+		chunks = append(chunks, stmt.FormattedChunk{Text: string(nrunes), Format: zkc_util.EMPTY_FORMAT})
+	}
+	// parse expression arguments
+	for p.match(COMMA) {
+		arg, errs := p.parseExpr(env)
+		//
+		if len(errs) > 0 {
+			return false, nil, errs
+		}
+		//
+		args = append(args, arg)
+	}
+	// Sanity check for matching arguments / chunks
+	if len(args) > nargs {
+		return false, nil, p.srcmap.SyntaxErrors(args[nargs], "too many arguments")
+	} else if len(args) > 0 && len(args) < nargs {
+		n := len(args) - 1
+		//
+		return false, nil, p.srcmap.SyntaxErrors(args[n], "insufficient arguments")
+	} else if len(args) < nargs {
+		return false, nil, p.syntaxErrors(token, "insufficient arguments")
+	}
+	//
+	return false, &stmt.Printf[symbol.Unresolved]{Chunks: chunks, Arguments: args}, nil
+}
+
+func parseFormatting(index int, runes []rune) (int, zkc_util.Format, bool) {
+	if index >= len(runes) {
+		return 0, zkc_util.EMPTY_FORMAT, false
+	}
+	//
+	switch runes[index] {
+	case 'd':
+		return index + 1, zkc_util.DecimalFormat(), true
+	case 'x':
+		return index + 1, zkc_util.HexFormat(), true
+	default:
+		return 0, zkc_util.EMPTY_FORMAT, false
+	}
+}
+
+func escapeCharacter(ch rune) (rune, bool) {
+	switch ch {
+	case 'n':
+		return '\n', true
+	case 'r':
+		return '\r', true
+	case 't':
+		return '\t', true
+	case '\\':
+		return '\\', true
+	}
+	//
+	return ' ', false
+}
+
 func (p *Parser) parseBreak(env Environment) (bool, stmt.Unresolved, []source.SyntaxError) {
 	var (
 		label     = env.BreakLabel()

--- a/pkg/zkc/compiler/validate/typing.go
+++ b/pkg/zkc/compiler/validate/typing.go
@@ -120,6 +120,8 @@ func (p *TypeChecker) typeFunction(fn decl.ResolvedFunction) []source.SyntaxErro
 			errors = append(errors, p.typeAssignment(s, &fn, effects)...)
 		case *stmt.IfGoto[symbol.Resolved]:
 			errors = append(errors, p.typeIfGoto(s, &fn, effects)...)
+		case *stmt.Printf[symbol.Resolved]:
+			errors = append(errors, p.typePrintf(s, &fn, effects)...)
 		}
 	}
 	//
@@ -259,6 +261,23 @@ func checkTargets(s *stmt.Assign[symbol.Resolved], env VariableMap, srcmaps sour
 func (p *TypeChecker) typeIfGoto(s *stmt.IfGoto[symbol.Resolved], env VariableMap, effects bit.Set,
 ) []source.SyntaxError {
 	return p.typeCondition(s.Cond, env, effects)
+}
+
+func (p *TypeChecker) typePrintf(s *stmt.Printf[symbol.Resolved], env VariableMap, effects bit.Set,
+) []source.SyntaxError {
+	var errs []source.SyntaxError
+	//
+	for _, e := range s.Arguments {
+		ith, ierrs := p.typeExpression(e, env, effects)
+		//
+		if len(ierrs) == 0 && ith.AsUint(p.env) == nil {
+			errs = append(errs, *p.srcmaps.SyntaxError(e, "expected uint"))
+		} else {
+			errs = append(errs, ierrs...)
+		}
+	}
+	//
+	return errs
 }
 
 func (p *TypeChecker) typeCondition(e expr.ResolvedCondition, env VariableMap, effects bit.Set) []source.SyntaxError {

--- a/pkg/zkc/util/formatted_text.go
+++ b/pkg/zkc/util/formatted_text.go
@@ -1,0 +1,85 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package util
+
+import (
+	"strings"
+
+	"github.com/consensys/go-corset/pkg/zkc/vm/word"
+)
+
+// EscapeFormattedText takes a string and escapes any characters which need to
+// be escaped in order to be printed.
+func EscapeFormattedText(text string) string {
+	text = strings.ReplaceAll(text, "\\", "\\\\")
+	text = strings.ReplaceAll(text, "\n", "\\n")
+	text = strings.ReplaceAll(text, "\t", "\\t")
+	//
+	return strings.ReplaceAll(text, "\r", "\\r")
+}
+
+const (
+	// FORMAT_NONE indicates an empty format string
+	FORMAT_NONE uint = iota
+	// FORMAT_DEC indicates to format in decimal
+	FORMAT_DEC
+	// FORMAT_HEX indicates to format in hexadecimal
+	FORMAT_HEX
+)
+
+// Format simply encodes the set of permitted formatting strings in a printf
+// statement, such as "%d", "%x", etc.
+type Format struct {
+	Code uint
+}
+
+// EMPTY_FORMAT indicates no formatted argument is required.
+var EMPTY_FORMAT = Format{FORMAT_NONE}
+
+// DecimalFormat constructs a new decimal format.
+func DecimalFormat() Format {
+	return Format{FORMAT_DEC}
+}
+
+// HexFormat constructs a new hexadecimal format.
+func HexFormat() Format {
+	return Format{FORMAT_HEX}
+}
+
+// HasFormat checks whether this actually represents a format, or is empty.
+func (p Format) HasFormat() bool {
+	return p.Code != FORMAT_NONE
+}
+
+func (p Format) String() string {
+	switch p.Code {
+	case FORMAT_DEC:
+		return "%d"
+	case FORMAT_HEX:
+		return "%x"
+	}
+	//
+	panic("invalid format")
+}
+
+// FormatWord applies a given format to a given word to generate a formatted string.
+func FormatWord[W word.Word[W]](format Format, word W) string {
+	switch format.Code {
+	case FORMAT_DEC:
+		return word.Text(10)
+	case FORMAT_HEX:
+		return word.Text(16)
+	}
+	//
+	panic("invalid format")
+}

--- a/pkg/zkc/vm/instruction/debug.go
+++ b/pkg/zkc/vm/instruction/debug.go
@@ -1,0 +1,89 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package instruction
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/consensys/go-corset/pkg/schema/register"
+	"github.com/consensys/go-corset/pkg/util/field"
+	"github.com/consensys/go-corset/pkg/zkc/util"
+)
+
+// FormattedChunk represents a chunk of a printf string which consists of some
+// text, followed by an optional argument format.
+type FormattedChunk struct {
+	Text     string
+	Format   util.Format
+	Argument register.Id
+}
+
+// Debug performs an unconditional branch to a given target instructon.
+type Debug struct {
+	Chunks []FormattedChunk
+}
+
+// Uses implementation for Instruction interface.
+func (p *Debug) Uses() []register.Id {
+	var uses []register.Id
+	//
+	for _, c := range p.Chunks {
+		if c.Format.HasFormat() {
+			uses = append(uses, c.Argument)
+		}
+	}
+	//
+	return uses
+}
+
+// Definitions implementation for Instruction interface.
+func (p *Debug) Definitions() []register.Id {
+	return nil
+}
+
+func (p *Debug) String(env register.Map) string {
+	var (
+		tBuilder  strings.Builder
+		builder   strings.Builder
+		firstTime = true
+	)
+	//
+	for _, c := range p.Chunks {
+		tBuilder.WriteString(c.Text)
+		//
+		if c.Format.HasFormat() {
+			tBuilder.WriteString(c.Format.String())
+
+			if !firstTime {
+				builder.WriteString(",")
+			}
+			//
+			firstTime = false
+			//
+			builder.WriteString(env.Register(c.Argument.Id()).Name())
+		}
+	}
+	//
+	return fmt.Sprintf("debug \"%s\", %s", tBuilder.String(), builder.String())
+}
+
+// Validate implementation for Instruction interface.
+func (p *Debug) Validate(_ field.Config, _ register.Map) []error {
+	return nil
+}
+
+// MicroValidate implementation for Instruction interface.
+func (p *Debug) MicroValidate(_ uint, _ field.Config, _ register.Map) []error {
+	return nil
+}

--- a/pkg/zkc/vm/machine/base.go
+++ b/pkg/zkc/vm/machine/base.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 
 	"github.com/consensys/go-corset/pkg/schema/register"
+	"github.com/consensys/go-corset/pkg/zkc/util"
 	"github.com/consensys/go-corset/pkg/zkc/vm/function"
 	"github.com/consensys/go-corset/pkg/zkc/vm/instruction"
 	"github.com/consensys/go-corset/pkg/zkc/vm/memory"
@@ -318,6 +319,8 @@ func (p *Base[W]) executeInstruction(insn instruction.MicroInstruction[W], width
 			pc = pc.Skip(insn.Skip)
 		}
 		// Fall thru
+	case *instruction.Debug:
+		err = executeDebug(*insn, frame, regs)
 	default:
 		panic("unknown instruction encountered")
 	}
@@ -531,6 +534,18 @@ func executeCast[W word.Word[W]](insn instruction.Cast[W], frame []W, _ []regist
 	}
 	//
 	frame[insn.Target.Unwrap()] = sliced
+	//
+	return nil
+}
+
+func executeDebug[W word.Word[W]](insn instruction.Debug, frame []W, _ []register.Register) error {
+	for _, chunk := range insn.Chunks {
+		fmt.Printf("%s", chunk.Text)
+		//
+		if chunk.Format.HasFormat() {
+			fmt.Printf("%s", util.FormatWord(chunk.Format, frame[chunk.Argument.Unwrap()]))
+		}
+	}
 	//
 	return nil
 }

--- a/testdata/zkc/invalid/printf_01.zkc
+++ b/testdata/zkc/invalid/printf_01.zkc
@@ -1,0 +1,10 @@
+//error:9:35-38:too many arguments
+pub input data(address:u16) -> (byte:u32)
+
+// prove that two numbers add up to a third.
+fn main() {
+  var lhs:u32 = data[0]
+  var rhs:u32 = data[1]
+  //
+  printf "hello world %d\n", lhs, rhs
+}

--- a/testdata/zkc/invalid/printf_02.zkc
+++ b/testdata/zkc/invalid/printf_02.zkc
@@ -1,0 +1,10 @@
+//error:9:10-28:insufficient arguments
+pub input data(address:u16) -> (byte:u32)
+
+// prove that two numbers add up to a third.
+fn main() {
+  var lhs:u32 = data[0]
+  var rhs:u32 = data[1]
+  //
+  printf "hello world %d\n"
+}

--- a/testdata/zkc/invalid/printf_03.zkc
+++ b/testdata/zkc/invalid/printf_03.zkc
@@ -1,0 +1,10 @@
+//error:9:30-34:insufficient arguments (expected 1)
+pub input data(address:u16) -> (byte:u32)
+
+// prove that two numbers add up to a third.
+fn main() {
+  var lhs:u32 = data[0]
+  var rhs:u32 = data[1]
+  //
+  printf "hello world %d\n", data
+}

--- a/testdata/zkc/invalid/printf_04.zkc
+++ b/testdata/zkc/invalid/printf_04.zkc
@@ -1,0 +1,10 @@
+//error:9:31-32:unknown symbol
+pub input data(address:u16) -> (byte:u32)
+
+// prove that two numbers add up to a third.
+fn main() {
+  var lhs:u32 = data[0]
+  var rhs:u32 = data[1]
+  //
+  printf "hello world %d\n", (x+1)
+}

--- a/testdata/zkc/unit/printf_01.zkc
+++ b/testdata/zkc/unit/printf_01.zkc
@@ -1,0 +1,9 @@
+pub input data(address:u16) -> (byte:u32)
+
+// prove that two numbers add up to a third.
+fn main() {
+  var lhs:u32 = data[0]
+  var rhs:u32 = data[1]
+  //
+  printf "hello world %d\n",1
+}

--- a/testdata/zkc/unit/printf_02.zkc
+++ b/testdata/zkc/unit/printf_02.zkc
@@ -1,0 +1,11 @@
+pub input data(address:u16) -> (byte:u32)
+
+const ONE:u16 = 1
+
+// prove that two numbers add up to a third.
+fn main() {
+  var lhs:u32 = data[0]
+  var rhs:u32 = data[1]
+  //
+  printf "hello world %d\n",ONE
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new language statement plus VM execution behavior that prints to stdout, which can affect runtime determinism/logging and test environments. Parser/lexer token re-numbering and the `type` keyword rename could also cause subtle compatibility issues for existing ZkC sources.
> 
> **Overview**
> Adds a `printf "..."` statement to ZkC as a debugging aid, including parsing of `%d`/`%x` format specifiers and basic escape handling, with argument-count validation.
> 
> Wires `printf` through the full pipeline: new AST stmt (`stmt.Printf`), linker support, type-checking (arguments must be `uint`), and codegen that emits a new VM `Debug` instruction which prints formatted register values during execution.
> 
> Refactors lexer token definitions to `iota`, introduces `KEYWORD_PRINTF`, and renames the type-alias keyword token from `KEYWORD_TYPE_ALIAS` to `KEYWORD_TYPE`; adds unit/invalid test cases and new `testdata` fixtures covering `printf` success and failure modes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09f4b4c31079412462585e06976d052919ee4379. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->