### PR TITLE
feat: support annotation descriptions

### DIFF
--- a/pkg/cmd/zkc/lsp/hover.go
+++ b/pkg/cmd/zkc/lsp/hover.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/consensys/go-corset/pkg/util/source"
+	"github.com/consensys/go-corset/pkg/util/source/lex"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/data"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/decl"
@@ -41,13 +42,24 @@ func HoverFor(
 	// Lex the document to find the identifier token under the cursor.
 	tokens := parser.Lex(*srcfile, false, false)
 
-	tok, _, ok := tokenAtOffset(tokens, offset)
-	if !ok || tok.Kind != parser.IDENTIFIER {
+	tok, idx, ok := tokenAtOffset(tokens, offset)
+	if !ok {
+		return nil, nil
+	}
+
+	contents := srcfile.Contents()
+
+	// Annotations (e.g. @inline) take precedence: the cursor may be on the
+	// '@' symbol or on the identifier immediately following it.
+	if h := hoverAnnotation(tokens, idx, contents); h != nil {
+		return h, nil
+	}
+
+	if tok.Kind != parser.IDENTIFIER {
 		return nil, nil
 	}
 
 	// Extract the identifier text.
-	contents := srcfile.Contents()
 	name := string(contents[tok.Span.Start():tok.Span.End()])
 
 	env := program.Environment()
@@ -83,6 +95,40 @@ func HoverFor(
 	}
 
 	return nil, nil
+}
+
+// hoverAnnotation returns hover content if the token at idx is part of an
+// annotation usage — either the '@' symbol itself or the identifier
+// immediately after it. Returns nil otherwise, or when the annotation name is
+// not registered in decl.ANNOTATIONS.
+func hoverAnnotation(tokens []lex.Token, idx int, contents []rune) *protocol.Hover {
+	var nameTok lex.Token
+
+	switch {
+	case tokens[idx].Kind == parser.AT && idx+1 < len(tokens) && tokens[idx+1].Kind == parser.IDENTIFIER:
+		nameTok = tokens[idx+1]
+	case tokens[idx].Kind == parser.IDENTIFIER && idx > 0 && tokens[idx-1].Kind == parser.AT:
+		nameTok = tokens[idx]
+	default:
+		return nil
+	}
+
+	name := string(contents[nameTok.Span.Start():nameTok.Span.End()])
+
+	for _, ann := range decl.ANNOTATIONS {
+		if ann.Name() == name {
+			value := "```zkc\n@" + ann.Name() + "\n```\n\n" + ann.Description()
+			//
+			return &protocol.Hover{
+				Contents: protocol.MarkupContent{
+					Kind:  protocol.Markdown,
+					Value: value,
+				},
+			}
+		}
+	}
+
+	return nil
 }
 
 // hoverLocalVariable searches for a local variable named name inside the

--- a/pkg/zkc/compiler/ast/decl/annotation.go
+++ b/pkg/zkc/compiler/ast/decl/annotation.go
@@ -34,20 +34,29 @@ const (
 type Annotation struct {
 	// name is the annotation identifier (e.g. "inline" for "@inline").
 	name string
+	// description explains what the annotation is for, used in documentation
+	// and error messages.
+	description string
 	// permitted is a bitmask of the DeclarationKind values on which this
 	// annotation is allowed.
 	permitted DeclarationKind
 }
 
-// NewAnnotation constructs an Annotation schema with the given name and the
-// set of declaration kinds on which it is permitted.
-func NewAnnotation(name string, permitted DeclarationKind) Annotation {
-	return Annotation{name: name, permitted: permitted}
+// NewAnnotation constructs an Annotation schema with the given name,
+// description, and the set of declaration kinds on which it is permitted.
+func NewAnnotation(name, description string, permitted DeclarationKind) Annotation {
+	return Annotation{name: name, description: description, permitted: permitted}
 }
 
 // Name returns the annotation's name without the leading '@'.
 func (a Annotation) Name() string {
 	return a.name
+}
+
+// Description returns a human-readable description of what the annotation is
+// for.
+func (a Annotation) Description() string {
+	return a.description
 }
 
 // Permits reports whether this annotation is allowed on a declaration of the
@@ -80,5 +89,5 @@ func (k DeclarationKind) String() string {
 // appear.
 var ANNOTATIONS = []Annotation{
 	// @inline is permitted only on function declarations.
-	NewAnnotation("inline", FUNCTION_KIND),
+	NewAnnotation("inline", "marks a function to be inlined at every call site", FUNCTION_KIND),
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small additive changes to annotation metadata and LSP hover behavior, with no auth/security or data persistence impact. Main risk is minor UI/UX regressions in hover token detection and markdown formatting.
> 
> **Overview**
> Adds annotation descriptions to the `decl.Annotation` schema (new `description` field, `Description()` accessor) and updates `NewAnnotation`/`decl.ANNOTATIONS` to supply that text.
> 
> Enhances LSP `HoverFor` to recognize `@annotation` usage (cursor on `@` or the following identifier) and display a dedicated hover popup showing the annotation and its description, before falling back to identifier-based hovers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcee64ee0887fe8b858ced4e78bf55cd9756c1e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->