### PR TITLE
feat: add more invalid tests

### DIFF
--- a/pkg/test/zkc_invalid_test.go
+++ b/pkg/test/zkc_invalid_test.go
@@ -125,6 +125,19 @@ func Test_ZkcInvalid_Basic_27(t *testing.T) {
 	checkZkcInvalid(t, "zkc/invalid/basic_27")
 }
 
+func Test_ZkcInvalid_Basic_28(t *testing.T) {
+	checkZkcInvalid(t, "zkc/invalid/basic_28")
+}
+func Test_ZkcInvalid_Basic_29(t *testing.T) {
+	checkZkcInvalid(t, "zkc/invalid/basic_29")
+}
+func Test_ZkcInvalid_Basic_30(t *testing.T) {
+	checkZkcInvalid(t, "zkc/invalid/basic_30")
+}
+func Test_ZkcInvalid_Basic_31(t *testing.T) {
+	checkZkcInvalid(t, "zkc/invalid/basic_31")
+}
+
 // ===================================================================
 // If Tests
 // ===================================================================

--- a/testdata/zkc/invalid/basic_28.zkc
+++ b/testdata/zkc/invalid/basic_28.zkc
@@ -1,0 +1,12 @@
+//error:11:7-11:too many arguments (expected 0)
+//error:7:11-12:expected type u16
+const X:u32 = 123
+
+fn f(y:u16) -> (r:u32) {
+  //
+  if y != X {
+     fail
+  }
+  //
+  r = X(0)
+}

--- a/testdata/zkc/invalid/basic_29.zkc
+++ b/testdata/zkc/invalid/basic_29.zkc
@@ -1,0 +1,8 @@
+//error:7:7-11:too many arguments (expected 0)
+//error:4:1-21:cyclic definition for cyclic
+const X:u32 = 123
+type cyclic = cyclic
+
+fn f(y:u16) -> (r:u32) {
+  r = X(0)
+}

--- a/testdata/zkc/invalid/basic_30.zkc
+++ b/testdata/zkc/invalid/basic_30.zkc
@@ -1,0 +1,9 @@
+//error:7:10-14:too many arguments (expected 0)
+//error:9:1-2:return r possibly undefined
+const X:u32 = 123
+
+fn f(y:u16) -> (r:u32) {
+   if y != 0 {
+     r = X(0)
+   }
+}

--- a/testdata/zkc/invalid/basic_31.zkc
+++ b/testdata/zkc/invalid/basic_31.zkc
@@ -1,0 +1,9 @@
+//error:7:10-11:expected type u32
+//error:9:1-2:return r possibly undefined
+const X:u16 = 123
+
+fn f(y:u16) -> (r:u32) {
+   if y != 0 {
+     r = X
+   }
+}


### PR DESCRIPTION
This adds several additional invalid tests which span the boundaries between linking / typing / cfg / cycle detection.  Specifically, where errors arise across two of these areas.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 97fe778339e747983a64bae430658fd9839eff35. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->