### PR TITLE
feat: support fail with error message

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,17 +23,25 @@ make install
 
 ### Running specific test subsets
 
+The test targets vary widely in runtime — pick the smallest set that covers
+your change to keep the iteration loop tight. The slow targets (`asm-unit`,
+`asm-bench`, `corset-test`) will exceed the default 2-minute `go test`
+timeout if invoked directly, which is why the Makefile passes `--timeout 0`.
+
 ```shell
-# Corset constraint tests (valid/invalid/agnostic)
+# ZkC compiler/VM tests — Test_ZkcBench|Test_ZkcUnit|Test_ZkcInvalid (fast)
+make zkc-test
+
+# Cheap "everything else" — skips Asm/Bench/Corset/Zkc system tests (fast)
+make unit-test
+
+# Corset constraint tests (valid/invalid/agnostic) — slow (minutes)
 make corset-test   # go test -run "Test_Agnostic|Test_Valid|Test_Invalid"
 
-# Assembly tests
+# Assembly tests — slow; Test_AsmUnit_ByteShift alone takes ~2+ min
 make asm-unit      # go test -run "Test_AsmInvalid|Test_AsmUnit"
 make asm-util      # go test -run "Test_AsmUtil"
-make asm-bench     # go test -run "Test_AsmBench"
-
-# All tests except Asm/Bench/Corset system tests
-make unit-test
+make asm-bench     # go test -run "Test_AsmBench"  (slowest; -p 1)
 
 # Run a single named test
 go test --timeout 0 -run "Test_Valid_Basic_01" ./pkg/test/...
@@ -41,6 +49,11 @@ go test --timeout 0 -run "Test_Valid_Basic_01" ./pkg/test/...
 # Run tests with race detection
 make asm-racer
 ```
+
+When iterating on ZkC changes (e.g. `pkg/zkc/...`), `make zkc-test` is the
+relevant target — `make asm-unit` will not exercise ZkC code and is too slow
+for a quick check. Combining `Test_ZkcUnit|Test_AsmUnit` in a single
+`go test -run` invocation will time out at the default 2-minute limit.
 
 ### CLI usage
 
@@ -100,29 +113,29 @@ Layer constants (defined in `schema_stacker.go`):
 
 ### Key packages
 
