### PR TITLE
fix memory performance gremlin

### DIFF
--- a/pkg/zkc/vm/memory/bipartite_array.go
+++ b/pkg/zkc/vm/memory/bipartite_array.go
@@ -117,12 +117,8 @@ func (p *BiPartiteArray[W]) Write(frame []W, address []register.Id, data []regis
 	//
 	if start < HALF_START {
 		// extend lower partition if needed
-		if uint64(len(p.lower)) < end {
-			ndata := make([]W, end)
-			copy(ndata, p.lower)
-			p.lower = ndata
-		}
-		//
+		p.lower = expand(p.lower, end)
+		// copy over values
 		for i := range data {
 			p.lower[start+uint64(i)] = frame[data[i].Unwrap()]
 		}
@@ -131,12 +127,8 @@ func (p *BiPartiteArray[W]) Write(frame []W, address []register.Id, data []regis
 		// i==0) so the upper partition must have at least TOP_POS-start+1
 		// elements.
 		var needed = TOP_POS - start + 1
-		//
-		if uint64(len(p.upper)) < needed {
-			ndata := make([]W, needed)
-			copy(ndata, p.upper)
-			p.upper = ndata
-		}
+		// extend upper partition if needed
+		p.upper = expand(p.upper, needed)
 		// Cap iteration at `needed`: any cell whose position would exceed
 		// TOP_POS lies outside the addressable range (start+i would wrap
 		// uint64) and is silently dropped, mirroring the zero returned by

--- a/pkg/zkc/vm/memory/static_array.go
+++ b/pkg/zkc/vm/memory/static_array.go
@@ -13,6 +13,8 @@
 package memory
 
 import (
+	"slices"
+
 	"github.com/consensys/go-corset/pkg/schema/register"
 	"github.com/consensys/go-corset/pkg/util"
 )
@@ -67,20 +69,26 @@ func (p *StaticArray[W]) Read(frame []W, address []register.Id, data []register.
 
 // Write implementation for Memory interface.
 func (p *StaticArray[W]) Write(frame []W, address []register.Id, data []register.Id) error {
-	var (
-		n          = uint64(len(p.data))
-		start, end = p.geometry.FrameDecode(frame, address)
-	)
+	var start, end = p.geometry.FrameDecode(frame, address)
 	// expand memory if needed
-	if n <= end {
-		ndata := make([]W, end)
-		copy(ndata, p.data)
-		p.data = ndata
-	}
-	//
+	p.data = expand(p.data, end)
+	// copy over data
 	for i := range data {
 		p.data[uint64(i)+start] = frame[data[i].Unwrap()]
 	}
 	//
 	return nil
+}
+
+// Expand a slice to ensure it has at least length n.  If the slice already has
+// at least n elements it is returned as-is.  Otherwise capacity is grown if
+// needed (via slices.Grow, which uses the runtime's append-style growth
+// heuristic) and the length is extended to n.
+func expand[T any](slice []T, n uint64) []T {
+	m := uint64(len(slice))
+	if n <= m {
+		return slice
+	}
+	//
+	return slices.Grow(slice, int(n-m))[:n]
 }


### PR DESCRIPTION
There was a problem in the way memory was being managed internally, leading to excessive reallocations when consecutive locations were being written.  This stemed from the fact that new allocations did not include additional capacity for subsequent writes.  For a now, a relatively simple capacity calculation is used which doubles the length on every allocation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core VM memory write paths and changes slice growth behavior; functional intent is the same but allocation/capacity changes could impact performance or reveal edge-case panics if sizing assumptions are wrong.
> 
> **Overview**
> Improves VM memory write performance by replacing per-write `make`+`copy` reallocations with a shared `expand` helper that grows slices using `slices.Grow` and then extends length.
> 
> `StaticArray.Write` and both partitions in `BiPartiteArray.Write` now call `expand(...)` to ensure capacity/length before copying in written words, reducing churn on consecutive writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e59f1c81683ec8c8b0b4dd49847f67e230415ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->