### PR TITLE
feat: add binary search tree benchmark

### DIFF
--- a/pkg/test/zkc_bench_test.go
+++ b/pkg/test/zkc_bench_test.go
@@ -24,7 +24,9 @@ import (
 func Test_ZkcBench_Blake(t *testing.T) {
 	checkZkcBench(t, "zkc/bench/blake")
 }
-
+func Test_ZkcBench_BinarySearchTree(t *testing.T) {
+	checkZkcBench(t, "zkc/bench/bsearch_tree")
+}
 func Test_ZkcBench_Fnv1aHash(t *testing.T) {
 	checkZkcBench(t, "zkc/bench/fnv1a_hash")
 }

--- a/testdata/zkc/bench/bsearch_tree.accepts
+++ b/testdata/zkc/bench/bsearch_tree.accepts
@@ -1,0 +1,22 @@
+{ "ins": "0x00", "outs": "0x00", "nodes_val": "0x", "nodes_left": "0xff", "nodes_right": "0xff" }
+{ "ins": "0x01_00", "outs": "0x03_01_23_e0", "nodes_val": "0x00", "nodes_left": "0xff", "nodes_right": "0xff" }
+;;
+;;   00
+;;     \
+;;      ab
+;;
+{ "ins": "0x02_00_ab", "outs": "0x03_01_88_ac", "nodes_val": "0x00_ab", "nodes_left": "0xff_ff", "nodes_right": "0x01_ff" }
+;;
+;;   0a
+;;  /  \
+;; 01  ab
+;;
+{ "ins": "0x03_01_ab_0a", "outs": "0x09_00_02_03_04_05_06_07_08_09", "nodes_val": "0x0a_ab_01", "nodes_left": "0x02_ff_ff", "nodes_right": "0x01_ff_ff" }
+;;
+;;     0a
+;;    /  \
+;;   05  ab
+;;  /  \
+;; 01  08
+;;
+{ "ins": "0x05_01_ab_0a_05_08", "outs": "0x0a_00_02_03_04_06_07_09_0b_aa_ac", "nodes_val": "0x0a_ab_05_01_08", "nodes_left": "0x02_ff_03_ff_ff", "nodes_right": "0x01_ff_04_ff_ff" }

--- a/testdata/zkc/bench/bsearch_tree.zkc
+++ b/testdata/zkc/bench/bsearch_tree.zkc
@@ -1,0 +1,55 @@
+const NIL:u8 = 0xFF
+
+// =============================================================================
+// Test Harness
+// =============================================================================
+
+pub input ins(address:u8) -> (value:u8)
+pub input outs(address:u8) -> (value:u8)
+
+fn main() {
+    var n_ins:u8 = ins[0]
+    var n_outs:u8 = outs[0]
+    // run containment checks
+    for i:u8 = 0; i<n_ins; i = i + 1 {
+        if contains(ins[i + 1], 0) == 0 {
+            fail
+        }
+    }
+    // run non-containment checks
+    for i:u8 = 0; i<n_outs; i = i + 1 {
+        if contains(outs[i + 1], 0) == 1 {
+            fail
+        }
+    }
+}
+
+// =============================================================================
+// Binary Search Tree
+// =============================================================================
+
+// An array of nodes whose left / right values are either: (1) indexes back into
+// the array; or (2) terminators signalted by 0xFFFF.
+input nodes_val(address:u8) -> (value:u8)
+input nodes_left(address:u8) -> (left:u8)
+input nodes_right(address:u8) -> (right:u8)
+
+// Check whether the given value is stored in the tree rooted at ptr,
+// returning 1=true or 0=false otherwise.
+fn contains(value:u8, ptr:u8) -> (res:u1) {
+    var v:u8
+    // Check for empty tree
+    if ptr == NIL {
+        res = 0
+        return
+    }
+    v = nodes_val[ptr]
+    // Check whether we found it or, if not, which branch to traverse.
+    if v == value {
+        res = 1
+    } else if v>value {
+        res = contains(value, nodes_left[ptr])
+    } else {
+        res = contains(value, nodes_right[ptr])
+    }
+}


### PR DESCRIPTION
This adds a binary search tree benchmark which, albeit a bit cumbersome, illustrates the potential for representing tree-like structures in ZkC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new benchmark + fixtures without changing core compiler/runtime behavior; risk is limited to test/benchmark coverage and potential test flakiness from incorrect fixtures.
> 
> **Overview**
> Adds a new `bsearch_tree` ZkC benchmark and wires it into the Go benchmark test suite via `Test_ZkcBench_BinarySearchTree`.
> 
> The new benchmark program models a binary search tree using array-backed node inputs and validates membership/non-membership via recursive `contains`, with accompanying `.accepts` fixtures covering several tree shapes and queries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdae49a7d3982ff12848ea9c8f160cfa61fcab15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->