### PR TITLE
1656 feat flesh out lsp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,40 @@ zkc lsp
 
 Requires Neovim 0.9 or later (semantic token support was added in 0.9).
 
+#### Neovim 0.11+ (native LSP, no plugins required)
+
+Add the following to your Neovim configuration:
+
+**`~/.config/nvim/lua/autocmd.lua`** (or equivalent — anywhere that runs at startup):
+
+```lua
+vim.filetype.add({ extension = { zkc = 'zkc' } })
+```
+
+**`~/.config/nvim/lsp/zkc.lua`**:
+
+```lua
+return {
+  cmd = { 'zkc', 'lsp' },
+  filetypes = { 'zkc' },
+  root_markers = { '.git' },
+}
+```
+
+**`~/.config/nvim/lua/lsp.lua`** (or wherever you call `vim.lsp.enable`):
+
+```lua
+vim.lsp.enable({ 'zkc' })
+```
+
+To enable `gc`/`gcc` commenting, add **`~/.config/nvim/ftplugin/zkc.lua`**:
+
+```lua
+vim.bo.commentstring = '// %s'
+```
+
+#### Neovim 0.9+ (via nvim-lspconfig)
+
 Install [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) and add the
 following to your Neovim configuration (e.g. `~/.config/nvim/init.lua`):
 

--- a/pkg/cmd/zkc/lsp.go
+++ b/pkg/cmd/zkc/lsp.go
@@ -164,6 +164,8 @@ func (s *zkcServer) Initialize(
 				Legend: lsp.SemTokLegend,
 				Full:   true,
 			},
+			HoverProvider:          true,
+			DocumentSymbolProvider: true,
 		},
 		ServerInfo: &protocol.ServerInfo{Name: "zkc"},
 	}, nil
@@ -512,11 +514,18 @@ func (s *zkcServer) DocumentLinkResolve(
 // sends this to populate the editor's outline panel or breadcrumb bar. The
 // server returns a hierarchical or flat list of symbols (functions, types,
 // constants, etc.) present in the document, each with a name, kind, and range.
-// Not yet implemented.
 func (s *zkcServer) DocumentSymbol(
-	_ context.Context, _ *protocol.DocumentSymbolParams,
+	_ context.Context, params *protocol.DocumentSymbolParams,
 ) ([]interface{}, error) {
-	return nil, errNotImplemented
+	s.mu.RLock()
+	text, ok := s.docs[params.TextDocument.URI]
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil, nil
+	}
+
+	return lsp.DocumentSymbolsFor(params.TextDocument.URI, text)
 }
 
 // ExecuteCommand handles a workspace/executeCommand request. Servers
@@ -557,9 +566,16 @@ func (s *zkcServer) Formatting(
 // cursor rests on a token and requests contextual information to display in a
 // popup — typically the type signature of a symbol, its documentation comment,
 // or an evaluated value.
-// Not yet implemented.
-func (s *zkcServer) Hover(_ context.Context, _ *protocol.HoverParams) (*protocol.Hover, error) {
-	return nil, errNotImplemented
+func (s *zkcServer) Hover(_ context.Context, params *protocol.HoverParams) (*protocol.Hover, error) {
+	s.mu.RLock()
+	text, ok := s.docs[params.TextDocument.URI]
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil, nil
+	}
+
+	return lsp.HoverFor(params.TextDocument.URI, text, params.Position)
 }
 
 // Implementation handles a textDocument/implementation request. The client

--- a/pkg/cmd/zkc/lsp.go
+++ b/pkg/cmd/zkc/lsp.go
@@ -166,6 +166,10 @@ func (s *zkcServer) Initialize(
 			},
 			HoverProvider:          true,
 			DocumentSymbolProvider: true,
+			DefinitionProvider:     true,
+			SignatureHelpProvider: &protocol.SignatureHelpOptions{
+				TriggerCharacters: []string{"(", ","},
+			},
 		},
 		ServerInfo: &protocol.ServerInfo{Name: "zkc"},
 	}, nil
@@ -459,11 +463,18 @@ func (s *zkcServer) Declaration(
 // when the user invokes "go to definition" on a symbol. The server returns
 // the location (file and range) where the symbol is defined, allowing the
 // editor to navigate there.
-// Not yet implemented.
 func (s *zkcServer) Definition(
-	_ context.Context, _ *protocol.DefinitionParams,
+	_ context.Context, params *protocol.DefinitionParams,
 ) ([]protocol.Location, error) {
-	return nil, errNotImplemented
+	s.mu.RLock()
+	text, ok := s.docs[params.TextDocument.URI]
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil, nil
+	}
+
+	return lsp.DefinitionFor(params.TextDocument.URI, text, params.Position)
 }
 
 // DocumentColor handles a textDocument/documentColor request. The client
@@ -649,11 +660,18 @@ func (s *zkcServer) Rename(
 // sends this while the user is typing arguments inside a function call, to
 // display the callee's parameter list as a tooltip. The server returns the
 // matching overloads and identifies which parameter is active at the cursor.
-// Not yet implemented.
 func (s *zkcServer) SignatureHelp(
-	_ context.Context, _ *protocol.SignatureHelpParams,
+	_ context.Context, params *protocol.SignatureHelpParams,
 ) (*protocol.SignatureHelp, error) {
-	return nil, errNotImplemented
+	s.mu.RLock()
+	text, ok := s.docs[params.TextDocument.URI]
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil, nil
+	}
+
+	return lsp.SignatureHelpFor(params.TextDocument.URI, text, params.Position)
 }
 
 // Symbols handles a workspace/symbol request. The client sends this when the

--- a/pkg/cmd/zkc/lsp/definition.go
+++ b/pkg/cmd/zkc/lsp/definition.go
@@ -1,0 +1,63 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package lsp
+
+import (
+	"github.com/consensys/go-corset/pkg/util/source"
+	"github.com/consensys/go-corset/pkg/zkc/compiler"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/parser"
+	"go.lsp.dev/protocol"
+)
+
+// DefinitionFor compiles the given document and returns the source location of
+// the top-level declaration named by the identifier under the cursor at pos. It
+// returns nil when no definition is available (e.g. the cursor is on a keyword,
+// the name is not a top-level declaration, or the document cannot be compiled).
+func DefinitionFor(uri protocol.URI, text string, pos protocol.Position) ([]protocol.Location, error) {
+	srcfile := source.NewSourceFile(uri.Filename(), []byte(text))
+	program, srcmaps, _ := compiler.Compile(*srcfile)
+
+	// Convert LSP cursor position to a rune offset in the source file.
+	offset := posToOffset(*srcfile, pos)
+
+	// Lex the document to find the identifier token under the cursor.
+	tokens, _ := parser.Lex(*srcfile, false)
+
+	tok, ok := tokenAtOffset(tokens, offset)
+	if !ok || tok.Kind != parser.IDENTIFIER {
+		return nil, nil
+	}
+
+	// Extract the identifier text.
+	contents := srcfile.Contents()
+	name := string(contents[tok.Span.Start():tok.Span.End()])
+
+	// Search top-level declarations by name and return the first match.
+	for _, d := range program.Components() {
+		if d.Name() != name {
+			continue
+		}
+
+		defFile, span, found := srcmaps.Lookup(d)
+		if !found {
+			continue
+		}
+
+		rng := spanToRange(defFile, span)
+		defURI := protocol.URI("file://" + defFile.Filename())
+
+		return []protocol.Location{{URI: defURI, Range: rng}}, nil
+	}
+
+	return nil, nil
+}

