### PR TITLE
feat: support formatted text with padding

### DIFF
--- a/pkg/test/zkc_unit_test.go
+++ b/pkg/test/zkc_unit_test.go
@@ -603,6 +603,10 @@ func Test_ZkcUnit_Printf_02(t *testing.T) {
 	checkZkcUnit(t, "zkc/unit/printf_02", field.BLS12_377, field.KOALABEAR_16)
 }
 
+func Test_ZkcUnit_Printf_03(t *testing.T) {
+	checkZkcUnit(t, "zkc/unit/printf_03", field.BLS12_377, field.KOALABEAR_16)
+}
+
 // ===================================================================
 // Include Tests
 // ===================================================================

--- a/pkg/zkc/compiler/parser/parser.go
+++ b/pkg/zkc/compiler/parser/parser.go
@@ -1399,20 +1399,42 @@ func (p *Parser) parseFormattedString(env Environment) ([]stmt.FormattedChunk, [
 }
 
 func parseFormatting(index int, runes []rune) (int, zkc_util.Format, bool) {
+	var (
+		zeroPad bool
+		width   uint
+	)
+	// Optional '0' flag selects zero padding.
+	if index < len(runes) && runes[index] == '0' {
+		zeroPad = true
+		index++
+	}
+	// Optional decimal width.
+	for index < len(runes) && runes[index] >= '0' && runes[index] <= '9' {
+		width = width*10 + uint(runes[index]-'0')
+		index++
+	}
+	//
 	if index >= len(runes) {
 		return 0, zkc_util.EMPTY_FORMAT, false
 	}
 	//
+	var format zkc_util.Format
+	//
 	switch runes[index] {
 	case 'd':
-		return index + 1, zkc_util.DecimalFormat(), true
+		format = zkc_util.DecimalFormat()
 	case 'x':
-		return index + 1, zkc_util.HexFormat(), true
+		format = zkc_util.HexFormat()
 	case 'b':
-		return index + 1, zkc_util.BinFormat(), true
+		format = zkc_util.BinFormat()
 	default:
 		return 0, zkc_util.EMPTY_FORMAT, false
 	}
+	//
+	format.Width = width
+	format.ZeroPad = zeroPad
+	//
+	return index + 1, format, true
 }
 
 func escapeCharacter(ch rune) (rune, bool) {

--- a/pkg/zkc/util/formatted_text.go
+++ b/pkg/zkc/util/formatted_text.go
@@ -13,6 +13,7 @@
 package util
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -45,27 +46,32 @@ type Formattable interface {
 }
 
 // Format simply encodes the set of permitted formatting strings in a printf
-// statement, such as "%d", "%x", etc.
+// statement, such as "%d", "%x", "%08x", "%8x", etc.  Width specifies an
+// optional minimum number of digits to render, and ZeroPad selects between
+// zero-padding ('0' flag) and space-padding (the default).  Any base prefix
+// ("0x", "0b") is rendered separately and does not count towards Width.
 type Format struct {
-	Code uint
+	Code    uint
+	Width   uint
+	ZeroPad bool
 }
 
 // EMPTY_FORMAT indicates no formatted argument is required.
-var EMPTY_FORMAT = Format{FORMAT_NONE}
+var EMPTY_FORMAT = Format{Code: FORMAT_NONE}
 
 // DecimalFormat constructs a new decimal format.
 func DecimalFormat() Format {
-	return Format{FORMAT_DEC}
+	return Format{Code: FORMAT_DEC}
 }
 
 // HexFormat constructs a new hexadecimal format.
 func HexFormat() Format {
-	return Format{FORMAT_HEX}
+	return Format{Code: FORMAT_HEX}
 }
 
 // BinFormat constructs a new binary format.
 func BinFormat() Format {
-	return Format{FORMAT_BIN}
+	return Format{Code: FORMAT_BIN}
 }
 
 // HasFormat checks whether this actually represents a format, or is empty.
@@ -74,28 +80,63 @@ func (p Format) HasFormat() bool {
 }
 
 func (p Format) String() string {
+	var (
+		builder  strings.Builder
+		typeChar byte
+	)
+	//
 	switch p.Code {
 	case FORMAT_DEC:
-		return "%d"
+		typeChar = 'd'
 	case FORMAT_HEX:
-		return "%x"
+		typeChar = 'x'
 	case FORMAT_BIN:
-		return "%b"
+		typeChar = 'b'
+	default:
+		panic("invalid format")
 	}
 	//
-	panic("invalid format")
+	builder.WriteByte('%')
+	//
+	if p.ZeroPad {
+		builder.WriteByte('0')
+	}
+	//
+	if p.Width > 0 {
+		fmt.Fprintf(&builder, "%d", p.Width)
+	}
+	//
+	builder.WriteByte(typeChar)
+	//
+	return builder.String()
 }
 
 // FormatWord applies a given format to a given word to generate a formatted string.
 func FormatWord[W Formattable](format Format, word W) string {
+	var (
+		digits string
+	)
+	//
 	switch format.Code {
 	case FORMAT_DEC:
-		return word.Text(10)
+		digits = word.Text(10)
 	case FORMAT_HEX:
-		return "0x" + word.Text(16)
+		digits = word.Text(16)
 	case FORMAT_BIN:
-		return "0b" + word.Text(2)
+		digits = word.Text(2)
+	default:
+		panic("invalid format")
+	}
+	// Apply any padding to the digit portion.
+	if uint(len(digits)) < format.Width {
+		padding := int(format.Width) - len(digits)
+		//
+		if format.ZeroPad {
+			digits = strings.Repeat("0", padding) + digits
+		} else {
+			digits = strings.Repeat(" ", padding) + digits
+		}
 	}
 	//
-	panic("invalid format")
+	return digits
 }

--- a/pkg/zkc/util/formatted_text_test.go
+++ b/pkg/zkc/util/formatted_text_test.go
@@ -1,0 +1,81 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package util
+
+import (
+	"math/big"
+	"testing"
+)
+
+type bigWord big.Int
+
+func (p *bigWord) Text(base int) string {
+	return (*big.Int)(p).Text(base)
+}
+
+func newBigWord(n int64) *bigWord {
+	return (*bigWord)(big.NewInt(n))
+}
+
+func TestFormatString(t *testing.T) {
+	tests := []struct {
+		format   Format
+		expected string
+	}{
+		{DecimalFormat(), "%d"},
+		{HexFormat(), "%x"},
+		{BinFormat(), "%b"},
+		{Format{Code: FORMAT_HEX, Width: 8, ZeroPad: true}, "%08x"},
+		{Format{Code: FORMAT_HEX, Width: 8}, "%8x"},
+		{Format{Code: FORMAT_DEC, Width: 4, ZeroPad: true}, "%04d"},
+		{Format{Code: FORMAT_DEC, Width: 4}, "%4d"},
+		{Format{Code: FORMAT_BIN, Width: 16, ZeroPad: true}, "%016b"},
+	}
+	//
+	for _, tc := range tests {
+		if got := tc.format.String(); got != tc.expected {
+			t.Errorf("Format.String() = %q, want %q", got, tc.expected)
+		}
+	}
+}
+
+func TestFormatWord(t *testing.T) {
+	tests := []struct {
+		format   Format
+		value    int64
+		expected string
+	}{
+		// No padding.
+		{HexFormat(), 0x42, "42"},
+		{DecimalFormat(), 42, "42"},
+		{BinFormat(), 5, "101"},
+		// Zero padding for %08x.
+		{Format{Code: FORMAT_HEX, Width: 8, ZeroPad: true}, 0x42, "00000042"},
+		{Format{Code: FORMAT_HEX, Width: 8, ZeroPad: true}, 0xabcdef01, "abcdef01"},
+		// Space padding for %8x.
+		{Format{Code: FORMAT_HEX, Width: 8}, 0x42, "      42"},
+		// Width smaller than digits: leave unchanged.
+		{Format{Code: FORMAT_HEX, Width: 2, ZeroPad: true}, 0xabcdef, "abcdef"},
+		// Decimal padding.
+		{Format{Code: FORMAT_DEC, Width: 4, ZeroPad: true}, 42, "0042"},
+		{Format{Code: FORMAT_DEC, Width: 4}, 42, "  42"},
+		// Binary padding.
+		{Format{Code: FORMAT_BIN, Width: 8, ZeroPad: true}, 5, "00000101"},
+	}
+	//
+	for _, tc := range tests {
+		if got := FormatWord(tc.format, newBigWord(tc.value)); got != tc.expected {
+			t.Errorf("FormatWord(%s, %d) = %q, want %q", tc.format.String(), tc.value, got, tc.expected)
+		}
+	}
+}

--- a/testdata/zkc/unit/printf_03.zkc
+++ b/testdata/zkc/unit/printf_03.zkc
@@ -1,0 +1,10 @@
+pub input data(address:u16) -> (byte:u32)
+
+// Exercise padded format specifiers in printf.
+fn main() {
+    var lhs:u32 = data[0]
+    //
+    printf "zero-padded:  %08x\n", lhs
+    printf "space-padded: %8x\n", lhs
+    printf "padded dec:   %04d\n", lhs
+}


### PR DESCRIPTION
This adds support for padding specifiers in printf and fail statements, such as "%08x" to print a hexadecimal digit with at least 8 digits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the ZKC format-specifier parsing and runtime formatting output, which can alter `printf`/`fail` message rendering (notably padding and hex/bin prefixes) and may affect existing tests/log parsing.
> 
> **Overview**
> Adds support for *width* and *zero/space padding* in ZKC formatted strings (e.g. `%08x`, `%8x`, `%04d`) by extending `Format` with `Width`/`ZeroPad` and teaching the parser to recognize these flags before `d`/`x`/`b`.
> 
> Updates formatting utilities to render the new specifiers via `Format.String()` and apply padding in `FormatWord`, and adds unit + integration coverage via `formatted_text_test.go` and a new `printf_03` ZKC unit test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cc7ba7464b56da6dd511b4b55e9c015382fe34b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->