### PR TITLE
Minor improvements to `printf`

### DIFF
--- a/pkg/zkc/compiler/parser/parser.go
+++ b/pkg/zkc/compiler/parser/parser.go
@@ -1043,6 +1043,8 @@ func parseFormatting(index int, runes []rune) (int, zkc_util.Format, bool) {
 		return index + 1, zkc_util.DecimalFormat(), true
 	case 'x':
 		return index + 1, zkc_util.HexFormat(), true
+	case 'b':
+		return index + 1, zkc_util.BinFormat(), true
 	default:
 		return 0, zkc_util.EMPTY_FORMAT, false
 	}

--- a/pkg/zkc/util/formatted_text.go
+++ b/pkg/zkc/util/formatted_text.go
@@ -35,6 +35,8 @@ const (
 	FORMAT_DEC
 	// FORMAT_HEX indicates to format in hexadecimal
 	FORMAT_HEX
+	// FORMAT_BIN indicates to format in hexadecimal
+	FORMAT_BIN
 )
 
 // Format simply encodes the set of permitted formatting strings in a printf
@@ -56,6 +58,11 @@ func HexFormat() Format {
 	return Format{FORMAT_HEX}
 }
 
+// BinFormat constructs a new hexadecimal format.
+func BinFormat() Format {
+	return Format{FORMAT_BIN}
+}
+
 // HasFormat checks whether this actually represents a format, or is empty.
 func (p Format) HasFormat() bool {
 	return p.Code != FORMAT_NONE
@@ -67,6 +74,8 @@ func (p Format) String() string {
 		return "%d"
 	case FORMAT_HEX:
 		return "%x"
+	case FORMAT_BIN:
+		return "%b"
 	}
 	//
 	panic("invalid format")
@@ -78,7 +87,9 @@ func FormatWord[W word.Word[W]](format Format, word W) string {
 	case FORMAT_DEC:
 		return word.Text(10)
 	case FORMAT_HEX:
-		return word.Text(16)
+		return "0x" + word.Text(16)
+	case FORMAT_BIN:
+		return "0b" + word.Text(2)
 	}
 	//
 	panic("invalid format")

--- a/pkg/zkc/util/formatted_text.go
+++ b/pkg/zkc/util/formatted_text.go
@@ -35,7 +35,7 @@ const (
 	FORMAT_DEC
 	// FORMAT_HEX indicates to format in hexadecimal
 	FORMAT_HEX
-	// FORMAT_BIN indicates to format in hexadecimal
+	// FORMAT_BIN indicates to format in binary
 	FORMAT_BIN
 )
 
@@ -58,7 +58,7 @@ func HexFormat() Format {
 	return Format{FORMAT_HEX}
 }
 
-// BinFormat constructs a new hexadecimal format.
+// BinFormat constructs a new binary format.
 func BinFormat() Format {
 	return Format{FORMAT_BIN}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes `printf`/debug output formatting semantics by adding `%b` and altering `%x` to include a `0x` prefix, which can break consumers or golden-output tests relying on prior string formats.
> 
> **Overview**
> Extends `printf` format parsing to support `%b` for binary output.
> 
> Updates formatted word rendering to add `0b`/`0x` prefixes for `%b` and `%x` respectively, changing the exact text produced by existing hex-formatted prints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c89334571e12a4ae218320b78b30be67012f64ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->