### PR TITLE
Fix bug where parser misidentifies variables as keywords if the keyword is a prefix of the variable name

### DIFF
--- a/pkg/test/zkc_unit_test.go
+++ b/pkg/test/zkc_unit_test.go
@@ -84,6 +84,18 @@ func Test_ZkcUnit_Basic_16(t *testing.T) {
 	checkZkcUnit(t, "zkc/unit/basic_16")
 }
 
+func Test_ZkcUnit_Basic_17(t *testing.T) {
+	checkZkcUnit(t, "zkc/unit/basic_17")
+}
+
+func Test_ZkcUnit_Basic_18(t *testing.T) {
+	checkZkcUnit(t, "zkc/unit/basic_18")
+}
+
+func Test_ZkcUnit_Basic_19(t *testing.T) {
+	checkZkcUnit(t, "zkc/unit/basic_19")
+}
+
 // ===================================================================
 // If-Else-If Tests
 // ===================================================================

--- a/pkg/zkc/compiler/parser/lexer.go
+++ b/pkg/zkc/compiler/parser/lexer.go
@@ -259,6 +259,9 @@ var keywords = map[string]uint{
 	"while":    KEYWORD_WHILE,
 }
 
+// MAX_KEYWORD_LENGTH is used to optimise lexing of keywords.
+var MAX_KEYWORD_LENGTH int
+
 // Lex a given source file into a sequence of zero or more tokens, along with
 // any syntax errors arising. When includeComments is true, COMMENT tokens are
 // retained in the output (e.g. for syntax highlighting); otherwise they are
