### PR TITLE
feat: report syntax errors in lsp mode

### DIFF
--- a/pkg/cmd/zkc/lsp.go
+++ b/pkg/cmd/zkc/lsp.go
@@ -126,7 +126,7 @@ func runLspConn(rwc io.ReadWriteCloser) {
 	ctx := context.Background()
 	stream := jsonrpc2.NewStream(rwc)
 	conn := jsonrpc2.NewConn(stream)
-	handler := protocol.ServerHandler(&zkcServer{}, jsonrpc2.MethodNotFoundHandler)
+	handler := protocol.ServerHandler(&zkcServer{conn: conn}, jsonrpc2.MethodNotFoundHandler)
 	conn.Go(ctx, handler)
 	<-conn.Done()
 }
@@ -135,6 +135,7 @@ func runLspConn(rwc io.ReadWriteCloser) {
 type zkcServer struct {
 	mu   sync.RWMutex
 	docs map[protocol.URI]string
+	conn jsonrpc2.Conn // retained so the server can push notifications to the client
 }
 
 // ============================================================================
@@ -223,14 +224,25 @@ func (s *zkcServer) LogTrace(_ context.Context, _ *protocol.LogTraceParams) erro
 // trace level negotiated during initialization and takes effect immediately.
 func (s *zkcServer) SetTrace(_ context.Context, _ *protocol.SetTraceParams) error { return nil }
 
+// publishDiagnostics compiles uri from text and pushes a
+// textDocument/publishDiagnostics notification to the client.
+func (s *zkcServer) publishDiagnostics(ctx context.Context, uri protocol.URI, text string) {
+	params := lsp.DiagnosticsFor(uri, text)
+	if err := s.conn.Notify(ctx, "textDocument/publishDiagnostics", params); err != nil {
+		log.Printf("zkc-lsp: publishDiagnostics notify error: %v", err)
+	}
+}
+
 // DidOpen handles a textDocument/didOpen notification. The client sends this
 // when a text document is opened in the editor, supplying the full document
 // content. From this point the server is responsible for maintaining an
 // up-to-date view of the document until the corresponding didClose is received.
-func (s *zkcServer) DidOpen(_ context.Context, params *protocol.DidOpenTextDocumentParams) error {
+func (s *zkcServer) DidOpen(ctx context.Context, params *protocol.DidOpenTextDocumentParams) error {
 	s.mu.Lock()
 	s.docs[params.TextDocument.URI] = params.TextDocument.Text
 	s.mu.Unlock()
+
+	s.publishDiagnostics(ctx, params.TextDocument.URI, params.TextDocument.Text)
 
 	return nil
 }
@@ -239,15 +251,19 @@ func (s *zkcServer) DidOpen(_ context.Context, params *protocol.DidOpenTextDocum
 // this whenever the content of an open document changes, providing either a
 // full replacement of the document text or an incremental list of edits,
 // depending on what was agreed during capability negotiation.
-func (s *zkcServer) DidChange(_ context.Context, params *protocol.DidChangeTextDocumentParams) error {
+func (s *zkcServer) DidChange(ctx context.Context, params *protocol.DidChangeTextDocumentParams) error {
 	if len(params.ContentChanges) == 0 {
 		return nil
 	}
 
-	s.mu.Lock()
 	// Use the last change; in full-sync mode this carries the entire updated text.
-	s.docs[params.TextDocument.URI] = params.ContentChanges[len(params.ContentChanges)-1].Text
+	text := params.ContentChanges[len(params.ContentChanges)-1].Text
+
+	s.mu.Lock()
+	s.docs[params.TextDocument.URI] = text
 	s.mu.Unlock()
+
+	s.publishDiagnostics(ctx, params.TextDocument.URI, text)
 
 	return nil
 }
@@ -256,10 +272,18 @@ func (s *zkcServer) DidChange(_ context.Context, params *protocol.DidChangeTextD
 // this when a previously-opened document is closed in the editor. After this
 // point the server should discard any in-memory state for the document; the
 // source of truth reverts to the file system.
-func (s *zkcServer) DidClose(_ context.Context, params *protocol.DidCloseTextDocumentParams) error {
+func (s *zkcServer) DidClose(ctx context.Context, params *protocol.DidCloseTextDocumentParams) error {
 	s.mu.Lock()
 	delete(s.docs, params.TextDocument.URI)
 	s.mu.Unlock()
+
+	// Clear any squiggles the editor is displaying for this document.
+	if err := s.conn.Notify(ctx, "textDocument/publishDiagnostics", &protocol.PublishDiagnosticsParams{
+		URI:         params.TextDocument.URI,
+		Diagnostics: []protocol.Diagnostic{},
+	}); err != nil {
+		log.Printf("zkc-lsp: clear diagnostics: %v", err)
+	}
 
 	return nil
 }

--- a/pkg/cmd/zkc/lsp/diagnostics.go
+++ b/pkg/cmd/zkc/lsp/diagnostics.go
@@ -1,0 +1,64 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package lsp
+
+import (
+	"github.com/consensys/go-corset/pkg/util/source"
+	"github.com/consensys/go-corset/pkg/zkc/compiler"
+	"go.lsp.dev/protocol"
+)
+
+// DiagnosticsFor parses the given document text and returns a
+// PublishDiagnosticsParams ready to send to the client as a
+// textDocument/publishDiagnostics notification.
+func DiagnosticsFor(uri protocol.URI, text string) *protocol.PublishDiagnosticsParams {
+	srcfile := source.NewSourceFile(uri.Filename(), []byte(text))
+	_, _, errs := compiler.Compile(*srcfile)
+
+	// compiler.Compile also processes included files from disk and may return
+	// errors for them.  Only report errors that belong to the current document.
+	diags := make([]protocol.Diagnostic, 0, len(errs))
+	for _, err := range errs {
+		if err.SourceFile().Filename() == srcfile.Filename() {
+			diags = append(diags, syntaxErrToDiagnostic(err))
+		}
+	}
+
+	return &protocol.PublishDiagnosticsParams{
+		URI:         uri,
+		Diagnostics: diags,
+	}
+}
+
+// syntaxErrToDiagnostic converts a source.SyntaxError into a protocol.Diagnostic.
+// The range is clipped to the first enclosing line, mirroring the behaviour of
+// printSyntaxError in pkg/cmd/zkc/util.go.
+func syntaxErrToDiagnostic(err source.SyntaxError) protocol.Diagnostic {
+	span := err.Span()
+	line := err.FirstEnclosingLine()
+	startCol := uint32(span.Start() - line.Start())
+	// Clip length to the current line so the range stays within bounds.
+	length := min(line.Length()-int(startCol), span.Length())
+	endCol := startCol + uint32(length)
+	lineNo := uint32(line.Number() - 1) // LSP uses 0-indexed line numbers
+
+	return protocol.Diagnostic{
+		Range: protocol.Range{
+			Start: protocol.Position{Line: lineNo, Character: startCol},
+			End:   protocol.Position{Line: lineNo, Character: endCol},
+		},
+		Severity: protocol.DiagnosticSeverityError,
+		Source:   "zkc",
+		Message:  err.Message(),
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces compilation on every open/change event and new client notifications, which could impact LSP performance or produce incorrect/overly noisy diagnostics if the compiler returns unexpected spans.
> 
> **Overview**
> Adds **real-time syntax diagnostics** to `zkc`’s LSP mode by compiling the current document text and sending `textDocument/publishDiagnostics` notifications.
> 
> The LSP server now retains the JSON-RPC connection to push diagnostics on `didOpen`/`didChange`, and clears diagnostics on `didClose`. A new `lsp.DiagnosticsFor` helper converts compiler syntax errors into LSP `Diagnostic` ranges (scoped to the current file, with line-bounded spans).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e1b25987184d4061fb257da9b5c5826ba26c591. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->