### PR TITLE
feat: introduce notion of IncrementalCompiler

### DIFF
--- a/pkg/cmd/zkc/lsp.go
+++ b/pkg/cmd/zkc/lsp.go
@@ -16,15 +16,20 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"log"
 	"net"
 	"os"
+	"path/filepath"
 	"sync"
 
 	"go.lsp.dev/jsonrpc2"
 	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
 
 	"github.com/consensys/go-corset/pkg/cmd/zkc/lsp"
+	"github.com/consensys/go-corset/pkg/util/source"
+	"github.com/consensys/go-corset/pkg/zkc/compiler"
 	"github.com/spf13/cobra"
 )
 
@@ -70,7 +75,7 @@ func openLspLog(path string) *os.File {
 
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "zkc-lsp: cannot open log file %s: %v\n", path, err)
+		fmt.Fprintf(os.Stderr, "cannot open log file %s: %v\n", path, err)
 		os.Exit(1)
 	}
 
@@ -105,15 +110,15 @@ func runLspServerTCP(port uint16) {
 
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
-		log.Fatalf("zkc-lsp: cannot listen on %s: %v\n", addr, err)
+		log.Fatalf("cannot listen on %s: %v\n", addr, err)
 	}
 
-	log.Printf("zkc-lsp: listening on %s\n", addr)
+	log.Printf("listening on %s\n", addr)
 
 	for {
 		conn, err := listener.Accept()
 		if err != nil {
-			log.Printf("zkc-lsp: accept error: %v\n", err)
+			log.Printf("accept error: %v\n", err)
 			return
 		}
 
@@ -131,11 +136,82 @@ func runLspConn(rwc io.ReadWriteCloser) {
 	<-conn.Done()
 }
 
+// workspaceRoot extracts the workspace root directory from the parameters
+// passed by the client at initialize time.  It prefers WorkspaceFolders (the
+// modern LSP convention), falling back to the deprecated RootURI and then
+// RootPath fields.  Returns the empty string when the client did not provide
+// any of them, in which case no files are loaded up-front.
+func workspaceRoot(params *protocol.InitializeParams) string {
+	if len(params.WorkspaceFolders) > 0 {
+		return uri.URI(params.WorkspaceFolders[0].URI).Filename()
+	}
+
+	// RootURI / RootPath are deprecated by LSP but still emitted by some
+	// clients, so fall back to them when WorkspaceFolders is absent.
+	//nolint:staticcheck
+	if params.RootURI != "" {
+		//nolint:staticcheck
+		return params.RootURI.Filename()
+	}
+	//nolint:staticcheck
+	return params.RootPath
+}
+
+// discoverZkcFiles walks root recursively and returns a ChangedFile update
+// for each .zkc file it finds.  Files that cannot be read are logged and
+// skipped; an empty root yields no updates.
+func discoverZkcFiles(root string) []compiler.FileUpdate {
+	if root == "" {
+		return nil
+	}
+
+	var updates []compiler.FileUpdate
+
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			log.Printf("walk error at %s: %v", path, err)
+			return nil
+		}
+
+		if d.IsDir() || filepath.Ext(path) != ".zkc" {
+			return nil
+		}
+
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			log.Printf("zkc-lsp: cannot read %s: %v", path, err)
+			return nil
+		}
+
+		updates = append(updates, compiler.ChangedFile(path, string(contents)))
+
+		return nil
+	})
+	if err != nil {
+		log.Printf("walk under %s failed: %v", root, err)
+	}
+
+	return updates
+}
+
 // zkcServer implements protocol.Server for the ZkC language.
 type zkcServer struct {
-	mu   sync.RWMutex
-	docs map[protocol.URI]string
-	conn jsonrpc2.Conn // retained so the server can push notifications to the client
+	mu sync.RWMutex
+	// compiler holds the in-memory view of every .zkc file the server is
+	// tracking — those discovered under the workspace root at startup plus
+	// any opened by the editor since.  It is recompiled in full on each
+	// document change.
+	compiler *compiler.IncrementalCompiler
+	// dirtyDiagnostics is the set of file URIs for which the server most
+	// recently published a non-empty diagnostics list.  When a subsequent
+	// publish does not include such a file, an empty notification is sent
+	// for it so that previously-displayed squiggles are cleared.
+	dirtyDiagnostics map[protocol.URI]struct{}
+	// pendingDiagnostics buffers errors discovered during Initialize so
+	// they can be published from Initialized — the LSP spec forbids
+	// arbitrary notifications before the Initialize response is sent.
+	pendingDiagnostics []source.SyntaxError
+	conn               jsonrpc2.Conn // retained so the server can push notifications to the client
 }
 
 // ============================================================================
