### PR TITLE
feat: support variable declarations in high-level AST

### DIFF
--- a/pkg/zkc/compiler/ast/stmt/assign.go
+++ b/pkg/zkc/compiler/ast/stmt/assign.go
@@ -43,11 +43,6 @@ type Assign[S symbol.Symbol[S]] struct {
 	Source expr.Expr[S]
 }
 
-// Buses implementation for Instruction interface
-func (p *Assign[S]) Buses() []S {
-	panic("todo")
-}
-
 // Uses implementation for Instruction interface.
 func (p *Assign[S]) Uses() []variable.Id {
 	return expr.Uses[S](p.Source)

--- a/pkg/zkc/compiler/ast/stmt/break.go
+++ b/pkg/zkc/compiler/ast/stmt/break.go
@@ -24,11 +24,6 @@ type Break[S symbol.Symbol[S]] struct {
 	Dummy uint
 }
 
-// Buses implementation for Stmt interface
-func (p *Break[S]) Buses() []S {
-	return nil
-}
-
 // Uses implementation for Stmt interface.
 func (p *Break[S]) Uses() []variable.Id {
 	return nil

--- a/pkg/zkc/compiler/ast/stmt/continue.go
+++ b/pkg/zkc/compiler/ast/stmt/continue.go
@@ -24,11 +24,6 @@ type Continue[S symbol.Symbol[S]] struct {
 	Dummy uint
 }
 
-// Buses implementation for Stmt interface
-func (p *Continue[S]) Buses() []S {
-	return nil
-}
-
 // Uses implementation for Stmt interface.
 func (p *Continue[S]) Uses() []variable.Id {
 	return nil

--- a/pkg/zkc/compiler/ast/stmt/fail.go
+++ b/pkg/zkc/compiler/ast/stmt/fail.go
@@ -24,11 +24,6 @@ type Fail[S symbol.Symbol[S]] struct {
 	Dummy uint
 }
 
-// Buses implementation for Instruction interface
-func (p *Fail[S]) Buses() []S {
-	return nil
-}
-
 // Uses implementation for Instruction interface.
 func (p *Fail[S]) Uses() []variable.Id {
 	return nil

--- a/pkg/zkc/compiler/ast/stmt/for.go
+++ b/pkg/zkc/compiler/ast/stmt/for.go
@@ -34,11 +34,6 @@ type For[S symbol.Symbol[S]] struct {
 	Body []Stmt[S]
 }
 
-// Buses implementation for Stmt interface
-func (p *For[S]) Buses() []S {
-	panic("todo")
-}
-
 // Uses implementation for Stmt interface.
 func (p *For[S]) Uses() []variable.Id {
 	var reads []variable.Id

--- a/pkg/zkc/compiler/ast/stmt/goto.go
+++ b/pkg/zkc/compiler/ast/stmt/goto.go
@@ -24,11 +24,6 @@ type Goto[S symbol.Symbol[S]] struct {
 	Target uint
 }
 
-// Buses implementation for Instruction interface
-func (p *Goto[S]) Buses() []S {
-	return nil
-}
-
 // Uses implementation for Instruction interface.
 func (p *Goto[S]) Uses() []variable.Id {
 	return nil

--- a/pkg/zkc/compiler/ast/stmt/ifelse.go
+++ b/pkg/zkc/compiler/ast/stmt/ifelse.go
@@ -34,11 +34,6 @@ type IfElse[S symbol.Symbol[S]] struct {
 	FalseBranch []Stmt[S]
 }
 
-// Buses implementation for Stmt interface
-func (p *IfElse[S]) Buses() []S {
-	panic("todo")
-}
-
 // Uses implementation for Stmt interface.
 func (p *IfElse[S]) Uses() []variable.Id {
 	var reads []variable.Id

--- a/pkg/zkc/compiler/ast/stmt/ifgoto.go
+++ b/pkg/zkc/compiler/ast/stmt/ifgoto.go
@@ -48,11 +48,6 @@ type IfGoto[S symbol.Symbol[S]] struct {
 	Target uint
 }
 
-// Buses implementation for Instruction interface
-func (p *IfGoto[S]) Buses() []S {
-	panic("todo")
-}
-
 // Uses implementation for Instruction interface.
 func (p *IfGoto[S]) Uses() []variable.Id {
 	var (

--- a/pkg/zkc/compiler/ast/stmt/printf.go
+++ b/pkg/zkc/compiler/ast/stmt/printf.go
@@ -36,11 +36,6 @@ type Printf[S symbol.Symbol[S]] struct {
 	Arguments []expr.Expr[S]
 }
 
-// Buses implementation for Instruction interface
-func (p *Printf[S]) Buses() []S {
-	return nil
-}
-
 // Uses implementation for Instruction interface.
 func (p *Printf[S]) Uses() []variable.Id {
 	return expr.Uses(p.Arguments...)

--- a/pkg/zkc/compiler/ast/stmt/return.go
+++ b/pkg/zkc/compiler/ast/stmt/return.go
@@ -24,11 +24,6 @@ type Return[S symbol.Symbol[S]] struct {
 	Dummy uint
 }
 
-// Buses implementation for Instruction interface
-func (p *Return[S]) Buses() []S {
-	return nil
-}
-
 // Uses implementation for Instruction interface.
 func (p *Return[S]) Uses() []variable.Id {
 	return nil

--- a/pkg/zkc/compiler/ast/stmt/stmt.go
+++ b/pkg/zkc/compiler/ast/stmt/stmt.go
@@ -32,10 +32,6 @@ type Unresolved = Stmt[symbol.Unresolved]
 // Here, macro is intended to imply that the instruction may break down into
 // multiple underlying "micro instructions".
 type Stmt[S symbol.Symbol[S]] interface {
-	// Buses identifies any external components (i.e. functions, memories,
-	// types) used by this instruction.  For example, a function call will
-	// return the identifier of the function being called, etc.
-	Buses() []S
 	// Uses returns the set of variables used (i.e. read) by this instruction.
 	Uses() []variable.Id
 	// Definitions returns the set of variables registers defined (i.e. written)

--- a/pkg/zkc/compiler/ast/stmt/vardecl.go
+++ b/pkg/zkc/compiler/ast/stmt/vardecl.go
@@ -1,0 +1,80 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package stmt
+
+import (
+	"strings"
+
+	"github.com/consensys/go-corset/pkg/util"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/expr"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/symbol"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/variable"
+)
+
+// VarDecl represents a variable declaration of the form:
+//
+//	var x:T [= e]
+//
+// or, for multi-variable declarations:
+//
+//	var x:T, y:U
+//
+// Variables holds the IDs of all declared variables; their names and types are
+// accessible via the enclosing function's variable map.
+// Init holds the optional initialiser expression (util.None when absent).
+// Invariant: Init.HasValue() => len(Variables) == 1.
+type VarDecl[S symbol.Symbol[S]] struct {
+	// Variables contains the IDs of all declared variables.
+	Variables []variable.Id
+	// Init is the optional initialiser expression.
+	Init util.Option[expr.Expr[S]]
+}
+
+// Uses implementation for Stmt interface.
+func (p *VarDecl[S]) Uses() []variable.Id {
+	if p.Init.HasValue() {
+		return expr.Uses[S](p.Init.Unwrap())
+	}
+
+	return nil
+}
+
+// Definitions implementation for Stmt interface.
+func (p *VarDecl[S]) Definitions() []variable.Id {
+	return p.Variables
+}
+
+// String implementation for Stmt interface.
+func (p *VarDecl[S]) String(env variable.Map[S]) string {
+	var builder strings.Builder
+
+	builder.WriteString("var ")
+
+	for i, id := range p.Variables {
+		if i != 0 {
+			builder.WriteString(", ")
+		}
+
+		v := env.Variable(id)
+		builder.WriteString(v.Name)
+		builder.WriteString(":")
+		builder.WriteString(v.DataType.String(nil))
+	}
+
+	if p.Init.HasValue() {
+		builder.WriteString(" = ")
+		builder.WriteString(p.Init.Unwrap().String(env))
+	}
+
+	return builder.String()
+}

--- a/pkg/zkc/compiler/ast/stmt/while.go
+++ b/pkg/zkc/compiler/ast/stmt/while.go
@@ -30,11 +30,6 @@ type While[S symbol.Symbol[S]] struct {
 	Body []Stmt[S]
 }
 
-// Buses implementation for Stmt interface
-func (p *While[S]) Buses() []S {
-	panic("todo")
-}
-
 // Uses implementation for Stmt interface.
 func (p *While[S]) Uses() []variable.Id {
 	var reads []variable.Id

--- a/pkg/zkc/compiler/linker.go
+++ b/pkg/zkc/compiler/linker.go
@@ -15,6 +15,7 @@ package compiler
 import (
 	"fmt"
 
+	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/source"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/data"
@@ -300,6 +301,20 @@ func (p *Linker) linkStatement(s stmt.Unresolved) (stmt.Resolved, []source.Synta
 		ninsn = &stmt.Printf[symbol.Resolved]{Chunks: s.Chunks, Arguments: args}
 	case *stmt.Return[symbol.Unresolved]:
 		ninsn = &stmt.Return[symbol.Resolved]{}
+	case *stmt.VarDecl[symbol.Unresolved]:
+		if s.Init.IsEmpty() {
+			ninsn = &stmt.VarDecl[symbol.Resolved]{
+				Variables: s.Variables,
+				Init:      util.None[expr.Resolved](),
+			}
+		} else {
+			rhs, errs := p.linkExpr(s.Init.Unwrap())
+			ninsn = &stmt.VarDecl[symbol.Resolved]{
+				Variables: s.Variables,
+				Init:      util.Some[expr.Resolved](rhs),
+			}
+			errors = errs
+		}
 	case *stmt.While[symbol.Unresolved]:
 		cond, errs1 := p.linkExpr(s.Cond)
 		body, errs2 := p.linkStatements(s.Body)

--- a/pkg/zkc/compiler/lower/lower.go
+++ b/pkg/zkc/compiler/lower/lower.go
@@ -18,6 +18,7 @@ import (
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/decl"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/expr"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/lval"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/stmt"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/symbol"
 )
@@ -82,6 +83,8 @@ func lowerStatement(pc uint, s stmt.Resolved, env *lowerEnv, srcmaps source.Maps
 		return lowerBreak(t, env, srcmaps)
 	case *stmt.Continue[symbol.Resolved]:
 		return lowerContinue(t, env, srcmaps)
+	case *stmt.VarDecl[symbol.Resolved]:
+		return lowerVarDecl(t, srcmaps)
 	default:
 		return []stmt.Resolved{lowerStatementExprs(s, srcmaps)}
 	}
@@ -342,6 +345,20 @@ func lowerContinue(s *stmt.Continue[symbol.Resolved], env *lowerEnv, srcmaps sou
 	srcmaps.Copy(s, g)
 
 	return []stmt.Resolved{g}
+}
+
+func lowerVarDecl(s *stmt.VarDecl[symbol.Resolved], srcmaps source.Maps[any]) []stmt.Resolved {
+	if s.Init.IsEmpty() {
+		return nil
+	}
+
+	assign := &stmt.Assign[symbol.Resolved]{
+		Targets: []lval.LVal[symbol.Resolved]{lval.NewVariable[symbol.Resolved](s.Variables[0])},
+		Source:  lowerExpr(s.Init.Unwrap(), srcmaps),
+	}
+	srcmaps.Copy(s, assign)
+
+	return []stmt.Resolved{assign}
 }
 
 // flatternCondition converts a condition expression into a flat sequence of

--- a/pkg/zkc/compiler/parser/parser.go
+++ b/pkg/zkc/compiler/parser/parser.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/util/collection/array"
 	"github.com/consensys/go-corset/pkg/util/source"
 	"github.com/consensys/go-corset/pkg/util/source/lex"
@@ -995,9 +996,12 @@ func (p *Parser) parseForInit(env Environment) (stmt.Unresolved, []source.Syntax
 			return nil, errs
 		}
 
-		target := lval.NewVariable[symbol.Unresolved](env.LookupVariable(name))
+		id := env.LookupVariable(name)
 
-		return &stmt.Assign[symbol.Unresolved]{Targets: []LVal{target}, Source: rhs}, nil
+		return &stmt.VarDecl[symbol.Unresolved]{
+			Variables: []variable.Id{id},
+			Init:      util.Some[Expr](rhs),
+		}, nil
 	}
 	// Fall back to a plain assignment to an already-declared variable.
 	return p.parseAssignment(env)
@@ -1196,12 +1200,19 @@ func (p *Parser) parseVar(env Environment) ([]stmt.Unresolved, []source.SyntaxEr
 	}
 	// Declare all variables before parsing any initialiser, so the
 	// initialiser expression can reference other already-declared variables.
+	varIds := make([]variable.Id, len(names))
 	for i, name := range names {
 		env.DeclareVariable(variable.LOCAL, name, types[i])
+		varIds[i] = env.LookupVariable(name)
 	}
 	// Check for optional initialiser
 	if !p.match(EQUALS) {
-		return nil, nil
+		insn := &stmt.VarDecl[symbol.Unresolved]{
+			Variables: varIds,
+			Init:      util.None[Expr](),
+		}
+
+		return []stmt.Unresolved{insn}, nil
 	}
 	// Initialisers are only supported for single-variable declarations.
 	if len(names) > 1 {
@@ -1212,11 +1223,10 @@ func (p *Parser) parseVar(env Environment) ([]stmt.Unresolved, []source.SyntaxEr
 	if len(errs) > 0 {
 		return nil, errs
 	}
-	// Build the assignment instruction
-	target := env.LookupVariable(names[0])
-	insn := &stmt.Assign[symbol.Unresolved]{
-		Targets: []LVal{lval.NewVariable[symbol.Unresolved](target)},
-		Source:  rhs,
+	// Build the variable declaration with initialiser
+	insn := &stmt.VarDecl[symbol.Unresolved]{
+		Variables: varIds,
+		Init:      util.Some[Expr](rhs),
 	}
 	//
 	return []stmt.Unresolved{insn}, nil


### PR DESCRIPTION
Previously, variable declarations were not present in the high-level AST.  This meant the high-level AST did not capture all information about the original file and, hence, could not be used directly for pretty printing.  Therefore, a new AST node "VarDecl" has been added which is used to represent variable declarations in the high-level AST. This is then compiled away when lowering the AST.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the statement AST interface and updates parser/linker/lowering to handle a new `VarDecl` node; mistakes could affect compilation of variable declarations and loop initializers.
> 
> **Overview**
> Adds a new high-level statement node `stmt.VarDecl` to preserve `var` declarations (including optional initialisers) in the AST for printing/analysis.
> 
> Updates parsing to emit `VarDecl` for `var` statements and for-loop inline declarations, updates the linker to resolve `VarDecl` (including linking its optional init expression), and updates the lowering pass to compile `VarDecl` away by dropping decl-only statements and translating `var x = e` into an `Assign` to `x`.
> 
> Removes the unused `Buses()` method from the `stmt.Stmt` interface and from existing statement implementations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9917ff06307cb70e5e7bdf03082bf6c501b4f8a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->