### PR TITLE
fix: reversed order of destruct instruction

### DIFF
--- a/pkg/zkc/vm/instruction/word/destruct.go
+++ b/pkg/zkc/vm/instruction/word/destruct.go
@@ -58,10 +58,10 @@ func (p *Destruct) Definitions() []register.Id {
 func (p *Destruct) String(mapping base.SystemMap) string {
 	var builder strings.Builder
 	//
-	for i := 0; i < len(p.Targets); i++ {
-		var rid = p.Targets[i]
+	for i := len(p.Targets); i > 0; i-- {
+		var rid = p.Targets[i-1]
 		//
-		if i != 0 {
+		if i != len(p.Targets) {
 			builder.WriteString("::")
 		}
 		//


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: change is limited to `Destruct.String()` formatting logic and does not affect execution semantics or state updates.
> 
> **Overview**
> Fixes `Destruct.String()` to render destructuring targets in reverse (most-significant first) by iterating `Targets` from end to start and adjusting the `::` separator condition so the output order matches the instruction’s intended semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af6db44153e0bb9d9b69d9442226c5d5470c0ef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->