@@ -148,11 +224,16 @@ type zkcServer struct {
 // of features it supports. Clients must not send any further requests until
 // they have received this response.
 func (s *zkcServer) Initialize(
-	_ context.Context, _ *protocol.InitializeParams,
+	_ context.Context, params *protocol.InitializeParams,
 ) (*protocol.InitializeResult, error) {
 	s.mu.Lock()
-	s.docs = make(map[protocol.URI]string)
+	s.compiler = compiler.NewIncrementalCompiler()
+	s.dirtyDiagnostics = make(map[protocol.URI]struct{})
+	updates := discoverZkcFiles(workspaceRoot(params))
+	s.pendingDiagnostics = s.compiler.Apply(updates...)
 	s.mu.Unlock()
+
+	log.Printf("initialised %d file(s) from workspace", len(updates))
 
 	return &protocol.InitializeResult{
 		Capabilities: protocol.ServerCapabilities{
@@ -180,7 +261,14 @@ func (s *zkcServer) Initialize(
 // immediately after it has processed the initialize response. This marks the
 // point at which the server may begin sending requests and notifications to
 // the client (e.g. register dynamic capabilities, fetch configuration).
-func (s *zkcServer) Initialized(_ context.Context, _ *protocol.InitializedParams) error {
+func (s *zkcServer) Initialized(ctx context.Context, _ *protocol.InitializedParams) error {
+	s.mu.Lock()
+	errs := s.pendingDiagnostics
+	s.pendingDiagnostics = nil
+	s.mu.Unlock()
+
+	s.publishDiagnostics(ctx, errs)
+
 	return nil
 }
 
@@ -191,7 +279,7 @@ func (s *zkcServer) Initialized(_ context.Context, _ *protocol.InitializedParams
 // Responding to requests other than exit after shutdown should return an
 // error.
 func (s *zkcServer) Shutdown(_ context.Context) error {
-	log.Printf("SHUTDOWN")
+	log.Printf("Shutdown")
 	return nil
 }
 
@@ -231,12 +319,38 @@ func (s *zkcServer) LogTrace(_ context.Context, _ *protocol.LogTraceParams) erro
 // trace level negotiated during initialization and takes effect immediately.
 func (s *zkcServer) SetTrace(_ context.Context, _ *protocol.SetTraceParams) error { return nil }
 
-// publishDiagnostics compiles uri from text and pushes a
-// textDocument/publishDiagnostics notification to the client.
-func (s *zkcServer) publishDiagnostics(ctx context.Context, uri protocol.URI, text string) {
-	params := lsp.DiagnosticsFor(uri, text)
-	if err := s.conn.Notify(ctx, "textDocument/publishDiagnostics", params); err != nil {
-		log.Printf("zkc-lsp: publishDiagnostics notify error: %v", err)
+// publishDiagnostics groups the given syntax errors by source file and
+// pushes a textDocument/publishDiagnostics notification per affected file.
+//
+// To avoid stale squiggles, files that previously had diagnostics but no
+// longer appear in errs are sent an explicit empty notification: this is
+// tracked via s.dirtyDiagnostics, which always reflects the set of files for
+// which the server's last publish was non-empty.
+func (s *zkcServer) publishDiagnostics(ctx context.Context, errs []source.SyntaxError) {
+	byFile := lsp.DiagnosticsByFile(errs)
+
+	s.mu.Lock()
+	// Schedule a clear for any previously-dirty file that is now clean.
+	for u := range s.dirtyDiagnostics {
+		if _, still := byFile[u]; !still {
+			byFile[u] = []protocol.Diagnostic{}
+		}
+	}
+	// Refresh the dirty set to reflect what we are about to publish.
+	s.dirtyDiagnostics = make(map[protocol.URI]struct{}, len(byFile))
+	for u, diags := range byFile {
+		if len(diags) > 0 {
+			s.dirtyDiagnostics[u] = struct{}{}
+		}
+	}
+
+	s.mu.Unlock()
+
+	for u, diags := range byFile {
+		params := &protocol.PublishDiagnosticsParams{URI: u, Diagnostics: diags}
+		if err := s.conn.Notify(ctx, "textDocument/publishDiagnostics", params); err != nil {
+			log.Printf("publishDiagnostics notify error: %v", err)
+		}
 	}
 }
 
@@ -245,11 +359,14 @@ func (s *zkcServer) publishDiagnostics(ctx context.Context, uri protocol.URI, te
 // content. From this point the server is responsible for maintaining an
 // up-to-date view of the document until the corresponding didClose is received.
 func (s *zkcServer) DidOpen(ctx context.Context, params *protocol.DidOpenTextDocumentParams) error {
+	uri := params.TextDocument.URI
+	text := params.TextDocument.Text
+
 	s.mu.Lock()
-	s.docs[params.TextDocument.URI] = params.TextDocument.Text
+	errs := s.compiler.Apply(compiler.ChangedFile(uri.Filename(), text))
 	s.mu.Unlock()
 
-	s.publishDiagnostics(ctx, params.TextDocument.URI, params.TextDocument.Text)
+	s.publishDiagnostics(ctx, errs)
 
 	return nil
 }
@@ -265,12 +382,13 @@ func (s *zkcServer) DidChange(ctx context.Context, params *protocol.DidChangeTex
 
 	// Use the last change; in full-sync mode this carries the entire updated text.
 	text := params.ContentChanges[len(params.ContentChanges)-1].Text
+	uri := params.TextDocument.URI
 
 	s.mu.Lock()
-	s.docs[params.TextDocument.URI] = text
+	errs := s.compiler.Apply(compiler.ChangedFile(uri.Filename(), text))
 	s.mu.Unlock()
 
-	s.publishDiagnostics(ctx, params.TextDocument.URI, text)
+	s.publishDiagnostics(ctx, errs)
 
 	return nil
 }
@@ -280,17 +398,23 @@ func (s *zkcServer) DidChange(ctx context.Context, params *protocol.DidChangeTex
 // point the server should discard any in-memory state for the document; the
 // source of truth reverts to the file system.
 func (s *zkcServer) DidClose(ctx context.Context, params *protocol.DidCloseTextDocumentParams) error {
+	filename := params.TextDocument.URI.Filename()
+
+	// On close the source of truth reverts to disk: re-read the saved file
+	// so that any unsaved edits the user discarded are dropped from the
+	// compiler's view.  If the file has been deleted from disk, evict it.
+	var update compiler.FileUpdate
+	if contents, err := os.ReadFile(filename); err == nil {
+		update = compiler.ChangedFile(filename, string(contents))
+	} else {
+		update = compiler.RemovedFile(filename)
+	}
+
 	s.mu.Lock()
-	delete(s.docs, params.TextDocument.URI)
+	errs := s.compiler.Apply(update)
 	s.mu.Unlock()
 
-	// Clear any squiggles the editor is displaying for this document.
-	if err := s.conn.Notify(ctx, "textDocument/publishDiagnostics", &protocol.PublishDiagnosticsParams{
-		URI:         params.TextDocument.URI,
-		Diagnostics: []protocol.Diagnostic{},
-	}); err != nil {
-		log.Printf("zkc-lsp: clear diagnostics: %v", err)
-	}
+	s.publishDiagnostics(ctx, errs)
 
 	return nil
 }
@@ -468,14 +592,16 @@ func (s *zkcServer) Definition(
 	_ context.Context, params *protocol.DefinitionParams,
 ) ([]protocol.Location, error) {
 	s.mu.RLock()
-	text, ok := s.docs[params.TextDocument.URI]
+	text, ok := s.compiler.Source(params.TextDocument.URI.Filename())
+	program := s.compiler.Program()
+	srcmaps := s.compiler.SourceMaps()
 	s.mu.RUnlock()
 
 	if !ok {
 		return nil, nil
 	}
 
-	return lsp.DefinitionFor(params.TextDocument.URI, text, params.Position)
+	return lsp.DefinitionFor(params.TextDocument.URI, text, params.Position, program, srcmaps)
 }
 
 // DocumentColor handles a textDocument/documentColor request. The client
@@ -530,14 +656,16 @@ func (s *zkcServer) DocumentSymbol(
 	_ context.Context, params *protocol.DocumentSymbolParams,
 ) ([]interface{}, error) {
 	s.mu.RLock()
-	text, ok := s.docs[params.TextDocument.URI]
+	_, ok := s.compiler.Source(params.TextDocument.URI.Filename())
+	program := s.compiler.Program()
+	srcmaps := s.compiler.SourceMaps()
 	s.mu.RUnlock()
 
 	if !ok {
 		return nil, nil
 	}
 
-	return lsp.DocumentSymbolsFor(params.TextDocument.URI, text)
+	return lsp.DocumentSymbolsFor(params.TextDocument.URI, program, srcmaps)
 }
 
 // ExecuteCommand handles a workspace/executeCommand request. Servers
@@ -573,7 +701,7 @@ func (s *zkcServer) Formatting(
 	uri := params.TextDocument.URI
 
 	s.mu.RLock()
-	text, ok := s.docs[uri]
+	text, ok := s.compiler.Source(uri.Filename())
 	s.mu.RUnlock()
 
 	if !ok {
@@ -589,14 +717,16 @@ func (s *zkcServer) Formatting(
 // or an evaluated value.
 func (s *zkcServer) Hover(_ context.Context, params *protocol.HoverParams) (*protocol.Hover, error) {
 	s.mu.RLock()
-	text, ok := s.docs[params.TextDocument.URI]
+	text, ok := s.compiler.Source(params.TextDocument.URI.Filename())
+	program := s.compiler.Program()
+	srcmaps := s.compiler.SourceMaps()
 	s.mu.RUnlock()
 
 	if !ok {
 		return nil, nil
 	}
 
-	return lsp.HoverFor(params.TextDocument.URI, text, params.Position)
+	return lsp.HoverFor(params.TextDocument.URI, text, params.Position, program, srcmaps)
 }
 
 // Implementation handles a textDocument/implementation request. The client
@@ -674,14 +804,15 @@ func (s *zkcServer) SignatureHelp(
 	_ context.Context, params *protocol.SignatureHelpParams,
 ) (*protocol.SignatureHelp, error) {
 	s.mu.RLock()
-	text, ok := s.docs[params.TextDocument.URI]
+	text, ok := s.compiler.Source(params.TextDocument.URI.Filename())
+	program := s.compiler.Program()
 	s.mu.RUnlock()
 
 	if !ok {
 		return nil, nil
 	}
 
-	return lsp.SignatureHelpFor(params.TextDocument.URI, text, params.Position)
+	return lsp.SignatureHelpFor(params.TextDocument.URI, text, params.Position, program)
 }
 
 // Symbols handles a workspace/symbol request. The client sends this when the
@@ -805,7 +936,7 @@ func (s *zkcServer) SemanticTokensFull(
 	_ context.Context, params *protocol.SemanticTokensParams,
 ) (*protocol.SemanticTokens, error) {
 	s.mu.RLock()
-	text, ok := s.docs[params.TextDocument.URI]
+	text, ok := s.compiler.Source(params.TextDocument.URI.Filename())
 	s.mu.RUnlock()
 
 	if !ok {

--- a/pkg/cmd/zkc/lsp/definition.go
+++ b/pkg/cmd/zkc/lsp/definition.go
@@ -14,19 +14,27 @@ package lsp
 
 import (
 	"github.com/consensys/go-corset/pkg/util/source"
-	"github.com/consensys/go-corset/pkg/zkc/compiler"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/parser"
 	"go.lsp.dev/protocol"
 	lspuri "go.lsp.dev/uri"
 )
 
-// DefinitionFor compiles the given document and returns the source location of
-// the top-level declaration named by the identifier under the cursor at pos. It
-// returns nil when no definition is available (e.g. the cursor is on a keyword,
-// the name is not a top-level declaration, or the document cannot be compiled).
-func DefinitionFor(uri protocol.URI, text string, pos protocol.Position) ([]protocol.Location, error) {
+// DefinitionFor returns the source location of the top-level declaration
+// named by the identifier under the cursor at pos.  The caller supplies an
+// already-compiled program and its associated source maps (typically taken
+// from an IncrementalCompiler), so this function does not itself parse or
+// compile the source — it only lexes the supplied document text to find the
+// identifier under the cursor.
+//
+// Returns nil when no definition is available, e.g. the cursor is on a
+// keyword or whitespace, or the identifier does not name a top-level
+// declaration in program.
+func DefinitionFor(
+	uri protocol.URI, text string, pos protocol.Position,
+	program ast.Program, srcmaps source.Maps[any],
+) ([]protocol.Location, error) {
 	srcfile := source.NewSourceFile(uri.Filename(), []byte(text))
-	program, srcmaps, _ := compiler.Compile(*srcfile)
 
 	// Convert LSP cursor position to a rune offset in the source file.
 	offset := posToOffset(*srcfile, pos)

--- a/pkg/cmd/zkc/lsp/diagnostics.go
+++ b/pkg/cmd/zkc/lsp/diagnostics.go
@@ -14,30 +14,24 @@ package lsp
 
 import (
 	"github.com/consensys/go-corset/pkg/util/source"
-	"github.com/consensys/go-corset/pkg/zkc/compiler"
 	"go.lsp.dev/protocol"
+	"go.lsp.dev/uri"
 )
 
-// DiagnosticsFor parses the given document text and returns a
-// PublishDiagnosticsParams ready to send to the client as a
-// textDocument/publishDiagnostics notification.
-func DiagnosticsFor(uri protocol.URI, text string) *protocol.PublishDiagnosticsParams {
-	srcfile := source.NewSourceFile(uri.Filename(), []byte(text))
-	_, _, errs := compiler.Compile(*srcfile)
+// DiagnosticsByFile groups the given syntax errors by their source file and
+// converts each to a protocol.Diagnostic.  The returned map is keyed by the
+// URI of every affected file; files with no errors do not appear, so callers
+// that need to clear previously-published diagnostics must track that
+// separately.
+func DiagnosticsByFile(errs []source.SyntaxError) map[protocol.URI][]protocol.Diagnostic {
+	out := make(map[protocol.URI][]protocol.Diagnostic)
 
-	// compiler.Compile also processes included files from disk and may return
-	// errors for them.  Only report errors that belong to the current document.
-	diags := make([]protocol.Diagnostic, 0, len(errs))
 	for _, err := range errs {
-		if err.SourceFile().Filename() == srcfile.Filename() {
-			diags = append(diags, syntaxErrToDiagnostic(err))
-		}
+		u := uri.File(err.SourceFile().Filename())
+		out[u] = append(out[u], syntaxErrToDiagnostic(err))
 	}
 
-	return &protocol.PublishDiagnosticsParams{
-		URI:         uri,
-		Diagnostics: diags,
-	}
+	return out
 }
 
 // syntaxErrToDiagnostic converts a source.SyntaxError into a protocol.Diagnostic.

--- a/pkg/cmd/zkc/lsp/docsym.go
+++ b/pkg/cmd/zkc/lsp/docsym.go
@@ -14,32 +14,33 @@ package lsp
 
 import (
 	"github.com/consensys/go-corset/pkg/util/source"
-	"github.com/consensys/go-corset/pkg/zkc/compiler"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/data"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/decl"
 	"go.lsp.dev/protocol"
 )
 
-// DocumentSymbolsFor compiles the given document and returns a
-// protocol.DocumentSymbol for each top-level declaration defined in this file.
-// Declarations from included files are filtered out.  If the document cannot
-// be compiled (e.g. due to parse errors), an empty slice is returned with no
-// error; diagnostics for those failures are already reported separately.
-func DocumentSymbolsFor(uri protocol.URI, text string) ([]interface{}, error) {
-	srcfile := source.NewSourceFile(uri.Filename(), []byte(text))
-	program, srcmaps, _ := compiler.Compile(*srcfile)
-
+// DocumentSymbolsFor returns a protocol.DocumentSymbol for each top-level
+// declaration defined in the file identified by uri.  Declarations from
+// included files are filtered out by comparing the source file recorded in
+// srcmaps against uri.  The caller supplies an already-compiled program and
+// its source maps (typically taken from an IncrementalCompiler), so this
+// function does no parsing or compilation of its own.
+func DocumentSymbolsFor(
+	uri protocol.URI, program ast.Program, srcmaps source.Maps[any],
+) ([]interface{}, error) {
+	filename := uri.Filename()
 	env := program.Environment()
 
 	var symbols []interface{}
 
 	for _, d := range program.Components() {
 		srcFile, span, ok := srcmaps.Lookup(d)
-		if !ok || srcFile.Filename() != srcfile.Filename() {
+		if !ok || srcFile.Filename() != filename {
 			continue
 		}
 
-		rng := spanToRange(*srcfile, span)
+		rng := spanToRange(srcFile, span)
 
 		symbols = append(symbols, protocol.DocumentSymbol{
 			Name:           d.Name(),

--- a/pkg/cmd/zkc/lsp/hover.go
+++ b/pkg/cmd/zkc/lsp/hover.go
@@ -16,20 +16,24 @@ import (
 	"strings"
 
 	"github.com/consensys/go-corset/pkg/util/source"
-	"github.com/consensys/go-corset/pkg/zkc/compiler"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/data"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/decl"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/parser"
 	"go.lsp.dev/protocol"
 )
 
-// HoverFor compiles the given document and returns hover information for the
-// symbol under the cursor at pos.  It returns nil when no hover content is
-// available (e.g. the cursor is on punctuation or the document cannot be
-// compiled).
-func HoverFor(uri protocol.URI, text string, pos protocol.Position) (*protocol.Hover, error) {
+// HoverFor returns hover information for the symbol under the cursor at pos.
+// The caller supplies an already-compiled program and source maps (typically
+// taken from an IncrementalCompiler); this function only lexes the supplied
+// document text to find the identifier under the cursor.  Returns nil when
+// no hover content is available (e.g. the cursor is on punctuation or the
+// identifier names neither a local nor a top-level declaration).
+func HoverFor(
+	uri protocol.URI, text string, pos protocol.Position,
+	program ast.Program, srcmaps source.Maps[any],
+) (*protocol.Hover, error) {
 	srcfile := source.NewSourceFile(uri.Filename(), []byte(text))
-	program, srcmaps, _ := compiler.Compile(*srcfile)
 
 	// Convert LSP cursor position to a rune offset in the source file.
 	offset := posToOffset(*srcfile, pos)

--- a/pkg/cmd/zkc/lsp/sighelp.go
+++ b/pkg/cmd/zkc/lsp/sighelp.go
@@ -15,19 +15,24 @@ package lsp
 import (
 	"github.com/consensys/go-corset/pkg/util/source"
 	"github.com/consensys/go-corset/pkg/util/source/lex"
-	"github.com/consensys/go-corset/pkg/zkc/compiler"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/data"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/decl"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/parser"
 	"go.lsp.dev/protocol"
 )
 
-// SignatureHelpFor compiles the given document and returns signature help for
-// the function call the cursor is inside. It returns nil when the cursor is not
-// inside a function-call argument list or the callee cannot be resolved.
-func SignatureHelpFor(uri protocol.URI, text string, pos protocol.Position) (*protocol.SignatureHelp, error) {
+// SignatureHelpFor returns signature help for the function call the cursor
+// is inside.  The caller supplies an already-compiled program (typically
+// taken from an IncrementalCompiler); this function only lexes the supplied
+// document text to locate the enclosing call and active parameter.  Returns
+// nil when the cursor is not inside a function-call argument list or the
+// callee cannot be resolved.
+func SignatureHelpFor(
+	uri protocol.URI, text string, pos protocol.Position,
+	program ast.Program,
+) (*protocol.SignatureHelp, error) {
 	srcfile := source.NewSourceFile(uri.Filename(), []byte(text))
-	program, _, _ := compiler.Compile(*srcfile)
 
 	// Convert LSP cursor position to a rune offset in the source file.
 	offset := posToOffset(*srcfile, pos)

--- a/pkg/zkc/compiler/incremental_compiler.go
+++ b/pkg/zkc/compiler/incremental_compiler.go
@@ -1,0 +1,144 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package compiler
+
+import (
+	"github.com/consensys/go-corset/pkg/util/source"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/lower"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/parser"
+)
+
+// FileUpdate indicates that some change has been made to a given file
+// (including, for example, that the file was removed altogether).
+type FileUpdate struct {
+	// indicates whether file is removed or not
+	removed bool
+	// path of file in question
+	filename string
+	// contents of update
+	contents string
+}
+
+// ChangedFile constructs a FileUpdate describing a file that was added or
+// whose contents have changed.
+func ChangedFile(filename, contents string) FileUpdate {
+	return FileUpdate{filename: filename, contents: contents}
+}
+
+// RemovedFile constructs a FileUpdate describing a file that has been
+// deleted from the in-memory store.
+func RemovedFile(filename string) FileUpdate {
+	return FileUpdate{removed: true, filename: filename}
+}
+
+// IncrementalCompiler maintains an in-memory view of a set of source files and
+// recompiles them on demand as updates arrive.  It is intended to back tools
+// (such as the language server) which need to track the current state of an
+// edited project without ever reading from disk: every file the compiler
+// considers must first be supplied via Apply.
+//
+// The compiler is not safe for concurrent use; callers are responsible for
+// serialising access (e.g. through a single document-update goroutine).
+type IncrementalCompiler struct {
+	// files holds the current contents of every source file known to the
+	// compiler, keyed by filename.  This map is the sole source of truth:
+	// include directives are not resolved against the filesystem, so any
+	// file that is not present here is treated as if it does not exist.
+	files map[string]string
+	// program is the AST produced by the most recent call to Apply.  It is
+	// replaced wholesale on each invocation rather than patched in-place,
+	// so callers should re-read it after every update.
+	program ast.Program
+	// srcmaps maps AST nodes from the most recent compilation back to the
+	// source spans they originated from.  Like program, it is replaced
+	// wholesale on each Apply.
+	srcmaps source.Maps[any]
+}
+
+// Source returns the current contents of the file with the given filename
+// from the in-memory store.  The second return value is false when no such
+// file is known to the compiler.
+func (p *IncrementalCompiler) Source(filename string) (string, bool) {
+	contents, ok := p.files[filename]
+	return contents, ok
+}
+
+// Program returns the AST produced by the most recent call to Apply.
+func (p *IncrementalCompiler) Program() ast.Program {
+	return p.program
+}
+
+// SourceMaps returns the source-span map produced by the most recent call to
+// Apply, allowing callers to translate AST nodes back to their originating
+// file and span.
+func (p *IncrementalCompiler) SourceMaps() source.Maps[any] {
+	return p.srcmaps
+}
+
+// NewIncrementalCompiler constructs an IncrementalCompiler with an empty
+// in-memory file store and no compiled program.  Source files must be
+// introduced through Apply before any meaningful compilation can occur;
+// calling Apply with no updates on a fresh compiler will simply produce an
+// empty program.
+func NewIncrementalCompiler() *IncrementalCompiler {
+	return &IncrementalCompiler{
+		files: make(map[string]string),
+	}
+}
+
+// Apply a given set of updates to the internal state of this compiler.
+func (p *IncrementalCompiler) Apply(updates ...FileUpdate) []source.SyntaxError {
+	// Apply updates to the in-memory store.
+	for _, u := range updates {
+		if u.removed {
+			delete(p.files, u.filename)
+		} else {
+			p.files[u.filename] = u.contents
+		}
+	}
+	//
+	var (
+		items   []parser.UnlinkedSourceFile
+		errors  []source.SyntaxError
+		program ast.Program
+		srcmaps source.Maps[any]
+	)
+	// Parse every file currently in the in-memory store. Includes are not
+	// resolved against disk; the store is the sole source of truth.
+	for filename, contents := range p.files {
+		var (
+			srcfile  = source.NewSourceFile(filename, []byte(contents))
+			cs, errs = parser.Parse(srcfile)
+		)
+		if len(cs.Components) > 0 {
+			items = append(items, cs)
+		}
+
+		errors = append(errors, errs...)
+	}
+	// Link assembly and resolve external accesses.
+	var linkErrs []source.SyntaxError
+
+	program, srcmaps, linkErrs = Link(items...)
+	errors = append(errors, linkErrs...)
+	// Flatten block-level constructs (if/else, while, for) into flat if-goto form.
+	lower.Flatten(program, srcmaps)
+	// Well-formedness checks (assuming unlimited field width).
+	errors = append(errors, validateProgram(program, srcmaps)...)
+	// Update internal program state.
+	p.program = program
+	p.srcmaps = srcmaps
+	//
+	return errors
+}


### PR DESCRIPTION
The intention of this is that it because the defacto in-memory representation used for the LSP server.  At this stage, it is not at all efficient.  However, in principle, it could be made more efficient at some point in the future.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core LSP lifecycle, workspace scanning, and diagnostic publication behavior, which can affect editor UX and correctness across multi-file projects. The new compiler state model recompiles the full in-memory workspace on updates, so regressions are likely around stale/cleared diagnostics and file tracking.
> 
> **Overview**
> The LSP server now builds and maintains a shared in-memory compilation state via a new `compiler.IncrementalCompiler`, loading all `.zkc` files under the workspace root during `Initialize` and reapplying updates on `didOpen`/`didChange`/`didClose`.
> 
> Diagnostics publishing is reworked to emit results **per affected file** (including included files) and to explicitly clear previously-published diagnostics when errors disappear; initial diagnostics found during `Initialize` are deferred until `Initialized` to comply with the LSP notification rules. LSP features (`hover`, `definition`, `documentSymbol`, `signatureHelp`) are updated to consume the already-compiled `program`/`srcmaps` instead of recompiling the active document on each request.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75640b5da8aa5ab941796054dae60727ecef89ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->