### PR TITLE
fix: parsing empty memory

### DIFF
--- a/pkg/test/zkc_invalid_test.go
+++ b/pkg/test/zkc_invalid_test.go
@@ -390,6 +390,10 @@ func Test_ZkcInvalid_Static_07(t *testing.T) {
 	checkZkcInvalid(t, "zkc/invalid/static_07")
 }
 
+func Test_ZkcInvalid_Static_08(t *testing.T) {
+	checkZkcInvalid(t, "zkc/invalid/static_08")
+}
+
 // ===================================================================
 // Call Tests
 // ===================================================================

--- a/pkg/zkc/compiler/parser/parser.go
+++ b/pkg/zkc/compiler/parser/parser.go
@@ -464,8 +464,13 @@ func (p *Parser) parseStaticInitialiser() ([]expr.Unresolved, []source.SyntaxErr
 		}
 	}
 	//
-	if _, errs = p.expect(RCURLY); len(errs) > 0 {
+	rcurlyTok, errs := p.expect(RCURLY)
+	if len(errs) > 0 {
 		return nil, errs
+	}
+	// A static memory must have at least one entry.
+	if len(contents) == 0 {
+		return nil, p.syntaxErrors(rcurlyTok, "empty static memory")
 	}
 	//
 	return contents, nil

--- a/testdata/zkc/invalid/static_08.zkc
+++ b/testdata/zkc/invalid/static_08.zkc
@@ -1,0 +1,6 @@
+//error:6:1-2:empty static memory
+
+const TEST:u16 = 0xffff
+
+static reftable(addr:u16) -> (r:u16) {
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, localized parsing validation change with a new regression test; low risk aside from potentially rejecting previously-accepted (but likely unintended) empty `static` declarations.
> 
> **Overview**
> The ZKC parser now treats an empty `static` memory initialiser (`static ... { }`) as a syntax error, emitting `empty static memory` after consuming the closing `}`.
> 
> Adds a new invalid fixture `static_08.zkc` and corresponding `Test_ZkcInvalid_Static_08` to ensure the compiler rejects empty static memories with the expected diagnostic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54c1ca69284f35db5c8f150757853dd3eb2141e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->