### PR TITLE
feat: support renaming and finding references in lsp

### DIFF
--- a/pkg/cmd/zkc/lsp.go
+++ b/pkg/cmd/zkc/lsp.go
@@ -249,6 +249,7 @@ func (s *zkcServer) Initialize(
 			DocumentSymbolProvider:     true,
 			DefinitionProvider:         true,
 			ReferencesProvider:         true,
+			RenameProvider:             &protocol.RenameOptions{PrepareProvider: true},
 			DocumentFormattingProvider: true,
 			SignatureHelpProvider: &protocol.SignatureHelpOptions{
 				TriggerCharacters: []string{"(", ","},
@@ -757,11 +758,20 @@ func (s *zkcServer) OnTypeFormatting(
 // rename is valid at the given position and, if so, what range should be
 // pre-selected in the rename input box. The server may reject the request if
 // the symbol cannot be renamed (e.g. it is a built-in).
-// Not yet implemented.
 func (s *zkcServer) PrepareRename(
-	_ context.Context, _ *protocol.PrepareRenameParams,
+	_ context.Context, params *protocol.PrepareRenameParams,
 ) (*protocol.Range, error) {
-	return nil, errNotImplemented
+	s.mu.RLock()
+	text, ok := s.compiler.Source(params.TextDocument.URI.Filename())
+	program := s.compiler.Program()
+	srcmaps := s.compiler.SourceMaps()
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil, nil
+	}
+
+	return lsp.PrepareRenameFor(params.TextDocument.URI, text, params.Position, program, srcmaps)
 }
 
 // RangeFormatting handles a textDocument/rangeFormatting request. The client
@@ -802,11 +812,24 @@ func (s *zkcServer) References(
 // the user confirms a rename operation (following an optional PrepareRename).
 // The server returns a workspace edit — a set of text changes across all
 // affected files — that renames every occurrence of the symbol.
-// Not yet implemented.
 func (s *zkcServer) Rename(
-	_ context.Context, _ *protocol.RenameParams,
+	_ context.Context, params *protocol.RenameParams,
 ) (*protocol.WorkspaceEdit, error) {
-	return nil, errNotImplemented
+	s.mu.RLock()
+	text, ok := s.compiler.Source(params.TextDocument.URI.Filename())
+	program := s.compiler.Program()
+	srcmaps := s.compiler.SourceMaps()
+	sourceOf := s.compiler.Source
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil, nil
+	}
+
+	return lsp.RenameFor(
+		params.TextDocument.URI, text, params.Position, params.NewName,
+		program, srcmaps, sourceOf,
+	)
 }
 
 // SignatureHelp handles a textDocument/signatureHelp request. The client

--- a/pkg/cmd/zkc/lsp.go
+++ b/pkg/cmd/zkc/lsp.go
@@ -248,6 +248,7 @@ func (s *zkcServer) Initialize(
 			HoverProvider:              true,
 			DocumentSymbolProvider:     true,
 			DefinitionProvider:         true,
+			ReferencesProvider:         true,
 			DocumentFormattingProvider: true,
 			SignatureHelpProvider: &protocol.SignatureHelpOptions{
 				TriggerCharacters: []string{"(", ","},
@@ -778,11 +779,23 @@ func (s *zkcServer) RangeFormatting(
 // when the user invokes "find all references" on a symbol. The server returns
 // every location in the workspace where that symbol is used, optionally
 // including the declaration site itself.
-// Not yet implemented.
 func (s *zkcServer) References(
-	_ context.Context, _ *protocol.ReferenceParams,
+	_ context.Context, params *protocol.ReferenceParams,
 ) ([]protocol.Location, error) {
-	return nil, errNotImplemented
+	s.mu.RLock()
+	text, ok := s.compiler.Source(params.TextDocument.URI.Filename())
+	program := s.compiler.Program()
+	srcmaps := s.compiler.SourceMaps()
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil, nil
+	}
+
+	return lsp.ReferencesFor(
+		params.TextDocument.URI, text, params.Position,
+		params.Context.IncludeDeclaration, program, srcmaps,
+	)
 }
 
 // Rename handles a textDocument/rename request. The client sends this when

--- a/pkg/cmd/zkc/lsp.go
+++ b/pkg/cmd/zkc/lsp.go
@@ -819,7 +819,6 @@ func (s *zkcServer) Rename(
 	text, ok := s.compiler.Source(params.TextDocument.URI.Filename())
 	program := s.compiler.Program()
 	srcmaps := s.compiler.SourceMaps()
-	sourceOf := s.compiler.Source
 	s.mu.RUnlock()
 
 	if !ok {
@@ -828,7 +827,7 @@ func (s *zkcServer) Rename(
 
 	return lsp.RenameFor(
 		params.TextDocument.URI, text, params.Position, params.NewName,
-		program, srcmaps, sourceOf,
+		program, srcmaps,
 	)
 }
 

--- a/pkg/cmd/zkc/lsp/definition.go
+++ b/pkg/cmd/zkc/lsp/definition.go
@@ -42,7 +42,7 @@ func DefinitionFor(
 	// Lex the document to find the identifier token under the cursor.
 	tokens := parser.Lex(*srcfile, false, false)
 
-	tok, ok := tokenAtOffset(tokens, offset)
+	tok, _, ok := tokenAtOffset(tokens, offset)
 	if !ok || tok.Kind != parser.IDENTIFIER {
 		return nil, nil
 	}

--- a/pkg/cmd/zkc/lsp/hover.go
+++ b/pkg/cmd/zkc/lsp/hover.go
@@ -41,7 +41,7 @@ func HoverFor(
 	// Lex the document to find the identifier token under the cursor.
 	tokens := parser.Lex(*srcfile, false, false)
 
-	tok, ok := tokenAtOffset(tokens, offset)
+	tok, _, ok := tokenAtOffset(tokens, offset)
 	if !ok || tok.Kind != parser.IDENTIFIER {
 		return nil, nil
 	}

--- a/pkg/cmd/zkc/lsp/references.go
+++ b/pkg/cmd/zkc/lsp/references.go
@@ -74,20 +74,7 @@ func ReferencesFor(
 	}
 
 	// Walk every declaration collecting AST nodes that reference the target.
-	var refs []any
-
-	for _, d := range program.Components() {
-		switch d := d.(type) {
-		case *decl.ResolvedFunction:
-			collectFunctionRefs(d, targetIdx, &refs)
-		case *decl.ResolvedConstant:
-			collectExprRefs(d.ConstExpr, targetIdx, &refs)
-		case *decl.ResolvedMemory:
-			for _, c := range d.Contents {
-				collectExprRefs(c, targetIdx, &refs)
-			}
-		}
-	}
+	refs := collectProgramRefs(program, targetIdx)
 
 	// Convert collected nodes to LSP locations, optionally prepending the
 	// declaration site itself.
@@ -140,6 +127,29 @@ func narrowToName(file source.File, span source.Span, name string) source.Span {
 	}
 
 	return span
+}
+
+// collectProgramRefs walks every declaration in the program and returns
+// the AST nodes which reference the declaration at index target. Used by
+// both find-references and rename to discover the use sites of a top-level
+// declaration.
+func collectProgramRefs(program ast.Program, target uint) []any {
+	var refs []any
+
+	for _, d := range program.Components() {
+		switch d := d.(type) {
+		case *decl.ResolvedFunction:
+			collectFunctionRefs(d, target, &refs)
+		case *decl.ResolvedConstant:
+			collectExprRefs(d.ConstExpr, target, &refs)
+		case *decl.ResolvedMemory:
+			for _, c := range d.Contents {
+				collectExprRefs(c, target, &refs)
+			}
+		}
+	}
+
+	return refs
 }
 
 // collectFunctionRefs gathers references to the target declaration appearing

--- a/pkg/cmd/zkc/lsp/references.go
+++ b/pkg/cmd/zkc/lsp/references.go
@@ -42,7 +42,7 @@ func ReferencesFor(
 	// Lex the document to find the identifier token under the cursor.
 	tokens := parser.Lex(*srcfile, false, false)
 
-	tok, ok := tokenAtOffset(tokens, offset)
+	tok, _, ok := tokenAtOffset(tokens, offset)
 	if !ok || tok.Kind != parser.IDENTIFIER {
 		return nil, nil
 	}

--- a/pkg/cmd/zkc/lsp/references.go
+++ b/pkg/cmd/zkc/lsp/references.go
@@ -1,0 +1,293 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package lsp
+
+import (
+	"github.com/consensys/go-corset/pkg/util/source"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/decl"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/expr"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/lval"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/stmt"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/symbol"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/parser"
+	"go.lsp.dev/protocol"
+	lspuri "go.lsp.dev/uri"
+)
+
+// ReferencesFor returns the locations of every use of the top-level
+// declaration named by the identifier under the cursor at pos.  When
+// includeDecl is true, the declaration's own site is included in the
+// results.  Returns nil when no identifier is under the cursor or when the
+// identifier does not name a top-level declaration.
+func ReferencesFor(
+	uri protocol.URI, text string, pos protocol.Position, includeDecl bool,
+	program ast.Program, srcmaps source.Maps[any],
+) ([]protocol.Location, error) {
+	srcfile := source.NewSourceFile(uri.Filename(), []byte(text))
+
+	// Convert LSP cursor position to a rune offset in the source file.
+	offset := posToOffset(*srcfile, pos)
+
+	// Lex the document to find the identifier token under the cursor.
+	tokens := parser.Lex(*srcfile, false, false)
+
+	tok, ok := tokenAtOffset(tokens, offset)
+	if !ok || tok.Kind != parser.IDENTIFIER {
+		return nil, nil
+	}
+
+	contents := srcfile.Contents()
+	name := string(contents[tok.Span.Start():tok.Span.End()])
+
+	// Locate the matching top-level declaration so we can match references by
+	// declaration index rather than by name. This lets us be robust to names
+	// that happen to coincide with local variables.
+	var (
+		targetIdx   uint
+		targetDecl  decl.Resolved
+		targetFound bool
+	)
+
+	for i, d := range program.Components() {
+		if d.Name() == name {
+			targetIdx = uint(i)
+			targetDecl = d
+			targetFound = true
+
+			break
+		}
+	}
+
+	if !targetFound {
+		return nil, nil
+	}
+
+	// Walk every declaration collecting AST nodes that reference the target.
+	var refs []any
+
+	for _, d := range program.Components() {
+		switch d := d.(type) {
+		case *decl.ResolvedFunction:
+			collectFunctionRefs(d, targetIdx, &refs)
+		case *decl.ResolvedConstant:
+			collectExprRefs(d.ConstExpr, targetIdx, &refs)
+		case *decl.ResolvedMemory:
+			for _, c := range d.Contents {
+				collectExprRefs(c, targetIdx, &refs)
+			}
+		}
+	}
+
+	// Convert collected nodes to LSP locations, optionally prepending the
+	// declaration site itself.
+	var locations []protocol.Location
+
+	if includeDecl {
+		if defFile, span, found := srcmaps.Lookup(targetDecl); found {
+			locations = append(locations, locationOf(defFile, narrowToName(defFile, span, name)))
+		}
+	}
+
+	for _, n := range refs {
+		if file, span, found := srcmaps.Lookup(n); found {
+			locations = append(locations, locationOf(file, narrowToName(file, span, name)))
+		}
+	}
+
+	return locations, nil
+}
+
+// locationOf converts a source file and span to an LSP Location.
+func locationOf(file source.File, span source.Span) protocol.Location {
+	return protocol.Location{
+		URI:   lspuri.File(file.Filename()),
+		Range: spanToRange(file, span),
+	}
+}
+
+// narrowToName returns the span of the first IDENTIFIER token within the
+// supplied span whose text equals name.  When no such token is found the
+// original span is returned unchanged. This gives editors a tight highlight
+// over just the symbol name rather than the enclosing call or memory access.
+func narrowToName(file source.File, span source.Span, name string) source.Span {
+	contents := file.Contents()
+	if span.End() > len(contents) {
+		return span
+	}
+
+	sub := source.NewSourceFile(file.Filename(), []byte(string(contents[span.Start():span.End()])))
+	tokens := parser.Lex(*sub, false, false)
+
+	for _, t := range tokens {
+		if t.Kind != parser.IDENTIFIER {
+			continue
+		}
+
+		if string(contents[span.Start()+t.Span.Start():span.Start()+t.Span.End()]) == name {
+			return source.NewSpan(span.Start()+t.Span.Start(), span.Start()+t.Span.End())
+		}
+	}
+
+	return span
+}
+
+// collectFunctionRefs gathers references to the target declaration appearing
+// in a function: its memory effects and any usage inside its body.
+func collectFunctionRefs(fn *decl.ResolvedFunction, target uint, out *[]any) {
+	for _, e := range fn.Effects {
+		if e != nil && e.Index == target {
+			*out = append(*out, e)
+		}
+	}
+
+	for _, s := range fn.Code {
+		collectStmtRefs(s, target, out)
+	}
+}
+
+// collectStmtRefs walks a statement and any nested statements/expressions for
+// references to the target declaration.
+func collectStmtRefs(s stmt.Resolved, target uint, out *[]any) {
+	switch s := s.(type) {
+	case *stmt.Assign[symbol.Resolved]:
+		for _, lv := range s.Targets {
+			collectLValRefs(lv, target, out)
+		}
+
+		collectExprRefs(s.Source, target, out)
+	case *stmt.For[symbol.Resolved]:
+		if s.Init != nil {
+			collectStmtRefs(s.Init, target, out)
+		}
+
+		collectExprRefs(s.Cond, target, out)
+
+		if s.Post != nil {
+			collectStmtRefs(s.Post, target, out)
+		}
+
+		for _, b := range s.Body {
+			collectStmtRefs(b, target, out)
+		}
+	case *stmt.IfElse[symbol.Resolved]:
+		collectExprRefs(s.Cond, target, out)
+
+		for _, b := range s.TrueBranch {
+			collectStmtRefs(b, target, out)
+		}
+
+		for _, b := range s.FalseBranch {
+			collectStmtRefs(b, target, out)
+		}
+	case *stmt.IfGoto[symbol.Resolved]:
+		if cmp, ok := s.Cond.(*expr.Cmp[symbol.Resolved]); ok {
+			collectExprRefs(cmp, target, out)
+		}
+	case *stmt.Printf[symbol.Resolved]:
+		for _, a := range s.Arguments {
+			collectExprRefs(a, target, out)
+		}
+	case *stmt.VarDecl[symbol.Resolved]:
+		if s.Init.HasValue() {
+			collectExprRefs(s.Init.Unwrap(), target, out)
+		}
+	case *stmt.While[symbol.Resolved]:
+		collectExprRefs(s.Cond, target, out)
+
+		for _, b := range s.Body {
+			collectStmtRefs(b, target, out)
+		}
+	}
+}
+
+// collectLValRefs walks an lvalue for references to the target declaration.
+// MemAccess lvalues both reference the memory by name and contain index
+// expressions which may themselves reference further declarations.
+func collectLValRefs(lv lval.Resolved, target uint, out *[]any) {
+	if mem, ok := lv.(*lval.MemAccess[symbol.Resolved]); ok {
+		if mem.Name.Index == target {
+			*out = append(*out, mem)
+		}
+
+		for _, a := range mem.Args {
+			collectExprRefs(a, target, out)
+		}
+	}
+}
+
+// collectExprRefs walks an expression and any sub-expressions for references
+// to the target declaration. ExternAccess is the only leaf form that names a
+// top-level declaration; the remaining cases simply recurse into their
+// operands.
+func collectExprRefs(e expr.Resolved, target uint, out *[]any) {
+	if e == nil {
+		return
+	}
+
+	switch e := e.(type) {
+	case *expr.ExternAccess[symbol.Resolved]:
+		if e.Name.Index == target {
+			*out = append(*out, e)
+		}
+
+		for _, a := range e.Args {
+			collectExprRefs(a, target, out)
+		}
+	case *expr.Add[symbol.Resolved]:
+		collectExprListRefs(e.Exprs, target, out)
+	case *expr.BitwiseAnd[symbol.Resolved]:
+		collectExprListRefs(e.Exprs, target, out)
+	case *expr.BitwiseOr[symbol.Resolved]:
+		collectExprListRefs(e.Exprs, target, out)
+	case *expr.BitwiseNot[symbol.Resolved]:
+		collectExprRefs(e.Expr, target, out)
+	case *expr.Cast[symbol.Resolved]:
+		collectExprRefs(e.Expr, target, out)
+	case *expr.Cmp[symbol.Resolved]:
+		collectExprRefs(e.Left, target, out)
+		collectExprRefs(e.Right, target, out)
+	case *expr.Concat[symbol.Resolved]:
+		collectExprListRefs(e.Exprs, target, out)
+	case *expr.Div[symbol.Resolved]:
+		collectExprListRefs(e.Exprs, target, out)
+	case *expr.LogicalAnd[symbol.Resolved]:
+		collectExprListRefs(e.Exprs, target, out)
+	case *expr.LogicalNot[symbol.Resolved]:
+		collectExprRefs(e.Expr, target, out)
+	case *expr.LogicalOr[symbol.Resolved]:
+		collectExprListRefs(e.Exprs, target, out)
+	case *expr.Mul[symbol.Resolved]:
+		collectExprListRefs(e.Exprs, target, out)
+	case *expr.Rem[symbol.Resolved]:
+		collectExprListRefs(e.Exprs, target, out)
+	case *expr.Shl[symbol.Resolved]:
+		collectExprListRefs(e.Exprs, target, out)
+	case *expr.Shr[symbol.Resolved]:
+		collectExprListRefs(e.Exprs, target, out)
+	case *expr.Sub[symbol.Resolved]:
+		collectExprListRefs(e.Exprs, target, out)
+	case *expr.Ternary[symbol.Resolved]:
+		collectExprRefs(e.Cond, target, out)
+		collectExprRefs(e.IfTrue, target, out)
+		collectExprRefs(e.IfFalse, target, out)
+	case *expr.Xor[symbol.Resolved]:
+		collectExprListRefs(e.Exprs, target, out)
+	}
+}
+
+func collectExprListRefs(exprs []expr.Resolved, target uint, out *[]any) {
+	for _, e := range exprs {
+		collectExprRefs(e, target, out)
+	}
+}

--- a/pkg/cmd/zkc/lsp/rename.go
+++ b/pkg/cmd/zkc/lsp/rename.go
@@ -1,0 +1,325 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package lsp
+
+import (
+	"fmt"
+
+	"github.com/consensys/go-corset/pkg/util/source"
+	"github.com/consensys/go-corset/pkg/util/source/lex"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/decl"
+	"github.com/consensys/go-corset/pkg/zkc/compiler/parser"
+	"go.lsp.dev/protocol"
+	lspuri "go.lsp.dev/uri"
+)
+
+// PrepareRenameFor returns the range of the identifier under the cursor when
+// it names something the server knows how to rename: a top-level declaration
+// (function, constant, memory, type alias) or a local variable in the
+// enclosing function. Returns nil for any other token, signalling the editor
+// not to start a rename session.
+func PrepareRenameFor(
+	uri protocol.URI, text string, pos protocol.Position,
+	program ast.Program, srcmaps source.Maps[any],
+) (*protocol.Range, error) {
+	srcfile := source.NewSourceFile(uri.Filename(), []byte(text))
+	offset := posToOffset(*srcfile, pos)
+	tokens := parser.Lex(*srcfile, false, false)
+
+	tok, ok := tokenAtOffset(tokens, offset)
+	if !ok || tok.Kind != parser.IDENTIFIER {
+		return nil, nil
+	}
+
+	contents := srcfile.Contents()
+	name := string(contents[tok.Span.Start():tok.Span.End()])
+
+	if isTopLevelDecl(name, program) || isLocalVariable(name, offset, *srcfile, program, srcmaps) {
+		rng := spanToRange(*srcfile, tok.Span)
+		return &rng, nil
+	}
+
+	return nil, nil
+}
+
+// RenameFor produces a workspace edit which renames the identifier under the
+// cursor to newName.  Top-level declarations are renamed across every file in
+// the program; local variables (parameters, returns, and `var` bindings) are
+// renamed only within the enclosing function.  Returns nil when no rename is
+// possible — the cursor is not on a renameable identifier, newName is not a
+// valid identifier, or newName equals the existing name.
+func RenameFor(
+	uri protocol.URI, text string, pos protocol.Position, newName string,
+	program ast.Program, srcmaps source.Maps[any],
+	sourceOf func(filename string) (string, bool),
+) (*protocol.WorkspaceEdit, error) {
+	if !parser.IsValidIdentifier(newName) {
+		return nil, fmt.Errorf("invalid identifier: %q", newName)
+	}
+
+	srcfile := source.NewSourceFile(uri.Filename(), []byte(text))
+	offset := posToOffset(*srcfile, pos)
+	tokens := parser.Lex(*srcfile, false, false)
+
+	tok, ok := tokenAtOffset(tokens, offset)
+	if !ok || tok.Kind != parser.IDENTIFIER {
+		return nil, nil
+	}
+
+	contents := srcfile.Contents()
+	oldName := string(contents[tok.Span.Start():tok.Span.End()])
+
+	if oldName == newName {
+		return nil, nil
+	}
+
+	// Top-level declarations take precedence: they're shared across files
+	// and shadow any same-named local visible at the cursor (the parser
+	// would have rejected such a clash anyway).
+	for i, d := range program.Components() {
+		if d.Name() == oldName {
+			return renameTopLevel(d, uint(i), oldName, newName, program, srcmaps), nil
+		}
+	}
+
+	// Otherwise see whether the cursor is inside a function with a local of
+	// that name and rename within that function only.
+	if fn, fnFile, fnSpan := enclosingFunction(offset, *srcfile, program, srcmaps); fn != nil {
+		if hasLocal(fn, oldName) {
+			return renameLocal(fnFile, fnSpan, oldName, newName, sourceOf), nil
+		}
+	}
+
+	return nil, nil
+}
+
+// renameTopLevel constructs a workspace edit which renames every reference to
+// the given top-level declaration across all files in the program, plus the
+// declaration's own name.
+func renameTopLevel(
+	target decl.Resolved, targetIdx uint, oldName, newName string,
+	program ast.Program, srcmaps source.Maps[any],
+) *protocol.WorkspaceEdit {
+	// Collect AST nodes that reference the target — same traversal as
+	// ReferencesFor, but always including the declaration site.
+	var refs []any
+
+	for _, d := range program.Components() {
+		switch d := d.(type) {
+		case *decl.ResolvedFunction:
+			collectFunctionRefs(d, targetIdx, &refs)
+		case *decl.ResolvedConstant:
+			collectExprRefs(d.ConstExpr, targetIdx, &refs)
+		case *decl.ResolvedMemory:
+			for _, c := range d.Contents {
+				collectExprRefs(c, targetIdx, &refs)
+			}
+		}
+	}
+
+	changes := make(map[protocol.DocumentURI][]protocol.TextEdit)
+
+	addEdit := func(file source.File, span source.Span) {
+		uri := lspuri.File(file.Filename())
+		changes[uri] = append(changes[uri], protocol.TextEdit{
+			Range:   spanToRange(file, span),
+			NewText: newName,
+		})
+	}
+
+	if defFile, span, found := srcmaps.Lookup(target); found {
+		addEdit(defFile, narrowToName(defFile, span, oldName))
+	}
+
+	for _, n := range refs {
+		if file, span, found := srcmaps.Lookup(n); found {
+			addEdit(file, narrowToName(file, span, oldName))
+		}
+	}
+
+	if len(changes) == 0 {
+		return nil
+	}
+
+	return &protocol.WorkspaceEdit{Changes: changes}
+}
+
+// renameLocal constructs a workspace edit which renames every occurrence of
+// oldName within the supplied function span. Identifier tokens immediately
+// followed by `(` or `[` are skipped, since those are extern accesses (calls
+// and memory reads/writes) which cannot refer to a local.
+func renameLocal(
+	fnFile source.File, fnSpan source.Span, oldName, newName string,
+	sourceOf func(filename string) (string, bool),
+) *protocol.WorkspaceEdit {
+	contents, ok := sourceOf(fnFile.Filename())
+	if !ok {
+		contents = string(fnFile.Contents())
+	}
+
+	full := source.NewSourceFile(fnFile.Filename(), []byte(contents))
+	tokens := parser.Lex(*full, false, false)
+
+	var edits []protocol.TextEdit
+
+	for i, t := range tokens {
+		if t.Kind != parser.IDENTIFIER {
+			continue
+		}
+
+		if t.Span.Start() < fnSpan.Start() || t.Span.End() > fnSpan.End() {
+			continue
+		}
+
+		text := string(full.Contents()[t.Span.Start():t.Span.End()])
+		if text != oldName {
+			continue
+		}
+
+		// Skip extern accesses — name(...) and name[...] are always resolved
+		// against top-level declarations regardless of any local of the same
+		// name (the parser refuses to declare a local clashing with one).
+		if next, ok := nextSignificantToken(tokens, i); ok {
+			if next.Kind == parser.LBRACE || next.Kind == parser.LSQUARE {
+				continue
+			}
+		}
+
+		edits = append(edits, protocol.TextEdit{
+			Range:   spanToRange(*full, t.Span),
+			NewText: newName,
+		})
+	}
+
+	if len(edits) == 0 {
+		return nil
+	}
+
+	uri := lspuri.File(fnFile.Filename())
+
+	return &protocol.WorkspaceEdit{
+		Changes: map[protocol.DocumentURI][]protocol.TextEdit{
+			uri: edits,
+		},
+	}
+}
+
+// isTopLevelDecl reports whether name matches a top-level declaration in the
+// program.
+func isTopLevelDecl(name string, program ast.Program) bool {
+	for _, d := range program.Components() {
+		if d.Name() == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isLocalVariable reports whether name is a local variable (parameter,
+// return, or `var` binding) in the function whose source span contains
+// offset.
+func isLocalVariable(
+	name string, offset int, srcfile source.File,
+	program ast.Program, srcmaps source.Maps[any],
+) bool {
+	fn, _, _ := enclosingFunction(offset, srcfile, program, srcmaps)
+	return fn != nil && hasLocal(fn, name)
+}
+
+// enclosingFunction returns the function whose source span contains offset
+// in srcfile, along with the file and the span covering both its signature
+// and body. The parser only records the signature in the source map, so we
+// extend the recorded span by brace-matching forward to the close of the
+// body. Returns nil for fn when no function encloses the cursor.
+func enclosingFunction(
+	offset int, srcfile source.File, program ast.Program, srcmaps source.Maps[any],
+) (*decl.ResolvedFunction, source.File, source.Span) {
+	for _, d := range program.Components() {
+		fn, ok := d.(*decl.ResolvedFunction)
+		if !ok {
+			continue
+		}
+
+		fnFile, fnSpan, found := srcmaps.Lookup(d)
+		if !found || fnFile.Filename() != srcfile.Filename() {
+			continue
+		}
+
+		full := extendToBody(fnFile, fnSpan)
+
+		if offset < full.Start() || offset >= full.End() {
+			continue
+		}
+
+		return fn, fnFile, full
+	}
+
+	return nil, source.File{}, source.Span{}
+}
+
+// extendToBody returns a span that covers both the signature span passed in
+// and the function body's `{ ... }` block which immediately follows it. When
+// no balanced body block can be located the signature span is returned
+// unchanged.
+func extendToBody(file source.File, signature source.Span) source.Span {
+	contents := file.Contents()
+
+	if signature.End() > len(contents) {
+		return signature
+	}
+
+	sub := source.NewSourceFile(file.Filename(), []byte(string(contents[signature.End():])))
+	tokens := parser.Lex(*sub, false, false)
+
+	var depth int
+
+	for _, t := range tokens {
+		switch t.Kind {
+		case parser.LCURLY:
+			depth++
+		case parser.RCURLY:
+			depth--
+
+			if depth == 0 {
+				return source.NewSpan(signature.Start(), signature.End()+t.Span.End())
+			}
+		}
+	}
+
+	return signature
+}
+
+// hasLocal reports whether the function declares a local variable
+// (parameter, return, or `var` binding) named name.
+func hasLocal(fn *decl.ResolvedFunction, name string) bool {
+	for _, v := range fn.Variables {
+		if v.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// nextSignificantToken returns the next token in tokens after index i,
+// skipping nothing — Lex(false, false) already strips whitespace and
+// comments. Returns ok=false when there is no following token.
+func nextSignificantToken(tokens []lex.Token, i int) (lex.Token, bool) {
+	if i+1 < len(tokens) {
+		return tokens[i+1], true
+	}
+
+	return lex.Token{}, false
+}

--- a/pkg/cmd/zkc/lsp/rename.go
+++ b/pkg/cmd/zkc/lsp/rename.go
@@ -62,7 +62,6 @@ func PrepareRenameFor(
 func RenameFor(
 	uri protocol.URI, text string, pos protocol.Position, newName string,
 	program ast.Program, srcmaps source.Maps[any],
-	sourceOf func(filename string) (string, bool),
 ) (*protocol.WorkspaceEdit, error) {
 	if !parser.IsValidIdentifier(newName) {
 		return nil, fmt.Errorf("invalid identifier: %q", newName)
@@ -94,7 +93,7 @@ func RenameFor(
 	if !externAccess {
 		if fn, fnFile, fnSpan := enclosingFunction(offset, *srcfile, program, srcmaps); fn != nil {
 			if hasLocal(fn, oldName) {
-				return renameLocal(fnFile, fnSpan, oldName, newName, sourceOf), nil
+				return renameLocal(fnFile, fnSpan, oldName, newName), nil
 			}
 		}
 	}
@@ -116,22 +115,9 @@ func renameTopLevel(
 	target decl.Resolved, targetIdx uint, oldName, newName string,
 	program ast.Program, srcmaps source.Maps[any],
 ) *protocol.WorkspaceEdit {
-	// Collect AST nodes that reference the target — same traversal as
-	// ReferencesFor, but always including the declaration site.
-	var refs []any
-
-	for _, d := range program.Components() {
-		switch d := d.(type) {
-		case *decl.ResolvedFunction:
-			collectFunctionRefs(d, targetIdx, &refs)
-		case *decl.ResolvedConstant:
-			collectExprRefs(d.ConstExpr, targetIdx, &refs)
-		case *decl.ResolvedMemory:
-			for _, c := range d.Contents {
-				collectExprRefs(c, targetIdx, &refs)
-			}
-		}
-	}
+	// Collect AST nodes that reference the target — the declaration site
+	// itself is added separately below.
+	refs := collectProgramRefs(program, targetIdx)
 
 	changes := make(map[protocol.DocumentURI][]protocol.TextEdit)
 
@@ -166,15 +152,8 @@ func renameTopLevel(
 // and memory reads/writes) which cannot refer to a local.
 func renameLocal(
 	fnFile source.File, fnSpan source.Span, oldName, newName string,
-	sourceOf func(filename string) (string, bool),
 ) *protocol.WorkspaceEdit {
-	contents, ok := sourceOf(fnFile.Filename())
-	if !ok {
-		contents = string(fnFile.Contents())
-	}
-
-	full := source.NewSourceFile(fnFile.Filename(), []byte(contents))
-	tokens := parser.Lex(*full, false, false)
+	tokens := parser.Lex(fnFile, false, false)
 
 	var edits []protocol.TextEdit
 
@@ -187,7 +166,7 @@ func renameLocal(
 			continue
 		}
 
-		text := string(full.Contents()[t.Span.Start():t.Span.End()])
+		text := string(fnFile.Contents()[t.Span.Start():t.Span.End()])
 		if text != oldName {
 			continue
 		}
@@ -200,7 +179,7 @@ func renameLocal(
 		}
 
 		edits = append(edits, protocol.TextEdit{
-			Range:   spanToRange(*full, t.Span),
+			Range:   spanToRange(fnFile, t.Span),
 			NewText: newName,
 		})
 	}

--- a/pkg/cmd/zkc/lsp/rename.go
+++ b/pkg/cmd/zkc/lsp/rename.go
@@ -37,7 +37,7 @@ func PrepareRenameFor(
 	offset := posToOffset(*srcfile, pos)
 	tokens := parser.Lex(*srcfile, false, false)
 
-	tok, ok := tokenAtOffset(tokens, offset)
+	tok, _, ok := tokenAtOffset(tokens, offset)
 	if !ok || tok.Kind != parser.IDENTIFIER {
 		return nil, nil
 	}
@@ -72,7 +72,7 @@ func RenameFor(
 	offset := posToOffset(*srcfile, pos)
 	tokens := parser.Lex(*srcfile, false, false)
 
-	tok, ok := tokenAtOffset(tokens, offset)
+	tok, idx, ok := tokenAtOffset(tokens, offset)
 	if !ok || tok.Kind != parser.IDENTIFIER {
 		return nil, nil
 	}
@@ -84,20 +84,25 @@ func RenameFor(
 		return nil, nil
 	}
 
-	// Top-level declarations take precedence: they're shared across files
-	// and shadow any same-named local visible at the cursor (the parser
-	// would have rejected such a clash anyway).
-	for i, d := range program.Components() {
-		if d.Name() == oldName {
-			return renameTopLevel(d, uint(i), oldName, newName, program, srcmaps), nil
+	// An identifier directly followed by `(` or `[` is always an extern
+	// access — a function call or memory read/write — and so refers to a
+	// top-level declaration regardless of any same-named local in scope.
+	externAccess := isExternAccess(tokens, idx)
+
+	// Inside a function, a local of the same name shadows any top-level
+	// declaration — so prefer the local unless we're on an extern access.
+	if !externAccess {
+		if fn, fnFile, fnSpan := enclosingFunction(offset, *srcfile, program, srcmaps); fn != nil {
+			if hasLocal(fn, oldName) {
+				return renameLocal(fnFile, fnSpan, oldName, newName, sourceOf), nil
+			}
 		}
 	}
 
-	// Otherwise see whether the cursor is inside a function with a local of
-	// that name and rename within that function only.
-	if fn, fnFile, fnSpan := enclosingFunction(offset, *srcfile, program, srcmaps); fn != nil {
-		if hasLocal(fn, oldName) {
-			return renameLocal(fnFile, fnSpan, oldName, newName, sourceOf), nil
+	// Otherwise the identifier names a top-level declaration.
+	for i, d := range program.Components() {
+		if d.Name() == oldName {
+			return renameTopLevel(d, uint(i), oldName, newName, program, srcmaps), nil
 		}
 	}
 
@@ -187,13 +192,11 @@ func renameLocal(
 			continue
 		}
 
-		// Skip extern accesses — name(...) and name[...] are always resolved
-		// against top-level declarations regardless of any local of the same
-		// name (the parser refuses to declare a local clashing with one).
-		if next, ok := nextSignificantToken(tokens, i); ok {
-			if next.Kind == parser.LBRACE || next.Kind == parser.LSQUARE {
-				continue
-			}
+		// Skip extern accesses — name(...) and name[...] are always
+		// resolved against top-level declarations even when a local of
+		// the same name is in scope.
+		if isExternAccess(tokens, i) {
+			continue
 		}
 
 		edits = append(edits, protocol.TextEdit{
@@ -313,13 +316,16 @@ func hasLocal(fn *decl.ResolvedFunction, name string) bool {
 	return false
 }
 
-// nextSignificantToken returns the next token in tokens after index i,
-// skipping nothing — Lex(false, false) already strips whitespace and
-// comments. Returns ok=false when there is no following token.
-func nextSignificantToken(tokens []lex.Token, i int) (lex.Token, bool) {
-	if i+1 < len(tokens) {
-		return tokens[i+1], true
+// isExternAccess reports whether the token at index i in tokens is followed
+// by `(` or `[` — the syntactic shapes for a function call and a memory
+// read/write respectively. Such a use always resolves to a top-level
+// declaration even when a same-named local is in scope.
+func isExternAccess(tokens []lex.Token, i int) bool {
+	if i < 0 || i+1 >= len(tokens) {
+		return false
 	}
 
-	return lex.Token{}, false
+	next := tokens[i+1].Kind
+
+	return next == parser.LBRACE || next == parser.LSQUARE
 }

--- a/pkg/cmd/zkc/lsp/util.go
+++ b/pkg/cmd/zkc/lsp/util.go
@@ -63,16 +63,16 @@ func posToOffset(srcfile source.File, pos protocol.Position) int {
 }
 
 // tokenAtOffset finds the token whose span contains the given rune offset,
-// returning it and true.  If no token spans that offset, a zero Token and
-// false are returned.
-func tokenAtOffset(tokens []lex.Token, offset int) (lex.Token, bool) {
-	for _, tok := range tokens {
+// returning it, its index in tokens, and true.  If no token spans that
+// offset, a zero Token, -1, and false are returned.
+func tokenAtOffset(tokens []lex.Token, offset int) (lex.Token, int, bool) {
+	for i, tok := range tokens {
 		if tok.Span.Start() <= offset && offset < tok.Span.End() {
-			return tok, true
+			return tok, i, true
 		}
 	}
 
-	return lex.Token{}, false
+	return lex.Token{}, -1, false
 }
 
 // dataTypeToString converts a data type to its string representation. A nil

--- a/pkg/zkc/compiler/parser/lexer.go
+++ b/pkg/zkc/compiler/parser/lexer.go
@@ -327,6 +327,18 @@ func Lex(srcfile source.File, whitespace, comments bool) []lex.Token {
 	return tokens
 }
 
+// IsValidIdentifier reports whether s parses as a single IDENTIFIER token,
+// rejecting empty strings, keywords, and anything containing whitespace or
+// punctuation.
+func IsValidIdentifier(s string) bool {
+	var (
+		runes = []rune(s)
+		n     = identifier(runes)
+	)
+	//
+	return n == uint(len(runes)) && len(runes) > 0
+}
+
 func init() {
 	// Statically compute maximum length of any keyword
 	for k := range keywords {

--- a/pkg/zkc/compiler/parser/lexer.go
+++ b/pkg/zkc/compiler/parser/lexer.go
@@ -336,7 +336,13 @@ func IsValidIdentifier(s string) bool {
 		n     = identifier(runes)
 	)
 	//
-	return n == uint(len(runes)) && len(runes) > 0
+	if n != uint(len(runes)) || len(runes) == 0 {
+		return false
+	}
+	//
+	_, isKeyword := keywords[s]
+
+	return !isKeyword
 }
 
 func init() {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4681b1086363e247bd0f6be4146323b910b0af5f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->