--- a/pkg/cmd/zkc/lsp/definition.go
+++ b/pkg/cmd/zkc/lsp/definition.go
@@ -25,7 +25,7 @@ import (
 // the name is not a top-level declaration, or the document cannot be compiled).
 func DefinitionFor(uri protocol.URI, text string, pos protocol.Position) ([]protocol.Location, error) {
 	srcfile := source.NewSourceFile(uri.Filename(), []byte(text))
-	program, srcmaps, _ := compiler.Compile(*srcfile)
+	program, srcmaps := compiler.CompileBestEffort(*srcfile)
 
 	// Convert LSP cursor position to a rune offset in the source file.
 	offset := posToOffset(*srcfile, pos)

--- a/pkg/cmd/zkc/lsp/definition.go
+++ b/pkg/cmd/zkc/lsp/definition.go
@@ -17,6 +17,7 @@ import (
 	"github.com/consensys/go-corset/pkg/zkc/compiler"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/parser"
 	"go.lsp.dev/protocol"
+	lspuri "go.lsp.dev/uri"
 )
 
 // DefinitionFor compiles the given document and returns the source location of
@@ -54,7 +55,7 @@ func DefinitionFor(uri protocol.URI, text string, pos protocol.Position) ([]prot
 		}
 
 		rng := spanToRange(defFile, span)
-		defURI := protocol.URI("file://" + defFile.Filename())
+		defURI := lspuri.File(defFile.Filename())
 
 		return []protocol.Location{{URI: defURI, Range: rng}}, nil
 	}

--- a/pkg/cmd/zkc/lsp/docsym.go
+++ b/pkg/cmd/zkc/lsp/docsym.go
@@ -1,0 +1,160 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package lsp
+
+import (
+	"github.com/consensys/go-corset/pkg/util/source"
+	"github.com/consensys/go-corset/pkg/zkc/compiler"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/data"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/decl"
+	"go.lsp.dev/protocol"
+)
+
+// DocumentSymbolsFor compiles the given document and returns a
+// protocol.DocumentSymbol for each top-level declaration defined in this file.
+// Declarations from included files are filtered out.  If the document cannot
+// be compiled (e.g. due to parse errors), an empty slice is returned with no
+// error; diagnostics for those failures are already reported separately.
+func DocumentSymbolsFor(uri protocol.URI, text string) ([]interface{}, error) {
+	srcfile := source.NewSourceFile(uri.Filename(), []byte(text))
+	program, srcmaps, _ := compiler.Compile(*srcfile)
+
+	env := program.Environment()
+
+	var symbols []interface{}
+
+	for _, d := range program.Components() {
+		srcFile, span, ok := srcmaps.Lookup(d)
+		if !ok || srcFile.Filename() != srcfile.Filename() {
+			continue
+		}
+
+		rng := spanToRange(*srcfile, span)
+
+		symbols = append(symbols, protocol.DocumentSymbol{
+			Name:           d.Name(),
+			Detail:         declDetail(d, env),
+			Kind:           declSymbolKind(d),
+			Range:          rng,
+			SelectionRange: rng,
+		})
+	}
+
+	return symbols, nil
+}
+
+// declSymbolKind maps a ZkC declaration to the closest LSP SymbolKind.
+func declSymbolKind(d decl.Resolved) protocol.SymbolKind {
+	switch d.(type) {
+	case *decl.ResolvedFunction:
+		return protocol.SymbolKindFunction
+	case *decl.ResolvedConstant:
+		return protocol.SymbolKindConstant
+	case *decl.ResolvedMemory:
+		return protocol.SymbolKindVariable
+	case *decl.ResolvedTypeAlias:
+		return protocol.SymbolKindTypeParameter
+	default:
+		return protocol.SymbolKindNull
+	}
+}
+
+// declDetail returns a short, single-line description of the declaration shown
+// beside the name in the editor outline (the Detail field of DocumentSymbol).
+func declDetail(d decl.Resolved, env data.ResolvedEnvironment) string {
+	switch d := d.(type) {
+	case *decl.ResolvedFunction:
+		return funcDetail(d, env)
+	case *decl.ResolvedConstant:
+		return ": " + d.DataType.String(env)
+	case *decl.ResolvedMemory:
+		return memDetail(d, env)
+	case *decl.ResolvedTypeAlias:
+		return "= " + d.DataType.String(env)
+	default:
+		return ""
+	}
+}
+
+// funcDetail builds the compact parameter/return summary shown in the outline
+// for a function, e.g. "(x: u16, y: u32) -> (r: u16)".
+func funcDetail(fn *decl.ResolvedFunction, env data.ResolvedEnvironment) string {
+	s := "("
+
+	for i, v := range fn.Inputs() {
+		if i > 0 {
+			s += ", "
+		}
+
+		s += v.Name + ": " + v.DataType.String(env)
+	}
+
+	s += ")"
+
+	if outs := fn.Outputs(); len(outs) > 0 {
+		s += " -> ("
+
+		for i, v := range outs {
+			if i > 0 {
+				s += ", "
+			}
+
+			s += v.Name + ": " + v.DataType.String(env)
+		}
+
+		s += ")"
+	}
+
+	return s
+}
+
+// memDetail builds the compact signature shown in the outline for a memory
+// declaration, e.g. "input (addr: u16) -> (data: u32)".
+func memDetail(m *decl.ResolvedMemory, env data.ResolvedEnvironment) string {
+	var kind string
+
+	switch m.Kind {
+	case decl.PUBLIC_READ_ONLY_MEMORY, decl.PRIVATE_READ_ONLY_MEMORY:
+		kind = "input"
+	case decl.PUBLIC_WRITE_ONCE_MEMORY, decl.PRIVATE_WRITE_ONCE_MEMORY:
+		kind = "output"
+	case decl.PUBLIC_STATIC_MEMORY, decl.PRIVATE_STATIC_MEMORY:
+		kind = "static"
+	case decl.RANDOM_ACCESS_MEMORY:
+		kind = "memory"
+	}
+
+	s := kind + " ("
+
+	for i, v := range m.Address {
+		if i > 0 {
+			s += ", "
+		}
+
+		s += v.Name + ": " + v.DataType.String(env)
+	}
+
+	s += ") -> ("
+
+	for i, v := range m.Data {
+		if i > 0 {
+			s += ", "
+		}
+
+		s += v.Name + ": " + v.DataType.String(env)
+	}
+
+	s += ")"
+
+	return s
+}

--- a/pkg/cmd/zkc/lsp/docsym.go
+++ b/pkg/cmd/zkc/lsp/docsym.go
@@ -27,7 +27,7 @@ import (
 // error; diagnostics for those failures are already reported separately.
 func DocumentSymbolsFor(uri protocol.URI, text string) ([]interface{}, error) {
 	srcfile := source.NewSourceFile(uri.Filename(), []byte(text))
-	program, srcmaps, _ := compiler.Compile(*srcfile)
+	program, srcmaps := compiler.CompileBestEffort(*srcfile)
 
 	env := program.Environment()
 

--- a/pkg/cmd/zkc/lsp/hover.go
+++ b/pkg/cmd/zkc/lsp/hover.go
@@ -48,7 +48,13 @@ func HoverFor(uri protocol.URI, text string, pos protocol.Position) (*protocol.H
 
 	env := program.Environment()
 
-	// 1. Search top-level declarations first.
+	// 1. Local variables take precedence: a local shadows any top-level
+	//    declaration with the same name.
+	if h := hoverLocalVariable(name, offset, &program, srcmaps, *srcfile, env); h != nil {
+		return h, nil
+	}
+
+	// 2. Fall back to top-level declarations.
 	for _, d := range program.Components() {
 		if d.Name() != name {
 			continue
@@ -72,8 +78,7 @@ func HoverFor(uri protocol.URI, text string, pos protocol.Position) (*protocol.H
 		}, nil
 	}
 
-	// 2. Search local variables inside the enclosing function.
-	return hoverLocalVariable(name, offset, &program, srcmaps, *srcfile, env), nil
+	return nil, nil
 }
 
 // hoverLocalVariable searches for a local variable named name inside the

--- a/pkg/cmd/zkc/lsp/hover.go
+++ b/pkg/cmd/zkc/lsp/hover.go
@@ -1,0 +1,247 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package lsp
+
+import (
+	"strings"
+
+	"github.com/consensys/go-corset/pkg/util/source"
+	"github.com/consensys/go-corset/pkg/zkc/compiler"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/data"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/decl"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/parser"
+	"go.lsp.dev/protocol"
+)
+
+// HoverFor compiles the given document and returns hover information for the
+// symbol under the cursor at pos.  It returns nil when no hover content is
+// available (e.g. the cursor is on punctuation or the document cannot be
+// compiled).
+func HoverFor(uri protocol.URI, text string, pos protocol.Position) (*protocol.Hover, error) {
+	srcfile := source.NewSourceFile(uri.Filename(), []byte(text))
+	program, srcmaps, _ := compiler.Compile(*srcfile)
+
+	// Convert LSP cursor position to a rune offset in the source file.
+	offset := posToOffset(*srcfile, pos)
+
+	// Lex the document to find the identifier token under the cursor.
+	tokens, _ := parser.Lex(*srcfile, false)
+
+	tok, ok := tokenAtOffset(tokens, offset)
+	if !ok || tok.Kind != parser.IDENTIFIER {
+		return nil, nil
+	}
+
+	// Extract the identifier text.
+	contents := srcfile.Contents()
+	name := string(contents[tok.Span.Start():tok.Span.End()])
+
+	env := program.Environment()
+
+	// 1. Search top-level declarations first.
+	for _, d := range program.Components() {
+		if d.Name() != name {
+			continue
+		}
+
+		return &protocol.Hover{
+			Contents: protocol.MarkupContent{
+				Kind:  protocol.Markdown,
+				Value: formatDeclaration(d, env),
+			},
+		}, nil
+	}
+
+	// 2. Search local variables inside the enclosing function.
+	return hoverLocalVariable(name, offset, &program, srcmaps, *srcfile, env), nil
+}
+
+// hoverLocalVariable searches for a local variable named name inside the
+// function whose span in srcfile contains offset. Returns a Hover with the
+// variable's type, or nil if no match is found.
+func hoverLocalVariable(
+	name string,
+	offset int,
+	program interface{ Components() []decl.Resolved },
+	srcmaps source.Maps[any],
+	srcfile source.File,
+	env data.ResolvedEnvironment,
+) *protocol.Hover {
+	for _, d := range program.Components() {
+		fn, ok := d.(*decl.ResolvedFunction)
+		if !ok {
+			continue
+		}
+
+		// Check whether the cursor falls within this function's span.
+		srcFile, span, found := srcmaps.Lookup(d)
+		if !found || srcFile.Filename() != srcfile.Filename() {
+			continue
+		}
+
+		if offset < span.Start() || offset >= span.End() {
+			continue
+		}
+
+		// Cursor is inside this function — search its variables.
+		for _, v := range fn.Variables {
+			if v.Name == name {
+				return &protocol.Hover{
+					Contents: protocol.MarkupContent{
+						Kind:  protocol.Markdown,
+						Value: "```zkc\n" + name + ": " + v.DataType.String(env) + "\n```",
+					},
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// formatDeclaration formats a top-level declaration as a markdown code block
+// suitable for display in a hover popup.
+func formatDeclaration(d decl.Resolved, env data.ResolvedEnvironment) string {
+	var sig string
+
+	switch d := d.(type) {
+	case *decl.ResolvedFunction:
+		sig = formatFunctionDecl(d, env)
+	case *decl.ResolvedConstant:
+		sig = "const " + d.Name() + ": " + d.DataType.String(env)
+	case *decl.ResolvedMemory:
+		sig = formatMemoryDecl(d, env)
+	case *decl.ResolvedTypeAlias:
+		sig = "type " + d.Name() + " = " + d.DataType.String(env)
+	default:
+		sig = d.Name()
+	}
+
+	return "```zkc\n" + sig + "\n```"
+}
+
+// formatFunctionDecl formats a function declaration as a single-line
+// signature, e.g. "fn f<mem>(x: u16, y: u32) -> (r: u16)".
+func formatFunctionDecl(fn *decl.ResolvedFunction, env data.ResolvedEnvironment) string {
+	var sb strings.Builder
+
+	sb.WriteString("fn ")
+	sb.WriteString(fn.Name())
+
+	// Memory effects, e.g. <ram, rom>
+	if len(fn.Effects) > 0 {
+		sb.WriteString("<")
+
+		for i, e := range fn.Effects {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+
+			sb.WriteString(e.Name)
+		}
+
+		sb.WriteString(">")
+	}
+
+	// Parameters
+	sb.WriteString("(")
+
+	for i, v := range fn.Inputs() {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+
+		sb.WriteString(v.Name)
+		sb.WriteString(": ")
+		sb.WriteString(v.DataType.String(env))
+	}
+
+	sb.WriteString(")")
+
+	// Return values
+	if outs := fn.Outputs(); len(outs) > 0 {
+		sb.WriteString(" -> (")
+
+		for i, v := range outs {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+
+			sb.WriteString(v.Name)
+			sb.WriteString(": ")
+			sb.WriteString(v.DataType.String(env))
+		}
+
+		sb.WriteString(")")
+	}
+
+	return sb.String()
+}
+
+// formatMemoryDecl formats a memory declaration as a single-line signature,
+// e.g. "pub input rom(addr: u16) -> (data: u32)".
+func formatMemoryDecl(m *decl.ResolvedMemory, env data.ResolvedEnvironment) string {
+	var sb strings.Builder
+
+	// Public visibility prefix
+	switch m.Kind {
+	case decl.PUBLIC_READ_ONLY_MEMORY, decl.PUBLIC_WRITE_ONCE_MEMORY, decl.PUBLIC_STATIC_MEMORY:
+		sb.WriteString("pub ")
+	}
+
+	// Memory kind keyword
+	switch m.Kind {
+	case decl.PUBLIC_READ_ONLY_MEMORY, decl.PRIVATE_READ_ONLY_MEMORY:
+		sb.WriteString("input ")
+	case decl.PUBLIC_WRITE_ONCE_MEMORY, decl.PRIVATE_WRITE_ONCE_MEMORY:
+		sb.WriteString("output ")
+	case decl.PUBLIC_STATIC_MEMORY, decl.PRIVATE_STATIC_MEMORY:
+		sb.WriteString("static ")
+	case decl.RANDOM_ACCESS_MEMORY:
+		sb.WriteString("memory ")
+	}
+
+	sb.WriteString(m.Name())
+
+	// Address bus
+	sb.WriteString("(")
+
+	for i, v := range m.Address {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+
+		sb.WriteString(v.Name)
+		sb.WriteString(": ")
+		sb.WriteString(v.DataType.String(env))
+	}
+
+	sb.WriteString(")")
+
+	// Data bus
+	sb.WriteString(" -> (")
+
+	for i, v := range m.Data {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+
+		sb.WriteString(v.Name)
+		sb.WriteString(": ")
+		sb.WriteString(v.DataType.String(env))
+	}
+
+	sb.WriteString(")")
+
+	return sb.String()
+}

--- a/pkg/cmd/zkc/lsp/hover.go
+++ b/pkg/cmd/zkc/lsp/hover.go
@@ -29,7 +29,7 @@ import (
 // compiled).
 func HoverFor(uri protocol.URI, text string, pos protocol.Position) (*protocol.Hover, error) {
 	srcfile := source.NewSourceFile(uri.Filename(), []byte(text))
-	program, srcmaps, _ := compiler.Compile(*srcfile)
+	program, srcmaps := compiler.CompileBestEffort(*srcfile)
 
 	// Convert LSP cursor position to a rune offset in the source file.
 	offset := posToOffset(*srcfile, pos)

--- a/pkg/cmd/zkc/lsp/hover.go
+++ b/pkg/cmd/zkc/lsp/hover.go
@@ -54,10 +54,20 @@ func HoverFor(uri protocol.URI, text string, pos protocol.Position) (*protocol.H
 			continue
 		}
 
+		sig := formatDeclaration(d, env)
+		hover := sig
+
+		// Prepend any // doc-comment lines immediately preceding the declaration.
+		if declFile, span, found := srcmaps.Lookup(d); found {
+			if doc := extractPrecedingComments(declFile, span.Start()); doc != "" {
+				hover = doc + "\n\n---\n\n" + sig
+			}
+		}
+
 		return &protocol.Hover{
 			Contents: protocol.MarkupContent{
 				Kind:  protocol.Markdown,
-				Value: formatDeclaration(d, env),
+				Value: hover,
 			},
 		}, nil
 	}
@@ -186,6 +196,63 @@ func formatFunctionDecl(fn *decl.ResolvedFunction, env data.ResolvedEnvironment)
 	}
 
 	return sb.String()
+}
+
+// extractPrecedingComments walks backward from spanStart in srcFile and returns
+// any // comment lines directly preceding that position (no blank line between
+// the comments and the span). Lines are returned joined by "\n" with the "//"
+// prefix and optional following space stripped. Returns "" when none are found.
+func extractPrecedingComments(srcFile source.File, spanStart int) string {
+	contents := srcFile.Contents()
+
+	// Find the start of the line that contains spanStart.
+	lineStart := spanStart
+	for lineStart > 0 && contents[lineStart-1] != '\n' {
+		lineStart--
+	}
+
+	// Walk backward one line at a time from just before lineStart.
+	var commentLines []string
+
+	pos := lineStart // points just after the '\n' ending the previous line
+
+	for pos > 0 {
+		// pos-1 is the '\n' that terminates the previous line.
+		end := pos - 1 // the '\n' character itself — not part of line content
+
+		// Find where that line starts.
+		start := end
+		for start > 0 && contents[start-1] != '\n' {
+			start--
+		}
+
+		line := strings.TrimSpace(string(contents[start:end]))
+
+		if line == "" {
+			// Blank line — stop collecting.
+			break
+		}
+
+		if !strings.HasPrefix(line, "//") {
+			break
+		}
+
+		text := strings.TrimPrefix(line, "//")
+		text = strings.TrimPrefix(text, " ")
+		commentLines = append(commentLines, text)
+		pos = start
+	}
+
+	if len(commentLines) == 0 {
+		return ""
+	}
+
+	// We collected lines newest-first; reverse to chronological order.
+	for i, j := 0, len(commentLines)-1; i < j; i, j = i+1, j-1 {
+		commentLines[i], commentLines[j] = commentLines[j], commentLines[i]
+	}
+
+	return strings.Join(commentLines, "\n")
 }
 
 // formatMemoryDecl formats a memory declaration as a single-line signature,

--- a/pkg/cmd/zkc/lsp/semtok.go
+++ b/pkg/cmd/zkc/lsp/semtok.go
@@ -95,6 +95,8 @@ func semTokType(kind uint) (uint32, bool) {
 // A small state machine tracks the previous non-comment token kind so that
 // identifiers in type-annotation position (after ':' or 'as') are classified
 // as type tokens, and function-name identifiers (after 'fn') as function tokens.
+// Lookahead is also used: an identifier immediately followed by '(' is a call
+// site and is classified as a function token.
 func encodeTokens(srcfile source.File, tokens []lex.Token) []uint32 {
 	data := make([]uint32, 0, len(tokens)*5)
 
@@ -103,18 +105,27 @@ func encodeTokens(srcfile source.File, tokens []lex.Token) []uint32 {
 	// Initialised to END_OF (0) which matches no special case.
 	prevMeaningfulKind := parser.END_OF
 
-	for _, tok := range tokens {
+	for i, tok := range tokens {
 		var (
 			tokType uint32
 			ok      bool
 		)
 
 		if tok.Kind == parser.IDENTIFIER {
-			switch prevMeaningfulKind {
-			case parser.COLON, parser.KEYWORD_AS:
-				tokType, ok = 5, true // type
-			case parser.KEYWORD_FN:
-				tokType, ok = 6, true // function
+			// Look ahead past any intervening comment to the next meaningful token.
+			nextKind := parser.END_OF
+			for j := i + 1; j < len(tokens); j++ {
+				if tokens[j].Kind != parser.COMMENT {
+					nextKind = tokens[j].Kind
+					break
+				}
+			}
+
+			switch {
+			case prevMeaningfulKind == parser.COLON || prevMeaningfulKind == parser.KEYWORD_AS:
+				tokType, ok = 5, true // type annotation
+			case prevMeaningfulKind == parser.KEYWORD_FN || nextKind == parser.LBRACE:
+				tokType, ok = 6, true // function declaration name or call site
 			default:
 				tokType, ok = 7, true // variable
 			}

--- a/pkg/cmd/zkc/lsp/semtok.go
+++ b/pkg/cmd/zkc/lsp/semtok.go
@@ -42,10 +42,23 @@ var SemTokLegend = protocol.SemanticTokensLegend{
 	TokenModifiers: []protocol.SemanticTokenModifiers{},
 }
 
-// SemTokType maps a ZkC lexer token kind to an index into semTokLegend.TokenTypes.
+// Named indices into SemTokLegend.TokenTypes. The order here must mirror the
+// legend exactly; the iota ensures the values stay in step if entries are added.
+const (
+	semTokKeyword  uint32 = iota // protocol.SemanticTokenKeyword
+	semTokComment                // protocol.SemanticTokenComment
+	semTokString                 // protocol.SemanticTokenString
+	semTokNumber                 // protocol.SemanticTokenNumber
+	semTokOperator               // protocol.SemanticTokenOperator
+	semTokType                   // protocol.SemanticTokenType
+	semTokFunction               // protocol.SemanticTokenFunction
+	semTokVariable               // protocol.SemanticTokenVariable
+)
+
+// semTokForKind maps a ZkC lexer token kind to an index into SemTokLegend.TokenTypes.
 // The second return value is false for tokens that should not be emitted
 // (punctuation, whitespace, EOF).
-func semTokType(kind uint) (uint32, bool) {
+func semTokForKind(kind uint) (uint32, bool) {
 	switch kind {
 	// Keywords
 	case parser.KEYWORD_AS, parser.KEYWORD_BREAK, parser.KEYWORD_CONST,
@@ -55,16 +68,16 @@ func semTokType(kind uint) (uint32, bool) {
 		parser.KEYWORD_OUTPUT, parser.KEYWORD_PRINTF, parser.KEYWORD_PUB,
 		parser.KEYWORD_RETURN, parser.KEYWORD_STATIC, parser.KEYWORD_TYPE,
 		parser.KEYWORD_VAR, parser.KEYWORD_WHILE:
-		return 0, true
+		return semTokKeyword, true
 	// Comments
 	case parser.COMMENT:
-		return 1, true
+		return semTokComment, true
 	// String literals
 	case parser.STRING:
-		return 2, true
+		return semTokString, true
 	// Numeric literals
 	case parser.NUMBER:
-		return 3, true
+		return semTokNumber, true
 	// Operators and punctuation-like tokens that carry meaning
 	case parser.ADD, parser.SUB, parser.MUL, parser.DIV, parser.REM,
 		parser.EQUALS, parser.EQUALS_EQUALS, parser.NOT_EQUALS,
@@ -74,10 +87,10 @@ func semTokType(kind uint) (uint32, bool) {
 		parser.BITWISE_AND, parser.BITWISE_OR, parser.BITWISE_XOR,
 		parser.BITWISE_NOT, parser.BITWISE_SHL, parser.BITWISE_SHR,
 		parser.RIGHTARROW, parser.QMARK:
-		return 4, true
+		return semTokOperator, true
 	// Identifiers — emitted as 'variable'; future work can refine via AST
 	case parser.IDENTIFIER:
-		return 7, true
+		return semTokVariable, true
 	// Punctuation (braces, colon, comma, semicolon) and EOF: skip
 	default:
 		return 0, false
@@ -123,14 +136,14 @@ func encodeTokens(srcfile source.File, tokens []lex.Token) []uint32 {
 
 			switch {
 			case prevMeaningfulKind == parser.COLON || prevMeaningfulKind == parser.KEYWORD_AS:
-				tokType, ok = 5, true // type annotation
+				tokType, ok = semTokType, true // type annotation
 			case prevMeaningfulKind == parser.KEYWORD_FN || nextKind == parser.LBRACE:
-				tokType, ok = 6, true // function declaration name or call site
+				tokType, ok = semTokFunction, true // function declaration name or call site
 			default:
-				tokType, ok = 7, true // variable
+				tokType, ok = semTokVariable, true // variable
 			}
 		} else {
-			tokType, ok = semTokType(tok.Kind)
+			tokType, ok = semTokForKind(tok.Kind)
 		}
 
 		// Update state for all non-comment tokens so that a comment between

--- a/pkg/cmd/zkc/lsp/semtok.go
+++ b/pkg/cmd/zkc/lsp/semtok.go
@@ -91,13 +91,43 @@ func semTokType(kind uint) (uint32, bool) {
 //
 // Positions are relative to the previous token (or the start of the file for
 // the first token). tokenModifiers is always 0 for now.
+//
+// A small state machine tracks the previous non-comment token kind so that
+// identifiers in type-annotation position (after ':' or 'as') are classified
+// as type tokens, and function-name identifiers (after 'fn') as function tokens.
 func encodeTokens(srcfile source.File, tokens []lex.Token) []uint32 {
 	data := make([]uint32, 0, len(tokens)*5)
 
 	var prevLine, prevChar uint32
+	// prevMeaningfulKind tracks the kind of the last non-comment token seen.
+	// Initialised to END_OF (0) which matches no special case.
+	prevMeaningfulKind := parser.END_OF
 
 	for _, tok := range tokens {
-		tokType, ok := semTokType(tok.Kind)
+		var (
+			tokType uint32
+			ok      bool
+		)
+
+		if tok.Kind == parser.IDENTIFIER {
+			switch prevMeaningfulKind {
+			case parser.COLON, parser.KEYWORD_AS:
+				tokType, ok = 5, true // type
+			case parser.KEYWORD_FN:
+				tokType, ok = 6, true // function
+			default:
+				tokType, ok = 7, true // variable
+			}
+		} else {
+			tokType, ok = semTokType(tok.Kind)
+		}
+
+		// Update state for all non-comment tokens so that a comment between
+		// ':' and a type name does not reset the type-position detection.
+		if tok.Kind != parser.COMMENT {
+			prevMeaningfulKind = tok.Kind
+		}
+
 		if !ok {
 			continue
 		}

--- a/pkg/cmd/zkc/lsp/semtok.go
+++ b/pkg/cmd/zkc/lsp/semtok.go
@@ -127,6 +127,7 @@ func encodeTokens(srcfile source.File, tokens []lex.Token) []uint32 {
 		if tok.Kind == parser.IDENTIFIER {
 			// Look ahead past any intervening comment to the next meaningful token.
 			nextKind := parser.END_OF
+
 			for j := i + 1; j < len(tokens); j++ {
 				if tokens[j].Kind != parser.COMMENT {
 					nextKind = tokens[j].Kind

--- a/pkg/cmd/zkc/lsp/sighelp.go
+++ b/pkg/cmd/zkc/lsp/sighelp.go
@@ -27,7 +27,7 @@ import (
 // inside a function-call argument list or the callee cannot be resolved.
 func SignatureHelpFor(uri protocol.URI, text string, pos protocol.Position) (*protocol.SignatureHelp, error) {
 	srcfile := source.NewSourceFile(uri.Filename(), []byte(text))
-	program, _, _ := compiler.Compile(*srcfile)
+	program, _ := compiler.CompileBestEffort(*srcfile)
 
 	// Convert LSP cursor position to a rune offset in the source file.
 	offset := posToOffset(*srcfile, pos)

--- a/pkg/cmd/zkc/lsp/sighelp.go
+++ b/pkg/cmd/zkc/lsp/sighelp.go
@@ -1,0 +1,144 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package lsp
+
+import (
+	"github.com/consensys/go-corset/pkg/util/source"
+	"github.com/consensys/go-corset/pkg/util/source/lex"
+	"github.com/consensys/go-corset/pkg/zkc/compiler"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/data"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/decl"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/parser"
+	"go.lsp.dev/protocol"
+)
+
+// SignatureHelpFor compiles the given document and returns signature help for
+// the function call the cursor is inside. It returns nil when the cursor is not
+// inside a function-call argument list or the callee cannot be resolved.
+func SignatureHelpFor(uri protocol.URI, text string, pos protocol.Position) (*protocol.SignatureHelp, error) {
+	srcfile := source.NewSourceFile(uri.Filename(), []byte(text))
+	program, _, _ := compiler.Compile(*srcfile)
+
+	// Convert LSP cursor position to a rune offset in the source file.
+	offset := posToOffset(*srcfile, pos)
+
+	// Lex the document (keep comments so whitespace-stripping doesn't shift
+	// token positions, but we drop them in the backward scan below anyway).
+	tokens, _ := parser.Lex(*srcfile, false)
+
+	// Find the enclosing function call and active parameter index.
+	contents := srcfile.Contents()
+
+	fnName, activeParam, ok := findCallContext(tokens, contents, offset)
+	if !ok {
+		return nil, nil
+	}
+
+	env := program.Environment()
+
+	// Search for the function declaration with that name.
+	for _, d := range program.Components() {
+		fn, isFn := d.(*decl.ResolvedFunction)
+		if !isFn || fn.Name() != fnName {
+			continue
+		}
+
+		sig := buildSignatureInfo(fn, env)
+
+		return &protocol.SignatureHelp{
+			Signatures:      []protocol.SignatureInformation{sig},
+			ActiveSignature: 0,
+			ActiveParameter: activeParam,
+		}, nil
+	}
+
+	return nil, nil
+}
+
+// findCallContext walks the token list backward from offset to find the name of
+// the function call enclosing the cursor and the 0-based index of the argument
+// position the cursor is in (counted by commas). Returns ok=false when the
+// cursor is not inside a function-call argument list.
+//
+// The scan counts all grouping tokens — `(`, `)`, `[`, `]` — for depth
+// tracking. A comma at depth 0 means we advance the active-parameter counter.
+// When an unmatched `(` is found at depth 0 and the preceding token is an
+// identifier, that identifier is the callee. An unmatched `[` at depth 0
+// means the cursor is inside a memory subscript, so no signature help applies.
+func findCallContext(tokens []lex.Token, contents []rune, offset int) (name string, activeParam uint32, ok bool) {
+	depth := 0
+	commas := 0
+
+	for i := len(tokens) - 1; i >= 0; i-- {
+		tok := tokens[i]
+
+		// Only consider tokens that end before (or at) the cursor.
+		if tok.Span.Start() >= offset {
+			continue
+		}
+
+		switch tok.Kind {
+		case parser.RBRACE, parser.RSQUARE:
+			depth++
+
+		case parser.LSQUARE:
+			if depth <= 0 {
+				// Cursor is directly inside a memory subscript — no sig help.
+				return "", 0, false
+			}
+			//
+			depth--
+
+		case parser.LBRACE:
+			if depth <= 0 {
+				// Found the opening `(` of the enclosing call.
+				// The token immediately before it must be an identifier.
+				if i > 0 && tokens[i-1].Kind == parser.IDENTIFIER {
+					t := tokens[i-1]
+					name = string(contents[t.Span.Start():t.Span.End()])
+
+					return name, uint32(commas), true
+				}
+				// Cursor is inside a bare parenthesised expression, not a call.
+				return "", 0, false
+			}
+			//
+			depth--
+		case parser.COMMA:
+			if depth == 0 {
+				commas++
+			}
+		}
+	}
+
+	return "", 0, false
+}
+
+// buildSignatureInfo constructs the LSP SignatureInformation for the given
+// function. The label is the full function signature; each input parameter
+// contributes a ParameterInformation whose label is a substring of that label.
+func buildSignatureInfo(fn *decl.ResolvedFunction, env data.ResolvedEnvironment) protocol.SignatureInformation {
+	label := formatFunctionDecl(fn, env)
+
+	params := make([]protocol.ParameterInformation, 0, len(fn.Inputs()))
+	for _, v := range fn.Inputs() {
+		params = append(params, protocol.ParameterInformation{
+			Label: v.Name + ": " + v.DataType.String(env),
+		})
+	}
+
+	return protocol.SignatureInformation{
+		Label:      label,
+		Parameters: params,
+	}
+}

--- a/pkg/cmd/zkc/lsp/sighelp.go
+++ b/pkg/cmd/zkc/lsp/sighelp.go
@@ -32,8 +32,8 @@ func SignatureHelpFor(uri protocol.URI, text string, pos protocol.Position) (*pr
 	// Convert LSP cursor position to a rune offset in the source file.
 	offset := posToOffset(*srcfile, pos)
 
-	// Lex the document (keep comments so whitespace-stripping doesn't shift
-	// token positions, but we drop them in the backward scan below anyway).
+	// Lex the document without comments; the backward scan only needs the
+	// structural tokens, and token spans already refer to original source offsets.
 	tokens, _ := parser.Lex(*srcfile, false)
 
 	// Find the enclosing function call and active parameter index.

--- a/pkg/cmd/zkc/lsp/util.go
+++ b/pkg/cmd/zkc/lsp/util.go
@@ -1,0 +1,74 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package lsp
+
+import (
+	"github.com/consensys/go-corset/pkg/util/source"
+	"github.com/consensys/go-corset/pkg/util/source/lex"
+	"go.lsp.dev/protocol"
+)
+
+// spanToRange converts a source.Span to a protocol.Range for the given file.
+// Both start and end positions are computed by finding the enclosing line for
+// each boundary, then computing the character offset within that line.
+func spanToRange(srcfile source.File, span source.Span) protocol.Range {
+	startLine := srcfile.FindFirstEnclosingLine(span)
+	startLspLine := uint32(startLine.Number() - 1)
+	startLspChar := uint32(span.Start() - startLine.Start())
+
+	var endLspLine, endLspChar uint32
+
+	if span.End() > span.Start() {
+		// Find the line that contains the last character of the span.
+		endSpan := source.NewSpan(span.End()-1, span.End())
+		endLine := srcfile.FindFirstEnclosingLine(endSpan)
+		endLspLine = uint32(endLine.Number() - 1)
+		endLspChar = uint32(span.End() - endLine.Start())
+	} else {
+		// Empty span: end == start.
+		endLspLine = startLspLine
+		endLspChar = startLspChar
+	}
+
+	return protocol.Range{
+		Start: protocol.Position{Line: startLspLine, Character: startLspChar},
+		End:   protocol.Position{Line: endLspLine, Character: endLspChar},
+	}
+}
+
+// posToOffset converts an LSP Position (0-indexed line and character) to a
+// rune offset within the source file.  If the line number exceeds the number
+// of lines in the file, the offset of the end of the file is returned.
+func posToOffset(srcfile source.File, pos protocol.Position) int {
+	lines := srcfile.Lines()
+	lineIdx := int(pos.Line)
+
+	if lineIdx >= len(lines) {
+		return len(srcfile.Contents())
+	}
+
+	return lines[lineIdx].Start() + int(pos.Character)
+}
+
+// tokenAtOffset finds the token whose span contains the given rune offset,
+// returning it and true.  If no token spans that offset, a zero Token and
+// false are returned.
+func tokenAtOffset(tokens []lex.Token, offset int) (lex.Token, bool) {
+	for _, tok := range tokens {
+		if tok.Span.Start() <= offset && offset < tok.Span.End() {
+			return tok, true
+		}
+	}
+
+	return lex.Token{}, false
+}

--- a/pkg/util/source/source_map.go
+++ b/pkg/util/source/source_map.go
@@ -78,6 +78,19 @@ func (p *Maps[T]) Has(node T) bool {
 	return false
 }
 
+// Lookup returns the source file and span for a given node. If the node is
+// found in any of the contained source maps, it returns the corresponding File
+// and Span with ok=true; otherwise it returns zero values with ok=false.
+func (p *Maps[T]) Lookup(node T) (File, Span, bool) {
+	for i := range p.maps {
+		if p.maps[i].Has(node) {
+			return p.maps[i].Source(), p.maps[i].Get(node), true
+		}
+	}
+	//
+	return File{}, Span{}, false
+}
+
 // SyntaxError constructs a syntax error for a given node contained within one
 // of the source files managed by this set of source maps.
 //

--- a/pkg/zkc/compiler/compiler.go
+++ b/pkg/zkc/compiler/compiler.go
@@ -14,6 +14,7 @@ package compiler
 
 import (
 	"path/filepath"
+	"strings"
 
 	"github.com/consensys/go-corset/pkg/util/source"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast"
@@ -84,20 +85,97 @@ func readIncludedFiles(file source.File, item parser.UnlinkedSourceFile,
 	)
 	//
 	for _, include := range item.Includes {
-		filename := filepath.Join(dir, *include)
-		// Check filename not already parsed
-		if seen, ok := visited[filename]; seen && ok {
-			// file already loaded, therefore ignore.
-		} else if fs, err := source.ReadFiles(filename); err == nil {
-			files = append(files, fs...)
+		if strings.ContainsAny(*include, "*?[") {
+			// Glob pattern: expand to matching files.
+			pattern := filepath.Join(dir, *include)
+
+			matches, err := filepath.Glob(pattern)
+			if err != nil {
+				errors = append(errors, *item.SourceMap.SyntaxError(include, err.Error()))
+				continue
+			}
+
+			if len(matches) == 0 {
+				errors = append(errors, *item.SourceMap.SyntaxError(include, "no files matched glob pattern"))
+				continue
+			}
+
+			for _, filename := range matches {
+				if seen, ok := visited[filename]; seen && ok {
+					continue
+				}
+
+				if fs, err := source.ReadFiles(filename); err == nil {
+					files = append(files, fs...)
+				} else {
+					errors = append(errors, *item.SourceMap.SyntaxError(include, err.Error()))
+				}
+
+				visited[filename] = true
+			}
 		} else {
-			errors = append(errors, *item.SourceMap.SyntaxError(include, err.Error()))
+			filename := filepath.Join(dir, *include)
+			// Check filename not already parsed
+			if seen, ok := visited[filename]; seen && ok {
+				// file already loaded, therefore ignore.
+			} else if fs, err := source.ReadFiles(filename); err == nil {
+				files = append(files, fs...)
+			} else {
+				errors = append(errors, *item.SourceMap.SyntaxError(include, err.Error()))
+			}
+			// Record that we've seen this file now.
+			visited[filename] = true
 		}
-		// Record that we've seen this file now.
-		visited[filename] = true
 	}
 	//
 	return files, errors
+}
+
+// CompileBestEffort is like Compile but tolerates link errors. It parses all
+// files (following includes) and links each declaration independently, keeping
+// those that resolve successfully and discarding only the ones with errors.
+// The returned program may therefore be incomplete, but it is always non-empty
+// as long as at least one declaration links cleanly. This is intended for IDE
+// features (hover, go-to-definition) where partial information is better than
+// nothing.
+func CompileBestEffort(files ...source.File) (ast.Program, source.Maps[any]) {
+	var (
+		items   []parser.UnlinkedSourceFile
+		visited map[string]bool = make(map[string]bool)
+	)
+	// Initialise visited map with all top-level files
+	for _, sf := range files {
+		visited[sf.Filename()] = true
+	}
+	// Parse each file in turn, following includes.
+	for len(files) > 0 {
+		var (
+			asm      = files[0]
+			included []source.File
+			cs       parser.UnlinkedSourceFile
+		)
+
+		files = files[1:]
+
+		if cs, _ = parser.Parse(&asm); len(cs.Components) > 0 || len(cs.Includes) > 0 {
+			items = append(items, cs)
+			included, _ = readIncludedFiles(asm, cs, visited)
+			files = append(files, included...)
+		}
+	}
+	// Link all declarations regardless of errors.
+	linker := NewLinker()
+	for _, item := range items {
+		linker.Join(item.SourceMap)
+
+		for _, declaration := range item.Components {
+			if !linker.Exists(declaration.Name()) {
+				linker.Register(declaration)
+			}
+		}
+	}
+
+	return linker.LinkBestEffort()
 }
 
 // Validate checks that a given program is well-formed.  For example, an

--- a/pkg/zkc/compiler/compiler.go
+++ b/pkg/zkc/compiler/compiler.go
@@ -131,13 +131,13 @@ func readIncludedFiles(file source.File, item parser.UnlinkedSourceFile,
 	return files, errors
 }
 
-// CompileBestEffort is like Compile but tolerates link errors. It parses all
-// files (following includes) and links each declaration independently, keeping
-// those that resolve successfully and discarding only the ones with errors.
-// The returned program may therefore be incomplete, but it is always non-empty
-// as long as at least one declaration links cleanly. This is intended for IDE
-// features (hover, go-to-definition) where partial information is better than
-// nothing.
+// CompileBestEffort is like Compile but tolerates parse, include, and link
+// errors so it can still return partial results. It parses all files
+// (following includes), registers every discovered declaration, and then
+// performs best-effort linking across the resulting set. The returned program
+// may therefore be incomplete and may include declarations that did not link
+// cleanly. This is intended for IDE features (hover, go-to-definition) where
+// partial information is better than nothing.
 func CompileBestEffort(files ...source.File) (ast.Program, source.Maps[any]) {
 	var (
 		items   []parser.UnlinkedSourceFile

--- a/pkg/zkc/compiler/compiler_test.go
+++ b/pkg/zkc/compiler/compiler_test.go
@@ -1,0 +1,132 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package compiler_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/consensys/go-corset/pkg/util/source"
+	"github.com/consensys/go-corset/pkg/zkc/compiler"
+)
+
+// TestGlobInclude_Match verifies that a glob pattern in an include directive
+// loads all matching files and compiles successfully.
+func TestGlobInclude_Match(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "sub")
+
+	writeFile(t, filepath.Join(subdir, "a.zkc"), `fn a(x:u8) -> (r:u8) { r = x }`)
+	writeFile(t, filepath.Join(subdir, "b.zkc"), `fn b(x:u8) -> (r:u8) { r = x }`)
+
+	// Both a and b must be loaded for this to compile.
+	mainContent := "include \"sub/*.zkc\"\nfn main(x:u8) -> (r:u8) { r = a(b(x)) }"
+	mainPath := filepath.Join(dir, "main.zkc")
+	writeFile(t, mainPath, mainContent)
+
+	sf := *source.NewSourceFile(mainPath, []byte(mainContent))
+	_, _, errs := compiler.Compile(sf)
+
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors, got %d: %v", len(errs), errs)
+	}
+}
+
+// TestGlobInclude_NoMatch verifies that a glob pattern that matches no files
+// is reported as a syntax error.
+func TestGlobInclude_NoMatch(t *testing.T) {
+	dir := t.TempDir()
+
+	mainContent := `include "nodir/*.zkc"`
+	mainPath := filepath.Join(dir, "main.zkc")
+	writeFile(t, mainPath, mainContent)
+
+	sf := *source.NewSourceFile(mainPath, []byte(mainContent))
+	_, _, errs := compiler.Compile(sf)
+
+	requireErrorContaining(t, errs, "no files matched glob pattern")
+}
+
+// TestGlobInclude_BadPattern verifies that a malformed glob pattern is
+// reported as a syntax error.
+func TestGlobInclude_BadPattern(t *testing.T) {
+	dir := t.TempDir()
+
+	// An unclosed '[' is a malformed glob in Go's filepath.Glob.
+	mainContent := `include "[invalid*.zkc"`
+	mainPath := filepath.Join(dir, "main.zkc")
+	writeFile(t, mainPath, mainContent)
+
+	sf := *source.NewSourceFile(mainPath, []byte(mainContent))
+	_, _, errs := compiler.Compile(sf)
+
+	requireErrorContaining(t, errs, "syntax error in pattern")
+}
+
+// TestGlobInclude_Dedup verifies that a file already loaded by an explicit
+// include is not loaded a second time when it is also matched by a subsequent
+// glob pattern.
+func TestGlobInclude_Dedup(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "sub")
+
+	// helper.zkc defines fn helper — loading it twice would cause a
+	// "duplicate declaration" error, so a single error-free compile proves
+	// deduplication is working.
+	writeFile(t, filepath.Join(subdir, "helper.zkc"), `fn helper(x:u8) -> (r:u8) { r = x }`)
+
+	mainContent := "include \"sub/helper.zkc\"\ninclude \"sub/*.zkc\"\nfn main(x:u8) -> (r:u8) { r = helper(x) }"
+	mainPath := filepath.Join(dir, "main.zkc")
+	writeFile(t, mainPath, mainContent)
+
+	sf := *source.NewSourceFile(mainPath, []byte(mainContent))
+	_, _, errs := compiler.Compile(sf)
+
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors (dedup should prevent double-loading), got %d: %v", len(errs), errs)
+	}
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func requireErrorContaining(t *testing.T, errs []source.SyntaxError, substr string) {
+	t.Helper()
+
+	if len(errs) == 0 {
+		t.Fatalf("expected an error containing %q, got none", substr)
+	}
+
+	for _, e := range errs {
+		if strings.Contains(e.Message(), substr) {
+			return
+		}
+	}
+
+	t.Fatalf("expected an error containing %q; actual errors: %v", substr, errs)
+}

--- a/pkg/zkc/compiler/linker.go
+++ b/pkg/zkc/compiler/linker.go
@@ -143,9 +143,16 @@ func (p *Linker) LinkBestEffort() (ast.Program, source.Maps[any]) {
 	var decls []decl.Resolved
 	//
 	for index := range p.components {
-		decl, _ := p.linkDeclaration(uint(index))
-		decls = append(decls, decl)
+		decl, errs := p.linkDeclaration(uint(index))
+		// Always copy the srcmap so go-to-definition can locate the declaration
+		// even when linking fails.
 		p.srcmap.Copy(p.components[index], decl)
+		// Only include structurally complete declarations in the program.
+		// Declarations with link errors may have nil DataType fields, which
+		// would panic in IDE features that call DataType.String().
+		if len(errs) == 0 {
+			decls = append(decls, decl)
+		}
 	}
 	//
 	return ast.NewProgram(decls, p.srcmap), p.srcmap

--- a/pkg/zkc/compiler/linker.go
+++ b/pkg/zkc/compiler/linker.go
@@ -135,6 +135,22 @@ func (p *Linker) Link() (ast.Program, []source.SyntaxError) {
 	return ast.NewProgram(decls, p.srcmap), errors
 }
 
+// LinkBestEffort is like Link but includes every declaration in the program
+// regardless of whether it had link errors. Declarations with errors may have
+// unresolved symbols, but their names and source locations are intact, which
+// is sufficient for IDE features such as hover and go-to-definition.
+func (p *Linker) LinkBestEffort() (ast.Program, source.Maps[any]) {
+	var decls []decl.Resolved
+	//
+	for index := range p.components {
+		decl, _ := p.linkDeclaration(uint(index))
+		decls = append(decls, decl)
+		p.srcmap.Copy(p.components[index], decl)
+	}
+	//
+	return ast.NewProgram(decls, p.srcmap), p.srcmap
+}
+
 // Link all buses used within this function to their intended targets.  This
 // means, for every bus used locally, settings the global bus identifier and
 // also allocated registers for the address/data lines.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the ZkC compiler include resolution and linking behavior (glob expansion and best-effort compilation), which could affect build correctness and IDE output; changes are localized and covered by new compiler tests.
> 
> **Overview**
> Adds **core LSP language features** to `zkc lsp`: implements `textDocument/hover`, `textDocument/definition`, `textDocument/documentSymbol`, and `textDocument/signatureHelp` (plus advertises capabilities/trigger characters) by compiling the current buffer and mapping cursor positions back to source locations.
> 
> Introduces `compiler.CompileBestEffort` and `Linker.LinkBestEffort` to produce partial AST/srcmap results even when parse/include/link errors exist, and extends `include` to support glob patterns with tests for match/no-match/bad-pattern and deduplication.
> 
> Improves semantic token classification with named token-type constants and lightweight context/lookahead so identifiers can be highlighted as `type`/`function` vs generic variables, and updates README Neovim setup for 0.11+ native LSP configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d73aab1f9bfa7c6532b91b903aa9a2265e492ae3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->