@@ -281,11 +284,13 @@ func Lex(srcfile source.File, includeComments bool) ([]lex.Token, []source.Synta
 	// Remove comments unless the caller wants them (e.g. for syntax highlighting)
 	if !includeComments {
 		tokens = array.RemoveMatching(tokens, func(t lex.Token) bool { return t.Kind == COMMENT })
+	}
 	// Reclassify identifiers whose full text is an exact keyword match.
 	contents := srcfile.Contents()
 
 	for i, tok := range tokens {
-		if tok.Kind == IDENTIFIER {
+		// Check whether the given identifier is a keyword, or not.
+		if tok.Kind == IDENTIFIER && tok.Span.Length() <= MAX_KEYWORD_LENGTH {
 			text := string(contents[tok.Span.Start():tok.Span.End()])
 			if kind, ok := keywords[text]; ok {
 				tokens[i].Kind = kind
@@ -294,4 +299,11 @@ func Lex(srcfile source.File, includeComments bool) ([]lex.Token, []source.Synta
 	}
 	// Done
 	return tokens, nil
+}
+
+func init() {
+	// Statically compute maximum length of any keyword
+	for k := range keywords {
+		MAX_KEYWORD_LENGTH = max(MAX_KEYWORD_LENGTH, len(k))
+	}
 }

--- a/pkg/zkc/compiler/parser/lexer.go
+++ b/pkg/zkc/compiler/parser/lexer.go
@@ -227,28 +227,36 @@ var rules []lex.LexRule[rune] = []lex.LexRule[rune]{
 	lex.Rule(whitespace, WHITESPACE),
 	lex.Rule(number, NUMBER),
 	lex.Rule(strung, STRING),
-	lex.Rule(lex.String("as"), KEYWORD_AS),
-	lex.Rule(lex.String("break"), KEYWORD_BREAK),
-	lex.Rule(lex.String("const"), KEYWORD_CONST),
-	lex.Rule(lex.String("continue"), KEYWORD_CONTINUE),
-	lex.Rule(lex.String("else"), KEYWORD_ELSE),
-	lex.Rule(lex.String("fail"), KEYWORD_FAIL),
-	lex.Rule(lex.String("for"), KEYWORD_FOR),
-	lex.Rule(lex.String("fn"), KEYWORD_FN),
-	lex.Rule(lex.String("if"), KEYWORD_IF),
-	lex.Rule(lex.String("include"), KEYWORD_INCLUDE),
-	lex.Rule(lex.String("input"), KEYWORD_INPUT),
-	lex.Rule(lex.String("memory"), KEYWORD_MEMORY),
-	lex.Rule(lex.String("output"), KEYWORD_OUTPUT),
-	lex.Rule(lex.String("printf"), KEYWORD_PRINTF),
-	lex.Rule(lex.String("pub"), KEYWORD_PUB),
-	lex.Rule(lex.String("return"), KEYWORD_RETURN),
-	lex.Rule(lex.String("static"), KEYWORD_STATIC),
-	lex.Rule(lex.String("type"), KEYWORD_TYPE),
-	lex.Rule(lex.String("var"), KEYWORD_VAR),
-	lex.Rule(lex.String("while"), KEYWORD_WHILE),
 	lex.Rule(identifier, IDENTIFIER),
 	lex.Rule(lex.Eof[rune](), END_OF),
+}
+
+// keywords maps exact identifier strings to their keyword token kinds.
+// Reclassification happens as a post-processing step in Lex so that
+// identifiers that merely start with a keyword (e.g. "as_X") are never
+// misidentified: the identifier rule always consumes the full token, and
+// only an exact match triggers reclassification.
+var keywords = map[string]uint{
+	"as":       KEYWORD_AS,
+	"break":    KEYWORD_BREAK,
+	"const":    KEYWORD_CONST,
+	"continue": KEYWORD_CONTINUE,
+	"else":     KEYWORD_ELSE,
+	"fail":     KEYWORD_FAIL,
+	"fn":       KEYWORD_FN,
+	"for":      KEYWORD_FOR,
+	"if":       KEYWORD_IF,
+	"include":  KEYWORD_INCLUDE,
+	"input":    KEYWORD_INPUT,
+	"memory":   KEYWORD_MEMORY,
+	"output":   KEYWORD_OUTPUT,
+	"printf":   KEYWORD_PRINTF,
+	"pub":      KEYWORD_PUB,
+	"return":   KEYWORD_RETURN,
+	"static":   KEYWORD_STATIC,
+	"type":     KEYWORD_TYPE,
+	"var":      KEYWORD_VAR,
+	"while":    KEYWORD_WHILE,
 }
 
 // Lex a given source file into a sequence of zero or more tokens, along with
@@ -273,6 +281,16 @@ func Lex(srcfile source.File, includeComments bool) ([]lex.Token, []source.Synta
 	// Remove comments unless the caller wants them (e.g. for syntax highlighting)
 	if !includeComments {
 		tokens = array.RemoveMatching(tokens, func(t lex.Token) bool { return t.Kind == COMMENT })
+	// Reclassify identifiers whose full text is an exact keyword match.
+	contents := srcfile.Contents()
+
+	for i, tok := range tokens {
+		if tok.Kind == IDENTIFIER {
+			text := string(contents[tok.Span.Start():tok.Span.End()])
+			if kind, ok := keywords[text]; ok {
+				tokens[i].Kind = kind
+			}
+		}
 	}
 	// Done
 	return tokens, nil

--- a/testdata/zkc/unit/basic_17.zkc
+++ b/testdata/zkc/unit/basic_17.zkc
@@ -1,0 +1,22 @@
+fn  keyword_at_beginning_of_word() {
+  var as_X       : u32
+  var break_X    : u32
+  var continue_X : u32
+  var const_X    : u32
+  var else_X     : u32
+  var fail_X     : u32
+  var fn_X       : u32
+  var for_X      : u32
+  var if_X       : u32
+  var include_X  : u32
+  var input_X    : u32
+  var memory_X   : u32
+  var return_X   : u32
+  var static_X   : u32
+  var output_X   : u32
+  var printf_X   : u32
+  var pub_X      : u32
+  var while_X    : u32
+  var var_X      : u32
+  var type_X     : u32
+}

--- a/testdata/zkc/unit/basic_18.zkc
+++ b/testdata/zkc/unit/basic_18.zkc
@@ -1,0 +1,22 @@
+fn  keyword_at_end_of_word() {
+  var X_as       : u32
+  var X_break    : u32
+  var X_continue : u32
+  var X_const    : u32
+  var X_else     : u32
+  var X_fail     : u32
+  var X_fn       : u32
+  var X_for      : u32
+  var X_if       : u32
+  var X_include  : u32
+  var X_input    : u32
+  var X_memory   : u32
+  var X_return   : u32
+  var X_static   : u32
+  var X_output   : u32
+  var X_printf   : u32
+  var X_pub      : u32
+  var X_while    : u32
+  var X_var      : u32
+  var X_type     : u32
+}

--- a/testdata/zkc/unit/basic_19.zkc
+++ b/testdata/zkc/unit/basic_19.zkc
@@ -1,0 +1,22 @@
+fn  keyword_in_middle_of_word() {
+  var X_as_Y       : u32
+  var X_break_Y    : u32
+  var X_continue_Y : u32
+  var X_const_Y    : u32
+  var X_else_Y     : u32
+  var X_fail_Y     : u32
+  var X_fn_Y       : u32
+  var X_for_Y      : u32
+  var X_if_Y       : u32
+  var X_include_Y  : u32
+  var X_input_Y    : u32
+  var X_memory_Y   : u32
+  var X_return_Y   : u32
+  var X_static_Y   : u32
+  var X_output_Y   : u32
+  var X_printf_Y   : u32
+  var X_pub_Y      : u32
+  var X_while_Y    : u32
+  var X_var_Y      : u32
+  var X_type_Y     : u32
+}


### PR DESCRIPTION
Initial attempt (adding a `whitespace` to the keyword pattern) was flawed: it would have misidentified e.g. `if(condition == 1)`. Claude made it robust. The approach: parse all tokens without looking for keywords. In a second pass look for exact matches in the keywords map


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core lexing logic, which can affect parsing across the language, but the change is localized and covered by new unit tests for keyword substrings in identifiers.
> 
> **Overview**
> Fixes a lexer bug where identifiers like `as_X` could be tokenized as keywords by removing per-keyword lex rules and instead *post-processing* `IDENTIFIER` tokens to reclassify them only when their full text exactly matches a keyword.
> 
> Adds new ZKC unit fixtures and tests (`basic_17`–`basic_19`) that declare variables with keywords at the start/end/middle of the name to ensure keyword substring occurrences no longer break parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d25eb6ddc04bef6e6e25177a842b7e906d2d1b43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->