### PR TITLE
fix: various typo fixes

### DIFF
--- a/pkg/asm/assembler/lexer.go
+++ b/pkg/asm/assembler/lexer.go
@@ -45,7 +45,7 @@ const COMMA uint = 7
 // COLON signals ":"
 const COLON uint = 8
 
-// SEMICOLON signals ":"
+// SEMICOLON signals ";"
 const SEMICOLON uint = 9
 
 // NUMBER signals an integer number

--- a/pkg/zkc/compiler/parser/lexer.go
+++ b/pkg/zkc/compiler/parser/lexer.go
@@ -45,7 +45,7 @@ const (
 	COLON
 	// COLONCOLON signals "::"
 	COLONCOLON
-	// SEMICOLON signals ":"
+	// SEMICOLON signals ";"
 	SEMICOLON
 	// NUMBER signals an integer number
 	NUMBER

--- a/pkg/zkc/compiler/parser/parser.go
+++ b/pkg/zkc/compiler/parser/parser.go
@@ -161,6 +161,8 @@ func (p *Parser) parseDeclaration() ([]decl.Declaration[symbol.Unresolved], []so
 	case KEYWORD_TYPE:
 		kind = decl.TYPE_ALIAS_KIND
 		components[0], errors = p.parseTypeAlias()
+	case EOF:
+		return nil, p.syntaxErrors(lookahead, "unexpected end-of-file")
 	default:
 		return nil, p.syntaxErrors(lookahead, "unknown declaration")
 	}
@@ -2045,7 +2047,8 @@ func (p *Parser) previousToken() lex.Token {
 	return p.tokens[p.index-1]
 }
 
-// Expect reurns an arror if the next token is not what was expected.
+// Expect returns an error if the next token is not of the expected Kind.
+// Otherwise it returns the token and increments the index by 1.
 func (p *Parser) expect(kind uint) (lex.Token, []source.SyntaxError) {
 	lookahead := p.lookahead()
 	//


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to error reporting and comment/doc fixes in lexer/parser code, with minimal impact on parsing behavior aside from clearer EOF diagnostics.
> 
> **Overview**
> Fixes token documentation for `SEMICOLON` in both the ASM and ZK compiler lexers (comment now correctly says `;`).
> 
> Updates the ZK compiler parser to explicitly treat an unexpected `EOF` while parsing a declaration as an "unexpected end-of-file" syntax error (instead of falling through to "unknown declaration"), and clarifies the `expect` helper’s comment to match its behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e15532f02dbd150d1eaceeccb7b5b3d3376ec4c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->