-| Package | Role |
-|---|---|
-| `pkg/corset/` | Corset DSL compiler: parses `.lisp`, resolves symbols, type-checks, and emits a `MacroHirProgram`. Standard library embedded as `stdlib.lisp`. |
-| `pkg/corset/ast/` | AST nodes for Corset: declarations, expressions, types, bindings |
-| `pkg/corset/compiler/` | Compiler internals: parser, resolver, type-checker, preprocessor, translator, register allocator |
-| `pkg/asm/` | Assembly layer: `MacroProgram` / `MicroProgram` types, lowering (macro→micro), vectorisation, concretisation to MIR |
-| `pkg/asm/io/` | Core abstractions: `Instruction`, `Function`, `Component`, `Program`, bus interface (Map) |
-| `pkg/asm/io/macro/` | Macro instruction set (high-level: assign, call, cast, divide, if/goto, …) |
-| `pkg/asm/io/micro/` | Micro instruction set (low-level: polynomial, skip_if, jmp, …); includes DFA for analysis |
-| `pkg/asm/assembler/` | Parser/linker for `.zkasm` assembly text format |
-| `pkg/ir/hir/` | High-level IR: `LowerToMir()` — HIR modules → MIR modules |
-| `pkg/ir/mir/` | Mid-level IR: `LowerToAir()` — MIR modules → AIR schema, optimiser |
-| `pkg/ir/air/` | AIR schema: final vanishing polynomials + gadgets |
-| `pkg/schema/` | Core schema interfaces (`Schema`, `Module`, `Assignment`, `Constraint`) parameterised over field element type `F` |
-| `pkg/schema/constraint/` | Constraint types: vanishing, lookup, permutation, range |
-| `pkg/trace/` | Trace representation; `json/` and `lt/` (binary) format readers/writers |
-| `pkg/binfile/` | Binary `.bin` file serialisation (gob-encoded) |
-| `pkg/zkc/` | ZK compiler / VM: a separate compiler+virtual machine (`pkg/zkc/vm/`) with ROM, RAM, WOM memories and a call stack |
-| `pkg/util/field/` | Field element implementations: `bls12_377`, `koalabear`, `gf251`, `gf8209`, `mersenne31` |
-| `pkg/util/` | General utilities: collections, iterators, source maps, math, word types |
-| `cmd/go-corset/` | Main entry point |
-| `pkg/cmd/corset/` | CLI commands: check, compile, debug, inspect, trace, generate |
-| `pkg/cmd/zkc/` | CLI commands for the ZK compiler toolchain |
+| Package                  | Role                                                                                                                                           |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pkg/corset/`            | Corset DSL compiler: parses `.lisp`, resolves symbols, type-checks, and emits a `MacroHirProgram`. Standard library embedded as `stdlib.lisp`. |
+| `pkg/corset/ast/`        | AST nodes for Corset: declarations, expressions, types, bindings                                                                               |
+| `pkg/corset/compiler/`   | Compiler internals: parser, resolver, type-checker, preprocessor, translator, register allocator                                               |
+| `pkg/asm/`               | Assembly layer: `MacroProgram` / `MicroProgram` types, lowering (macro→micro), vectorisation, concretisation to MIR                            |
+| `pkg/asm/io/`            | Core abstractions: `Instruction`, `Function`, `Component`, `Program`, bus interface (Map)                                                      |
+| `pkg/asm/io/macro/`      | Macro instruction set (high-level: assign, call, cast, divide, if/goto, …)                                                                     |
+| `pkg/asm/io/micro/`      | Micro instruction set (low-level: polynomial, skip_if, jmp, …); includes DFA for analysis                                                      |
+| `pkg/asm/assembler/`     | Parser/linker for `.zkasm` assembly text format                                                                                                |
+| `pkg/ir/hir/`            | High-level IR: `LowerToMir()` — HIR modules → MIR modules                                                                                      |
+| `pkg/ir/mir/`            | Mid-level IR: `LowerToAir()` — MIR modules → AIR schema, optimiser                                                                             |
+| `pkg/ir/air/`            | AIR schema: final vanishing polynomials + gadgets                                                                                              |
+| `pkg/schema/`            | Core schema interfaces (`Schema`, `Module`, `Assignment`, `Constraint`) parameterised over field element type `F`                              |
+| `pkg/schema/constraint/` | Constraint types: vanishing, lookup, permutation, range                                                                                        |
+| `pkg/trace/`             | Trace representation; `json/` and `lt/` (binary) format readers/writers                                                                        |
+| `pkg/binfile/`           | Binary `.bin` file serialisation (gob-encoded)                                                                                                 |
+| `pkg/zkc/`               | ZK compiler / VM: a separate compiler+virtual machine (`pkg/zkc/vm/`) with ROM, RAM, WOM memories and a call stack                             |
+| `pkg/util/field/`        | Field element implementations: `bls12_377`, `koalabear`, `gf251`, `gf8209`, `mersenne31`                                                       |
+| `pkg/util/`              | General utilities: collections, iterators, source maps, math, word types                                                                       |
+| `cmd/go-corset/`         | Main entry point                                                                                                                               |
+| `pkg/cmd/corset/`        | CLI commands: check, compile, debug, inspect, trace, generate                                                                                  |
+| `pkg/cmd/zkc/`           | CLI commands for the ZK compiler toolchain                                                                                                     |
 
 ### Schema and field polymorphism
 

--- a/pkg/test/zkc_invalid_test.go
+++ b/pkg/test/zkc_invalid_test.go
@@ -786,6 +786,26 @@ func Test_ZkcInvalid_Printf_04(t *testing.T) {
 }
 
 // ===================================================================
+// Fail Tests
+// ===================================================================
+
+func Test_ZkcInvalid_Fail_01(t *testing.T) {
+	checkZkcInvalid(t, "zkc/invalid/fail_01")
+}
+
+func Test_ZkcInvalid_Fail_02(t *testing.T) {
+	checkZkcInvalid(t, "zkc/invalid/fail_02")
+}
+
+func Test_ZkcInvalid_Fail_03(t *testing.T) {
+	checkZkcInvalid(t, "zkc/invalid/fail_03")
+}
+
+func Test_ZkcInvalid_Fail_04(t *testing.T) {
+	checkZkcInvalid(t, "zkc/invalid/fail_04")
+}
+
+// ===================================================================
 // Test Helpers
 // ===================================================================
 

--- a/pkg/zkc/compiler/ast/stmt/fail.go
+++ b/pkg/zkc/compiler/ast/stmt/fail.go
@@ -13,20 +13,25 @@
 package stmt
 
 import (
+	"strings"
+
+	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/expr"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/symbol"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast/variable"
+	"github.com/consensys/go-corset/pkg/zkc/util"
 )
 
-// Fail signals an exceptional return from the enclosing function.
+// Fail signals an exceptional return from the enclosing function.  An optional
+// formatted error message can be supplied using the same chunked
+// representation as Printf.
 type Fail[S symbol.Symbol[S]] struct {
-	// dummy is included to force Return structs to be stored in the heap.
-	//nolint
-	Dummy uint
+	Chunks    []FormattedChunk
+	Arguments []expr.Expr[S]
 }
 
 // Uses implementation for Instruction interface.
 func (p *Fail[S]) Uses() []variable.Id {
-	return nil
+	return expr.Uses(p.Arguments...)
 }
 
 // Definitions implementation for Instruction interface.
@@ -34,6 +39,28 @@ func (p *Fail[S]) Definitions() []variable.Id {
 	return nil
 }
 
-func (p *Fail[S]) String(_ variable.Map[S]) string {
-	return "fail"
+func (p *Fail[S]) String(env variable.Map[S]) string {
+	var builder strings.Builder
+	builder.WriteString("fail")
+	//
+	if len(p.Chunks) > 0 {
+		builder.WriteString(" \"")
+		//
+		for _, chunk := range p.Chunks {
+			builder.WriteString(util.EscapeFormattedText(chunk.Text))
+			//
+			if chunk.Format.HasFormat() {
+				builder.WriteString(chunk.Format.String())
+			}
+		}
+		//
+		builder.WriteString("\"")
+	}
+	//
+	for _, e := range p.Arguments {
+		builder.WriteString(",")
+		builder.WriteString(e.String(env))
+	}
+	//
+	return builder.String()
 }

--- a/pkg/zkc/compiler/codegen/statement.go
+++ b/pkg/zkc/compiler/codegen/statement.go
@@ -78,7 +78,7 @@ func (p *StmtCompiler) compileStatement(pc uint, mapping []uint, s Stmt) VectorI
 	case *stmt.Goto[symbol.Resolved]:
 		return instruction.NewVector[MicroInstruction](instruction.NewJmp(s.Target))
 	case *stmt.Fail[symbol.Resolved]:
-		return instruction.NewVector[MicroInstruction](instruction.NewFail())
+		return p.compileFail(mapping, s.Chunks, s.Arguments)
 	case *stmt.Printf[symbol.Resolved]:
 		return p.compilePrintf(mapping, s.Chunks, s.Arguments)
 	case *stmt.Return[symbol.Resolved]:
@@ -165,14 +165,36 @@ func (p *StmtCompiler) mapLVals(mapping []uint, lvals []LVal) ([]register.Id, []
 
 func (p *StmtCompiler) compilePrintf(mapping []uint, chunks []stmt.FormattedChunk, args []Expr,
 ) VectorInstruction {
+	nchunks, insns := p.compileFormattedChunks(mapping, chunks, args)
+	//
+	insns = append(insns, &instruction.Debug{Chunks: nchunks})
+	//
+	return instruction.NewVector(insns...)
+}
+
+func (p *StmtCompiler) compileFail(mapping []uint, chunks []stmt.FormattedChunk, args []Expr,
+) VectorInstruction {
+	//
+	nchunks, insns := p.compileFormattedChunks(mapping, chunks, args)
+	//
+	insns = append(insns, instruction.NewFail(nchunks...))
+	//
+	return instruction.NewVector(insns...)
+}
+
+// compileFormattedChunks compiles each argument expression into a temporary
+// register and pairs it with the corresponding format chunk.  Chunks without a
+// format directive are passed through unchanged with an unused argument
+// register.  Returns the resulting chunk list together with the
+// micro-instructions needed to evaluate the arguments.
+func (p *StmtCompiler) compileFormattedChunks(mapping []uint, chunks []stmt.FormattedChunk, args []Expr,
+) ([]instruction.FormattedChunk, []MicroInstruction) {
 	var (
 		nchunks     []instruction.FormattedChunk
 		regs, insns = p.compileArgs(mapping, args...)
 		index       uint
 	)
 	//
-
-	// Manage all chunks
 	for _, chunk := range chunks {
 		if chunk.Format.HasFormat() {
 			nchunks = append(nchunks, instruction.FormattedChunk{
@@ -187,9 +209,7 @@ func (p *StmtCompiler) compilePrintf(mapping []uint, chunks []stmt.FormattedChun
 		}
 	}
 	//
-	insns = append(insns, &instruction.Debug{Chunks: nchunks})
-	//
-	return instruction.NewVector(insns...)
+	return nchunks, insns
 }
 
 func (p *StmtCompiler) compileCondition(pc uint, e Condition, mapping []uint, target uint,

--- a/pkg/zkc/compiler/format/insert_rules.go
+++ b/pkg/zkc/compiler/format/insert_rules.go
@@ -34,6 +34,9 @@ func init() {
 	DEFAULT_INSERTION_RULES = make([]InsertionRule, parser.MAX_TOKEN)
 	// Space after keywords that introduce declarations or statements.
 	DEFAULT_INSERTION_RULES[parser.KEYWORD_CONST] = InsertAfter(ONE_SPACE)
+	// 'fail' optionally takes a formatted message; only insert a space when one
+	// is actually present, so a bare `fail` does not gain a trailing space.
+	DEFAULT_INSERTION_RULES[parser.KEYWORD_FAIL] = InsertSpaceAfterIfString()
 	DEFAULT_INSERTION_RULES[parser.KEYWORD_FN] = InsertAfter(ONE_SPACE)
 	DEFAULT_INSERTION_RULES[parser.KEYWORD_FOR] = InsertAfter(ONE_SPACE)
 	DEFAULT_INSERTION_RULES[parser.KEYWORD_IF] = InsertAfter(ONE_SPACE)
@@ -126,6 +129,14 @@ func InsertSpaceAfter() InsertionRule {
 	return &insertSpaceAfter{}
 }
 
+// InsertSpaceAfterIfString constructs a rule which inserts a space after the
+// matched token only when the immediately following token is a STRING.  Used
+// for keywords like 'fail' whose string argument is optional, so that a bare
+// keyword does not gain a trailing space.
+func InsertSpaceAfterIfString() InsertionRule {
+	return &insertSpaceAfterIfString{}
+}
+
 // InsertSpaceBefore constructs a rule which inserts a space before the matched
 // token only when the preceding token's rule did not already emit a trailing
 // space. This avoids double-spacing when two rules would otherwise both
@@ -199,6 +210,24 @@ func (p *insertSpaceAfter) After(_ uint, next iter.Iterator[lex.Token]) []lex.To
 	}
 
 	return []lex.Token{ONE_SPACE}
+}
+
+// ===================================================================
+// InsertSpaceAfterIfString
+// ===================================================================
+
+type insertSpaceAfterIfString struct{}
+
+func (p *insertSpaceAfterIfString) Before(_ uint, _ iter.Iterator[lex.Token]) []lex.Token {
+	return nil
+}
+
+func (p *insertSpaceAfterIfString) After(_ uint, next iter.Iterator[lex.Token]) []lex.Token {
+	if next.HasNext() && next.Next().Kind == parser.STRING {
+		return []lex.Token{ONE_SPACE}
+	}
+	//
+	return nil
 }
 
 // ===================================================================

--- a/pkg/zkc/compiler/linker.go
+++ b/pkg/zkc/compiler/linker.go
@@ -256,7 +256,11 @@ func (p *Linker) linkStatement(s stmt.Unresolved) (stmt.Resolved, []source.Synta
 	case *stmt.Continue[symbol.Unresolved]:
 		ninsn = &stmt.Continue[symbol.Resolved]{}
 	case *stmt.Fail[symbol.Unresolved]:
-		ninsn = &stmt.Fail[symbol.Resolved]{}
+		var args []expr.Expr[symbol.Resolved]
+		//
+		args, errors = p.linkExprs(s.Arguments...)
+		//
+		ninsn = &stmt.Fail[symbol.Resolved]{Chunks: s.Chunks, Arguments: args}
 	case *stmt.For[symbol.Unresolved]:
 		init, errs1 := p.linkStatement(s.Init)
 		cond, errs2 := p.linkExpr(s.Cond)

--- a/pkg/zkc/compiler/parser/parser.go
+++ b/pkg/zkc/compiler/parser/parser.go
@@ -819,7 +819,7 @@ func (p *Parser) parseStatement(env Environment,
 	case KEYWORD_CONTINUE:
 		returned, insn, errs = p.parseContinue(env)
 	case KEYWORD_FAIL:
-		returned, insn, errs = p.parseFail()
+		returned, insn, errs = p.parseFail(env)
 	case KEYWORD_FOR:
 		returned, insn, errs = p.parseFor(env)
 	case KEYWORD_IF:
@@ -1287,30 +1287,51 @@ func (p *Parser) parseReturn() (bool, stmt.Unresolved, []source.SyntaxError) {
 	return true, &stmt.Return[symbol.Unresolved]{}, nil
 }
 
-func (p *Parser) parseFail() (bool, stmt.Unresolved, []source.SyntaxError) {
+func (p *Parser) parseFail(env Environment) (bool, stmt.Unresolved, []source.SyntaxError) {
 	if _, errs := p.expect(KEYWORD_FAIL); len(errs) > 0 {
 		return true, nil, errs
 	}
+	// An error message is optional; without one, fail produces a bare abort.
+	if p.lookahead().Kind != STRING {
+		return true, &stmt.Fail[symbol.Unresolved]{}, nil
+	}
 	//
-	return true, &stmt.Fail[symbol.Unresolved]{}, nil
+	chunks, args, errs := p.parseFormattedString(env)
+	if len(errs) > 0 {
+		return true, nil, errs
+	}
+	//
+	return true, &stmt.Fail[symbol.Unresolved]{Chunks: chunks, Arguments: args}, nil
 }
 
 func (p *Parser) parsePrintf(env Environment) (bool, stmt.Unresolved, []source.SyntaxError) {
-	var (
-		token  lex.Token
-		chunks []stmt.FormattedChunk
-	)
-	//
 	if _, errs := p.expect(KEYWORD_PRINTF); len(errs) > 0 {
 		return false, nil, errs
-	} else if token, errs = p.expect(STRING); len(errs) > 0 {
+	}
+	//
+	chunks, args, errs := p.parseFormattedString(env)
+	if len(errs) > 0 {
 		return false, nil, errs
+	}
+	//
+	return false, &stmt.Printf[symbol.Unresolved]{Chunks: chunks, Arguments: args}, nil
+}
+
+// parseFormattedString parses a printf-style string literal followed by an
+// optional comma-separated list of expression arguments, returning the
+// resulting chunks and arguments.  An error is reported if the count of format
+// specifiers does not match the count of supplied arguments.
+func (p *Parser) parseFormattedString(env Environment) ([]stmt.FormattedChunk, []Expr, []source.SyntaxError) {
+	token, errs := p.expect(STRING)
+	if len(errs) > 0 {
+		return nil, nil, errs
 	}
 	// Process string
 	var (
 		str    = p.string(token)
 		runes  = []rune(str[1 : len(str)-1])
 		nrunes []rune
+		chunks []stmt.FormattedChunk
 		args   []Expr
 		nargs  int
 	)
@@ -1323,7 +1344,7 @@ func (p *Parser) parsePrintf(env Environment) (bool, stmt.Unresolved, []source.S
 				ok bool
 			)
 			if i, f, ok = parseFormatting(i+1, runes); !ok {
-				return false, nil, p.syntaxErrors(token, "invalid formatting")
+				return nil, nil, p.syntaxErrors(token, "invalid formatting")
 			}
 			//
 			nargs++
@@ -1333,13 +1354,13 @@ func (p *Parser) parsePrintf(env Environment) (bool, stmt.Unresolved, []source.S
 			nrunes = nil
 		case '\\':
 			if i+1 == len(runes) {
-				return false, nil, p.syntaxErrors(token, "invalid escape")
+				return nil, nil, p.syntaxErrors(token, "invalid escape")
 			}
 			// Attempt to parse escape character
 			c, ok := escapeCharacter(runes[i+1])
 			//
 			if !ok {
-				return false, nil, p.syntaxErrors(token, "invalid escape")
+				return nil, nil, p.syntaxErrors(token, "invalid escape")
 			}
 			// Continue
 			nrunes = append(nrunes, c)
@@ -1358,23 +1379,23 @@ func (p *Parser) parsePrintf(env Environment) (bool, stmt.Unresolved, []source.S
 		arg, errs := p.parseLogicalExpr(env)
 		//
 		if len(errs) > 0 {
-			return false, nil, errs
+			return nil, nil, errs
 		}
 		//
 		args = append(args, arg)
 	}
 	// Sanity check for matching arguments / chunks
 	if len(args) > nargs {
-		return false, nil, p.srcmap.SyntaxErrors(args[nargs], "too many arguments")
+		return nil, nil, p.srcmap.SyntaxErrors(args[nargs], "too many arguments")
 	} else if len(args) > 0 && len(args) < nargs {
 		n := len(args) - 1
 		//
-		return false, nil, p.srcmap.SyntaxErrors(args[n], "insufficient arguments")
+		return nil, nil, p.srcmap.SyntaxErrors(args[n], "insufficient arguments")
 	} else if len(args) < nargs {
-		return false, nil, p.syntaxErrors(token, "insufficient arguments")
+		return nil, nil, p.syntaxErrors(token, "insufficient arguments")
 	}
 	//
-	return false, &stmt.Printf[symbol.Unresolved]{Chunks: chunks, Arguments: args}, nil
+	return chunks, args, nil
 }
 
 func parseFormatting(index int, runes []rune) (int, zkc_util.Format, bool) {

--- a/pkg/zkc/compiler/validate/typing.go
+++ b/pkg/zkc/compiler/validate/typing.go
@@ -200,10 +200,12 @@ func (p *TypeChecker) typeFunction(fn decl.ResolvedFunction) []source.SyntaxErro
 		switch s := s.(type) {
 		case *stmt.Assign[symbol.Resolved]:
 			errors = append(errors, p.typeAssignment(s, &fn, effects)...)
+		case *stmt.Fail[symbol.Resolved]:
+			errors = append(errors, p.typeFormatArgs(s.Arguments, &fn, effects)...)
 		case *stmt.IfGoto[symbol.Resolved]:
 			errors = append(errors, p.typeIfGoto(s, &fn, effects)...)
 		case *stmt.Printf[symbol.Resolved]:
-			errors = append(errors, p.typePrintf(s, &fn, effects)...)
+			errors = append(errors, p.typeFormatArgs(s.Arguments, &fn, effects)...)
 		}
 	}
 	//
@@ -404,11 +406,11 @@ func (p *TypeChecker) typeIfGoto(s *stmt.IfGoto[symbol.Resolved], env VariableMa
 	return p.typeCondition(s.Cond, env, effects)
 }
 
-func (p *TypeChecker) typePrintf(s *stmt.Printf[symbol.Resolved], env VariableMap, effects bit.Set,
+func (p *TypeChecker) typeFormatArgs(args []expr.Resolved, env VariableMap, effects bit.Set,
 ) []source.SyntaxError {
 	var errs []source.SyntaxError
 	//
-	for _, e := range s.Arguments {
+	for _, e := range args {
 		ith, ierrs := p.typeExpression(nil, e, env, effects)
 		//
 		if len(ierrs) > 0 {

--- a/pkg/zkc/vm/instruction/base.go
+++ b/pkg/zkc/vm/instruction/base.go
@@ -76,17 +76,13 @@ func NewCall(id uint, arguments []register.Id, returns []register.Id) *Call {
 
 // ============================================================================
 
-// Fail aborts execution of the machine, signalling an unrecoverable error
-// (a "machine panic").  No further instructions are executed and the
-// surrounding call stack is not unwound; the executor returns an error to its
-// caller.  The immediate operand is unused.  Fail is one of the three
-// control-flow terminators (along with Jmp and Return) recognised by the
-// vectoriser as ending a basic block.
-type Fail struct{ base.OpImm }
+// Fail is a convenient alias
+type Fail = base.Fail
 
-// NewFail constructs a fresh fail instruction.
-func NewFail() *Fail {
-	return &Fail{base.OpImm{Op: opcode.FAIL, Immediate: 0}}
+// NewFail constructs a fresh fail instruction with the given (possibly empty)
+// formatted error message.
+func NewFail(chunks ...FormattedChunk) *Fail {
+	return &Fail{Chunks: chunks}
 }
 
 // ============================================================================

--- a/pkg/zkc/vm/instruction/base/fail.go
+++ b/pkg/zkc/vm/instruction/base/fail.go
@@ -1,0 +1,102 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package base
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/consensys/go-corset/pkg/schema/register"
+	"github.com/consensys/go-corset/pkg/util/field"
+	"github.com/consensys/go-corset/pkg/zkc/util"
+	"github.com/consensys/go-corset/pkg/zkc/vm/instruction/opcode"
+)
+
+// Fail aborts execution of the machine, signalling an unrecoverable error
+// (a "machine panic").  No further instructions are executed and the
+// surrounding call stack is not unwound; the executor returns an error to its
+// caller.  An optional sequence of formatted chunks describes the error
+// message: each chunk holds some literal text plus, optionally, a format
+// directive paired with a register holding the value to format.  Fail is one
+// of the three control-flow terminators (along with Jmp and Return) recognised
+// by the vectoriser as ending a basic block.
+type Fail struct {
+	Chunks []FormattedChunk
+}
+
+// OpCode implementation for Instruction interface
+func (p *Fail) OpCode() opcode.OpCode {
+	return opcode.FAIL
+}
+
+// Uses implementation for Instruction interface.
+func (p *Fail) Uses() []register.Id {
+	var uses []register.Id
+	//
+	for _, c := range p.Chunks {
+		if c.Format.HasFormat() {
+			uses = append(uses, c.Argument)
+		}
+	}
+	//
+	return uses
+}
+
+// Definitions implementation for Instruction interface.
+func (p *Fail) Definitions() []register.Id {
+	return nil
+}
+
+func (p *Fail) String(mapping SystemMap) string {
+	if len(p.Chunks) == 0 {
+		return "fail"
+	}
+	//
+	var (
+		tBuilder  strings.Builder
+		builder   strings.Builder
+		firstTime = true
+	)
+	//
+	for _, c := range p.Chunks {
+		tBuilder.WriteString(util.EscapeFormattedText(c.Text))
+		//
+		if c.Format.HasFormat() {
+			tBuilder.WriteString(c.Format.String())
+
+			if !firstTime {
+				builder.WriteString(",")
+			}
+			//
+			firstTime = false
+			//
+			builder.WriteString(mapping.Register(c.Argument.Id()).Name())
+		}
+	}
+	//
+	if builder.Len() == 0 {
+		return fmt.Sprintf("fail \"%s\"", tBuilder.String())
+	}
+	//
+	return fmt.Sprintf("fail \"%s\", %s", tBuilder.String(), builder.String())
+}
+
+// Validate implementation for Instruction interface.
+func (p *Fail) Validate(_ field.Config, _ SystemMap) []error {
+	return nil
+}
+
+// MicroValidate implementation for Instruction interface.
+func (p *Fail) MicroValidate(_ uint, _ field.Config, _ SystemMap) []error {
+	return nil
+}

--- a/pkg/zkc/vm/instruction/base/op_imm.go
+++ b/pkg/zkc/vm/instruction/base/op_imm.go
@@ -26,8 +26,8 @@ import (
 
 // OpImm represents an instruction parameterised solely by an opcode and a uint
 // immediate value.  This is used for control-flow instructions such as JUMP
-// (where the immediate identifies the branch target), as well as RETURN and
-// FAIL (which ignore the immediate).
+// (where the immediate identifies the branch target), as well as RETURN
+// (which ignores the immediate).
 type OpImm struct {
 	Op        opcode.OpCode
 	Immediate uint
@@ -54,8 +54,6 @@ func (p *OpImm) String(_ SystemMap) string {
 		return fmt.Sprintf("jmp %d", p.Immediate)
 	case opcode.RETURN:
 		return "ret"
-	case opcode.FAIL:
-		return "fail"
 	default:
 		panic("unknown OpImm32 opcode")
 	}

--- a/pkg/zkc/vm/machine/base.go
+++ b/pkg/zkc/vm/machine/base.go
@@ -13,8 +13,8 @@
 package machine
 
 import (
-	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/consensys/go-corset/pkg/schema/register"
 	"github.com/consensys/go-corset/pkg/util"
@@ -232,7 +232,12 @@ func (p *Base[W, I, T]) executeInstruction(insn I, width uint, regs []register.R
 		// Don't fall thru
 		return nil
 	case opcode.FAIL:
-		return errors.New("machine panic")
+		var (
+			insn = binsn.(*instruction.Fail)
+			msg  = executeFormattedChunks(insn.Chunks, frame)
+		)
+		//
+		return fmt.Errorf("machine panic: %s", msg)
 	case opcode.JUMP:
 		insn := binsn.(*instruction.Jmp)
 		// Goto target instruction in current frame
@@ -288,8 +293,7 @@ func (p *Base[W, I, T]) executeInstruction(insn I, width uint, regs []register.R
 		// Fall thru
 	case opcode.DEBUG:
 		insn := binsn.(*instruction.Debug)
-		err = executeDebug(*insn, frame, regs)
-
+		fmt.Print(executeFormattedChunks(insn.Chunks, frame))
 	default:
 		// Call provided executor
 		err = p.executor.Execute(insn, frame, regs)
@@ -302,16 +306,18 @@ func (p *Base[W, I, T]) executeInstruction(insn I, width uint, regs []register.R
 	return err
 }
 
-func executeDebug[W zkc_util.Formattable](insn instruction.Debug, frame []W, _ []register.Register) error {
-	for _, chunk := range insn.Chunks {
-		fmt.Printf("%s", chunk.Text)
+func executeFormattedChunks[W zkc_util.Formattable](chunks []instruction.FormattedChunk, frame []W) string {
+	var builder strings.Builder
+	//
+	for _, chunk := range chunks {
+		builder.WriteString(chunk.Text)
 		//
 		if chunk.Format.HasFormat() {
-			fmt.Printf("%s", zkc_util.FormatWord(chunk.Format, frame[chunk.Argument.Unwrap()]))
+			builder.WriteString(zkc_util.FormatWord(chunk.Format, frame[chunk.Argument.Unwrap()]))
 		}
 	}
 	//
-	return nil
+	return builder.String()
 }
 
 // ==============================================================

--- a/pkg/zkc/vm/machine/base.go
+++ b/pkg/zkc/vm/machine/base.go
@@ -13,6 +13,7 @@
 package machine
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -234,9 +235,14 @@ func (p *Base[W, I, T]) executeInstruction(insn I, width uint, regs []register.R
 	case opcode.FAIL:
 		var (
 			insn = binsn.(*instruction.Fail)
-			msg  = executeFormattedChunks(insn.Chunks, frame)
+			//
+			msg = executeFormattedChunks(insn.Chunks, frame)
 		)
-		//
+		// check whether to include msg or not
+		if len(insn.Chunks) == 0 {
+			return errors.New("machine panic")
+		}
+		// include msg in error
 		return fmt.Errorf("machine panic: %s", msg)
 	case opcode.JUMP:
 		insn := binsn.(*instruction.Jmp)

--- a/testdata/zkc/invalid/fail_01.zkc
+++ b/testdata/zkc/invalid/fail_01.zkc
@@ -1,0 +1,10 @@
+//error:9:33-36:too many arguments
+pub input data(address:u16) -> (byte:u32)
+
+// prove that two numbers add up to a third.
+fn main() {
+  var lhs:u32 = data[0]
+  var rhs:u32 = data[1]
+  //
+  fail "hello world %d\n", lhs, rhs
+}

--- a/testdata/zkc/invalid/fail_02.zkc
+++ b/testdata/zkc/invalid/fail_02.zkc
@@ -1,0 +1,10 @@
+//error:9:8-26:insufficient arguments
+pub input data(address:u16) -> (byte:u32)
+
+// prove that two numbers add up to a third.
+fn main() {
+  var lhs:u32 = data[0]
+  var rhs:u32 = data[1]
+  //
+  fail "hello world %d\n"
+}

--- a/testdata/zkc/invalid/fail_03.zkc
+++ b/testdata/zkc/invalid/fail_03.zkc
@@ -1,0 +1,10 @@
+//error:9:28-32:insufficient arguments (expected 1)
+pub input data(address:u16) -> (byte:u32)
+
+// prove that two numbers add up to a third.
+fn main() {
+  var lhs:u32 = data[0]
+  var rhs:u32 = data[1]
+  //
+  fail "hello world %d\n", data
+}

--- a/testdata/zkc/invalid/fail_04.zkc
+++ b/testdata/zkc/invalid/fail_04.zkc
@@ -1,0 +1,10 @@
+//error:9:29-30:unknown symbol
+pub input data(address:u16) -> (byte:u32)
+
+// prove that two numbers add up to a third.
+fn main() {
+  var lhs:u32 = data[0]
+  var rhs:u32 = data[1]
+  //
+  fail "hello world %d\n", (x+1)
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches ZkC parser/linker/typechecker, codegen, and VM `FAIL` instruction handling; failures now carry formatted data, so any mismatch in chunk/arg compilation could change runtime panic behavior.
> 
> **Overview**
> Adds support for `fail` to take an *optional* printf-style formatted message (string literal plus comma-separated args), reusing the existing chunked formatting pipeline used by `printf`.
> 
> This threads formatted chunks/arguments through the ZkC compiler stages (AST, parser, linker, type checking, and codegen) and updates the VM `FAIL` instruction to carry chunks and include the formatted message in the returned panic error; it also tweaks the formatter to avoid inserting a trailing space for bare `fail` and adds new invalid test fixtures covering argument-count and symbol-resolution errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb3f9e990772b73e80e544c0b3b6c5aae1451f3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->