### PR TITLE
feat: support trace generation

### DIFF
--- a/pkg/cmd/zkc/debug/observer.go
+++ b/pkg/cmd/zkc/debug/observer.go
@@ -25,9 +25,14 @@ import (
 // TraceObserver prints a trace
 type TraceObserver[W vm.Word[W]] struct {
 	depth uint
-	fun   *vm.Function[vm.Instruction]
+	fun   *vm.Function[vm.WordInstruction]
 	insn  vm.Instruction
 	pc    vm.ProgramCounter
+}
+
+// Initialise implementation for Observer interface
+func (p *TraceObserver[W]) Initialise(machine *vm.WordMachine[W]) {
+
 }
 
 // PreExecution implementation for Observer interface
@@ -70,7 +75,7 @@ func (p *TraceObserver[W]) enterFunction(machine *vm.WordMachine[W]) {
 	)
 	//
 	p.depth = n
-	p.fun = machine.Module(frame.Function()).(*vm.Function[instruction.Instruction])
+	p.fun = machine.Module(frame.Function()).(*vm.Function[vm.WordInstruction])
 	p.insn = nil
 }
 
@@ -114,7 +119,7 @@ func (p *TraceObserver[W]) callStack(machine *vm.WordMachine[W]) string {
 	for i := uint(0); i < p.depth; i++ {
 		var (
 			ith = machine.StackFrame(i)
-			fun = machine.Module(ith.Function()).(*vm.Function[instruction.Instruction])
+			fun = machine.Module(ith.Function()).(*vm.Function[vm.WordInstruction])
 		)
 		//
 		if i+1 == p.depth {
@@ -149,7 +154,7 @@ func functionInputs[W vm.Word[W], I vm.Instruction](frame vm.StackFrame[W],
 }
 
 func decode[W vm.Word[W]](frame vm.StackFrame[W],
-	fn *vm.Function[instruction.Instruction]) instruction.Instruction {
+	fn *vm.Function[vm.WordInstruction]) vm.WordInstruction {
 	//
 	var (
 		pc   = frame.PC()

--- a/pkg/cmd/zkc/execute.go
+++ b/pkg/cmd/zkc/execute.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/consensys/go-corset/pkg/trace/lt"
 	"github.com/consensys/go-corset/pkg/util/field"
 	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 	"github.com/consensys/go-corset/pkg/util/field/gf251"
@@ -50,22 +51,88 @@ var executeCmds = []FieldAgnosticCmd{
 
 func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field field.Config) {
 	var (
+		errors []error
 		// compiler config
 		config = codegen.DEFAULT_CONFIG.
 			Vectorize(GetFlag(cmd, "vectorize")).
 			Field(field)
+		// output file for trace
+		output = GetString(cmd, "output")
 	)
 	//
 	input := ParseInputFile(args[0])
 	// Compile source files, or print errors
 	program := CompileSourceFiles(field, args[1:]...)
 	//
-	executeIrProgram[EmptyBaseObserver]("main", config, program, input, EmptyBaseObserver{})
+	if output == "" {
+		errors = executeAndPrint("main", config, program, input)
+	} else {
+		errors = executeAndWrite("main", config, program, input, output)
+	}
+	// Exit with failure (if errors)
+	if len(errors) > 0 {
+		// Log errors
+		for _, e := range errors {
+			log.Error(fmt.Sprintf("%s (IR)", e))
+		}
+		//
+		os.Exit(4)
+	}
 }
 
-func executeIrProgram[V BaseObserver[vm.Uint]](mainFn string, config codegen.Config, program ast.Program,
+func executeAndPrint(mainFn string, config codegen.Config, program ast.Program, input map[string][]byte) []error {
+	var (
+		wm     *vm.WordMachine[vm.Uint]
+		errors []error
+	)
+	//
+	if wm, errors = executeIrProgram(mainFn, config, program, input, vm.EmptyBaseObserver{}); len(errors) > 0 {
+		return errors
+	}
+	// Collect raw outputs from write-once memories
+	rawOutputs := make(map[string][]vm.Uint)
+	//
+	for _, m := range wm.Modules() {
+		if output, ok := m.(vm.InputOutputMemory[vm.Uint]); ok && output.IsWriteOnly() {
+			rawOutputs[output.Name()] = output.Contents()
+		}
+	}
+	// Encode outputs back to bytes
+	encodedOutputs, encErrors := program.EncodeInputsOutputs(rawOutputs)
+	//
+	for _, e := range encErrors {
+		log.Error(fmt.Sprintf("%s (IR)", e))
+	}
+	// Write output
+	for name, bytes := range encodedOutputs {
+		fmt.Printf("%s = 0x%s\n", name, hex.EncodeToString(bytes))
+	}
+	//
+	return nil
+}
+
+func executeAndWrite(mainFn string, config codegen.Config, prog ast.Program, in map[string][]byte, out string) []error {
+	//
+	var (
+		observer vm.TraceObserver[vm.Uint, *vm.WordMachine[vm.Uint]]
+		trace    lt.TraceFile
+	)
+	// Execute and trace
+	wm, errors := executeIrProgram(mainFn, config, prog, in, &observer)
+	// Check for errors
+	if len(errors) == 0 {
+		// Extract trace
+		trace = observer.Trace(wm)
+		// Write trace to output file
+		WriteTraceFile(out, trace)
+	}
+	// Done
+	return errors
+}
+
+func executeIrProgram[V vm.BaseObserver[vm.Uint]](mainFn string, config codegen.Config, program ast.Program,
 	input map[string][]byte, view V,
-) {
+) (*vm.WordMachine[vm.Uint], []error) {
 	var (
 		wm        *vm.WordMachine[vm.Uint]
 		bigInputs map[string][]vm.Uint
@@ -84,44 +151,21 @@ func executeIrProgram[V BaseObserver[vm.Uint]](mainFn string, config codegen.Con
 		if len(errors) == 0 {
 			if err := wm.Boot(mainFn, bigInputs); err != nil {
 				errors = append(errors, err)
-			} else if _, err := execute[vm.Uint, V](wm, 1, view); err != nil {
+			} else if _, err := execute(wm, 1, view); err != nil {
 				errors = append(errors, err)
 			}
 		}
 	}
-	// Exit with failure (if errors)
-	if len(errors) > 0 {
-		// Log errors
-		for _, e := range errors {
-			log.Error(fmt.Sprintf("%s (IR)", e))
-		}
-		//
-		os.Exit(4)
-	}
-	// Collect raw outputs from write-once memories
-	rawOutputs := make(map[string][]vm.Uint)
-
-	for _, m := range wm.Modules() {
-		if output, ok := m.(vm.InputOutputMemory[vm.Uint]); ok && output.IsWriteOnly() {
-			rawOutputs[output.Name()] = output.Contents()
-		}
-	}
-	// Encode outputs back to bytes
-	encodedOutputs, encErrors := program.EncodeInputsOutputs(rawOutputs)
-	//
-	for _, e := range encErrors {
-		log.Error(fmt.Sprintf("%s (IR)", e))
-	}
-	// Write output
-	for name, bytes := range encodedOutputs {
-		fmt.Printf("%s = 0x%s\n", name, hex.EncodeToString(bytes))
-	}
+	// return machine + errors (if errors)
+	return wm, errors
 }
 
-func execute[W vm.Word[W], V BaseObserver[W]](machine *vm.WordMachine[W], n uint, observer V) (uint, error) {
+func execute[W vm.Word[W], V vm.BaseObserver[W]](machine *vm.WordMachine[W], n uint, observer V) (uint, error) {
 	var (
 		nsteps uint
 	)
+	//
+	observer.Initialise(machine)
 	//
 	for {
 		// observe pre execution
@@ -143,33 +187,6 @@ func execute[W vm.Word[W], V BaseObserver[W]](machine *vm.WordMachine[W], n uint
 // Machine observers
 // ============================================================================
 
-// BaseObserver is an observer for a base machin
-type BaseObserver[W vm.Word[W]] = VmObserver[W, *vm.WordMachine[W]]
-
-// EmptyBaseObserver is an empty observer for a base machine.
-type EmptyBaseObserver = EmptyObserver[vm.Uint, *vm.WordMachine[vm.Uint]]
-
-// VmObserver is a generic interface for extract information before and after an
-// execution step of the VM.  For example, to generate debugging information.
-type VmObserver[W any, M vm.Machine[W]] interface {
-	PreExecution(machine M)
-	PostExecution(machine M)
-}
-
-// EmptyObserver does nothing
-type EmptyObserver[W any, M vm.Machine[W]] struct {
-}
-
-// PreExecution implementation for Observer interface
-func (p EmptyObserver[W, M]) PreExecution(machine M) {
-	// do nothing
-}
-
-// PostExecution implementation for Observer interface
-func (p EmptyObserver[W, M]) PostExecution(machine M) {
-	// do nothing
-}
-
 // ============================================================================
 // Misc
 // ============================================================================
@@ -177,5 +194,5 @@ func (p EmptyObserver[W, M]) PostExecution(machine M) {
 //nolint:errcheck
 func init() {
 	rootCmd.AddCommand(executeCmd)
-	executeCmd.Flags().Bool("ir", false, "execute intermediate representation (IR)")
+	executeCmd.Flags().StringP("output", "o", "", "specify output file for writing trace")
 }

--- a/pkg/cmd/zkc/util.go
+++ b/pkg/cmd/zkc/util.go
@@ -18,6 +18,8 @@ import (
 	"path"
 	"strings"
 
+	"github.com/consensys/go-corset/pkg/trace/json"
+	"github.com/consensys/go-corset/pkg/trace/lt"
 	"github.com/consensys/go-corset/pkg/util/field"
 	"github.com/consensys/go-corset/pkg/util/file"
 	"github.com/consensys/go-corset/pkg/util/source"
@@ -110,4 +112,37 @@ func printSyntaxError(err *source.SyntaxError) {
 	fmt.Print(strings.Repeat(" ", lineOffset))
 	// Print highlight
 	fmt.Println(strings.Repeat("^", length))
+}
+
+// WriteTraceFile writes a given lt trace file to disk, either in JSON or LT
+// formats.
+func WriteTraceFile(filename string, tracefile lt.TraceFile) {
+	var (
+		err   error
+		bytes []byte
+	)
+	// Check file extension
+	ext := path.Ext(filename)
+	//
+	switch ext {
+	case ".json":
+		js := json.ToJsonString(tracefile.RawModules())
+		//
+		if err = os.WriteFile(filename, []byte(js), 0644); err == nil {
+			return
+		}
+	case ".lt":
+		bytes, err = tracefile.MarshalBinary()
+		//
+		if err == nil {
+			if err = os.WriteFile(filename, bytes, 0644); err == nil {
+				return
+			}
+		}
+	default:
+		err = fmt.Errorf("unknown trace file format: %s", ext)
+	}
+	// Handle error
+	fmt.Println(err)
+	os.Exit(4)
 }

--- a/pkg/zkc/vm/instruction/base/util.go
+++ b/pkg/zkc/vm/instruction/base/util.go
@@ -22,8 +22,18 @@ import (
 
 // Module represents an either a function or memory within the machine.
 type Module interface {
-	// Name of this module
+	// Name returns the name given to the enclosing entity (i.e. memory or
+	// function).
 	Name() string
+	// HasRegister checks whether a register with the given name exists and, if
+	// so, returns its register identifier.  Otherwise, it returns false.
+	HasRegister(name string) (register.Id, bool)
+	// Access a given register in this module.
+	Register(register.Id) register.Register
+	// Registers providers access to the underlying registers of this map.
+	Registers() []register.Register
+	// Width returns the number of registers declared in this module.
+	Width() uint
 }
 
 // SystemMap provides a global view of modules in the systemn.

--- a/pkg/zkc/vm/internal/machine/core.go
+++ b/pkg/zkc/vm/internal/machine/core.go
@@ -41,6 +41,10 @@ type Core[W any] interface {
 	Module(id uint) Module
 	// Return set of modules in this machine.
 	Modules() []Module
+	// Depth returns the depth of the call stack.
+	Depth() uint
+	// StackFrame returns the nth stack frame, where n==0 returns the root frame.
+	StackFrame(n uint) Frame[W]
 	// Enter a new function on the call-stack, whilst initialising its arguments
 	// with those values in the current frame taken from the given argument
 	// registers.  In addition, the return registers are saved for when (if) the
@@ -120,6 +124,11 @@ func (p *Frame[W]) Return(reg uint) W {
 // its previous contents.
 func (p *Frame[W]) Store(reg uint, value W) {
 	p.registers[reg] = value
+}
+
+// Width returns the number of values in this stack frame.
+func (p *Frame[W]) Width() uint {
+	return uint(len(p.registers))
 }
 
 // ============================================================================

--- a/pkg/zkc/vm/internal/memory/bipartite_ram.go
+++ b/pkg/zkc/vm/internal/memory/bipartite_ram.go
@@ -74,22 +74,22 @@ func (p *BiPartiteRandomAccess[W]) IsPublic() bool {
 
 // IsStatic implementation for memory interface.
 func (p *BiPartiteRandomAccess[W]) IsStatic() bool {
-	return p.kind.IsPublic()
+	return p.kind.IsStatic()
 }
 
 // IsReadOnly implementation for memory interface.
 func (p *BiPartiteRandomAccess[W]) IsReadOnly() bool {
-	return p.kind.IsPublic()
+	return p.kind.IsReadOnly()
 }
 
 // IsWriteOnly implementation for memory interface.
 func (p *BiPartiteRandomAccess[W]) IsWriteOnly() bool {
-	return p.kind.IsPublic()
+	return p.kind.IsWriteOnly()
 }
 
 // IsReadWrite implementation for memory interface.
 func (p *BiPartiteRandomAccess[W]) IsReadWrite() bool {
-	return p.kind.IsPublic()
+	return p.kind.IsReadWrite()
 }
 
 // Name implementation for Memory interface.
@@ -168,6 +168,32 @@ func (p *BiPartiteRandomAccess[W]) Write(frame []W, address []register.Id, data 
 	}
 	//
 	return nil
+}
+
+// HasRegister implementation for vm.Module interface.
+func (p *BiPartiteRandomAccess[W]) HasRegister(name string) (register.Id, bool) {
+	for i, r := range p.geometry.registers {
+		if r.Name() == name {
+			return register.NewId(uint(i)), true
+		}
+	}
+	// Failed
+	return register.UnusedId(), false
+}
+
+// Register implementation for vm.Module interface.
+func (p *BiPartiteRandomAccess[W]) Register(id register.Id) register.Register {
+	return p.geometry.registers[id.Unwrap()]
+}
+
+// Registers implementation for vm.Module interface.
+func (p *BiPartiteRandomAccess[W]) Registers() []register.Register {
+	return p.geometry.registers
+}
+
+// Width implementation for Module interface.
+func (p *BiPartiteRandomAccess[W]) Width() uint {
+	return uint(len(p.geometry.registers))
 }
 
 // readLower returns the word at the given absolute position in the lower

--- a/pkg/zkc/vm/internal/memory/geometry.go
+++ b/pkg/zkc/vm/internal/memory/geometry.go
@@ -60,6 +60,16 @@ func NewGeometry[W util.Uinter64](registers []register.Register) Geometry[W] {
 	return Geometry[W]{registers, inputs, outputs}
 }
 
+// AddressLines returns the number of address lines
+func (p Geometry[W]) AddressLines() uint {
+	return p.numInputs
+}
+
+// DataLines returns the number of data lines
+func (p Geometry[W]) DataLines() uint {
+	return p.numOutputs
+}
+
 // Registers returns the set of registers used for the address and data lines of
 // this memory.
 func (p Geometry[W]) Registers() []register.Register {

--- a/pkg/zkc/vm/internal/memory/memory.go
+++ b/pkg/zkc/vm/internal/memory/memory.go
@@ -15,6 +15,7 @@ package memory
 import (
 	"github.com/consensys/go-corset/pkg/schema/register"
 	"github.com/consensys/go-corset/pkg/util"
+	"github.com/consensys/go-corset/pkg/zkc/vm/instruction/base"
 )
 
 // Memory represents (in many ways) the simplest form of memory
@@ -23,8 +24,8 @@ import (
 // not yet been written will return zero; otherwise, it will return the last
 // value written.
 type Memory[W util.Uinter64] interface {
-	// Name returns the name of this RAM
-	Name() string
+	base.Module
+	// Geometry defines the geometry of this RAM.
 	Geometry() Geometry[W]
 	// IsPublic indicates whether this is a public input or output.
 	IsPublic() bool

--- a/pkg/zkc/vm/internal/memory/static_array.go
+++ b/pkg/zkc/vm/internal/memory/static_array.go
@@ -49,22 +49,22 @@ func (p *StaticArray[W]) IsPublic() bool {
 
 // IsStatic implementation for memory interface.
 func (p *StaticArray[W]) IsStatic() bool {
-	return p.kind.IsPublic()
+	return p.kind.IsStatic()
 }
 
 // IsReadOnly implementation for memory interface.
 func (p *StaticArray[W]) IsReadOnly() bool {
-	return p.kind.IsPublic()
+	return p.kind.IsReadOnly()
 }
 
 // IsWriteOnly implementation for memory interface.
 func (p *StaticArray[W]) IsWriteOnly() bool {
-	return p.kind.IsPublic()
+	return p.kind.IsWriteOnly()
 }
 
 // IsReadWrite implementation for memory interface.
 func (p *StaticArray[W]) IsReadWrite() bool {
-	return p.kind.IsPublic()
+	return p.kind.IsReadWrite()
 }
 
 // Name implementation for Memory interface.
@@ -104,6 +104,32 @@ func (p *StaticArray[W]) Write(frame []W, address []register.Id, data []register
 	}
 	//
 	return nil
+}
+
+// HasRegister implementation for vm.Module interface.
+func (p *StaticArray[W]) HasRegister(name string) (register.Id, bool) {
+	for i, r := range p.geometry.registers {
+		if r.Name() == name {
+			return register.NewId(uint(i)), true
+		}
+	}
+	// Failed
+	return register.UnusedId(), false
+}
+
+// Register implementation for vm.Module interface.
+func (p *StaticArray[W]) Register(id register.Id) register.Register {
+	return p.geometry.registers[id.Unwrap()]
+}
+
+// Registers implementation for vm.Module interface.
+func (p *StaticArray[W]) Registers() []register.Register {
+	return p.geometry.registers
+}
+
+// Width implementation for Module interface.
+func (p *StaticArray[W]) Width() uint {
+	return uint(len(p.geometry.registers))
 }
 
 // Expand a slice to ensure it has at least length n.  If the slice already has

--- a/pkg/zkc/vm/internal/trace/empty_observer.go
+++ b/pkg/zkc/vm/internal/trace/empty_observer.go
@@ -1,0 +1,34 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package trace
+
+import "github.com/consensys/go-corset/pkg/zkc/vm/internal/machine"
+
+// EmptyObserver does nothing
+type EmptyObserver[W any, M machine.Core[W]] struct {
+}
+
+// Initialise implementation for Observer interface
+func (p EmptyObserver[W, M]) Initialise(machine M) {
+	// do nothing
+}
+
+// PreExecution implementation for Observer interface
+func (p EmptyObserver[W, M]) PreExecution(machine M) {
+	// do nothing
+}
+
+// PostExecution implementation for Observer interface
+func (p EmptyObserver[W, M]) PostExecution(machine M) {
+	// do nothing
+}

--- a/pkg/zkc/vm/internal/trace/full_observer.go
+++ b/pkg/zkc/vm/internal/trace/full_observer.go
@@ -1,0 +1,347 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package trace
+
+import (
+	"github.com/consensys/go-corset/pkg/schema/register"
+	"github.com/consensys/go-corset/pkg/trace"
+	"github.com/consensys/go-corset/pkg/trace/lt"
+	"github.com/consensys/go-corset/pkg/util/collection/array"
+	"github.com/consensys/go-corset/pkg/util/collection/bit"
+	"github.com/consensys/go-corset/pkg/util/collection/pool"
+	"github.com/consensys/go-corset/pkg/util/collection/stack"
+	"github.com/consensys/go-corset/pkg/util/field"
+	util_word "github.com/consensys/go-corset/pkg/util/word"
+	"github.com/consensys/go-corset/pkg/zkc/vm/instruction"
+	"github.com/consensys/go-corset/pkg/zkc/vm/internal/function"
+	"github.com/consensys/go-corset/pkg/zkc/vm/internal/machine"
+	"github.com/consensys/go-corset/pkg/zkc/vm/internal/memory"
+	"github.com/consensys/go-corset/pkg/zkc/vm/internal/word"
+)
+
+// FullObserver is an observer which can be used to extract a trace.
+type FullObserver[W word.Word[W], M machine.Core[W]] struct {
+	// Contains complete frames for the trace data being constructed during
+	// execution.
+	trace [][]State[W]
+	// Callstack contains partial data
+	callstack stack.Stack[StackFrame[W]]
+}
+
+// Initialise implementation for Observer interface
+func (p *FullObserver[W, M]) Initialise(machine M) {
+	// initialise data structures
+	p.trace = make([][]State[W], len(machine.Modules()))
+	p.callstack = stack.Stack[StackFrame[W]]{}
+	// initialise input ROMs
+	for i, m := range machine.Modules() {
+		// Check whether this is a (non-static) read-only memory
+		if m, ok := m.(*memory.ReadOnly[W]); ok {
+			p.trace[i] = initialiseROM(m)
+		}
+	}
+}
+
+// PreExecution implementation for Observer interface
+func (p *FullObserver[W, M]) PreExecution(machine M) {
+	var depth = p.callstack.Len()
+	//
+	if machine.Depth() > depth {
+		p.enterFunction(machine)
+	} else if machine.Depth() < depth {
+		p.leaveFunction(machine)
+	} else if depth != 0 {
+		// Extract enclosing frame
+		var frame = machine.StackFrame(depth - 1)
+		// Check whether enclosing vector is finishing (i.e. about to execute a
+		// terminal instruction which either terminates the enclosing function, or
+		// moves the program counter to the next vector instruction).
+		if next, end := isVectorTerminal(frame, machine); next || end {
+			var (
+				contents = loadWords(0, frame.Width(), frame)
+				state    = NewState(frame.PC().Macro(), end, frame.Width(), contents)
+			)
+			// Record state
+			sf := p.callstack.Pop()
+			sf.states = append(sf.states, state)
+			p.callstack.Push(sf)
+		}
+	}
+}
+
+// PostExecution implementation for Observer interface
+func (p *FullObserver[W, M]) PostExecution(machine M) {
+}
+
+// Trace returns an lt.TraceFile representing the given trace.
+func (p *FullObserver[W, M]) Trace(machine M) lt.TraceFile {
+	var (
+		heap    = pool.NewLocalHeap[util_word.BigEndian]()
+		builder = array.NewDynamicBuilder(heap)
+		modules = make([]lt.Module[util_word.BigEndian], len(machine.Modules()))
+	)
+	//
+	for i, t := range p.trace {
+		var m = machine.Module(uint(i))
+		//
+		modules[i] = p.traceModule(m, t, &builder)
+	}
+	// Construct trace file
+	return lt.NewTraceFile(nil, *heap, modules)
+}
+
+func (p *FullObserver[W, M]) traceModule(m machine.Module, states []State[W],
+	builder array.Builder[util_word.BigEndian]) lt.Module[util_word.BigEndian] {
+	//
+	var (
+		name      = trace.ModuleName{Name: m.Name(), Multiplier: 1}
+		cols      []array.MutArray[util_word.BigEndian]
+		nrows     = uint(len(states))
+		multiLine = isMultiLineFunction(m)
+	)
+	// Initialise columns
+	if multiLine {
+		// include space for two additional control registers
+		cols = make([]array.MutArray[util_word.BigEndian], m.Width()+2)
+	} else {
+		cols = make([]array.MutArray[util_word.BigEndian], m.Width())
+	}
+	// Initialise register columns
+	for i, r := range m.Registers() {
+		cols[i] = builder.NewArray(nrows, r.Width())
+	}
+	// Initialise control columns (if applicable)
+	// transcribe values
+	for row, st := range states {
+		for i := range m.Registers() {
+			var (
+				val  util_word.BigEndian
+				word = st.state[i]
+			)
+			// Copy over data
+			val = val.SetBytes(word.BigInt().Bytes())
+			//
+			cols[i] = cols[i].Set(uint(row), val)
+		}
+	}
+	// Set control registers for multi-line functions
+	if multiLine {
+		// Extract function
+		f := m.(*function.Function[instruction.Word])
+		// Add control registers
+		p.assignControlRegisters(f, cols, states, builder)
+	}
+	// Done
+	return lt.NewModule(name, traceColumns(m.Registers(), cols))
+}
+
+func (p *FullObserver[W, M]) assignControlRegisters(m *function.Function[instruction.Word],
+	cols []array.MutArray[util_word.BigEndian], states []State[W], builder array.Builder[util_word.BigEndian]) {
+	//
+	var (
+		zero  = field.Zero[util_word.BigEndian]()
+		one   = field.One[util_word.BigEndian]()
+		nrows = uint(len(states))
+		pc    = uint(len(m.Registers()))
+		ret   = pc + 1
+		// Calculate minimum size of PC; NOTE: +1 because PC==0 is reserved for padding.
+		pcWidth = bit.Width(uint(len(m.Code()) + 1))
+	)
+	// Initialise columns
+	cols[pc] = builder.NewArray(nrows, pcWidth)
+	cols[ret] = builder.NewArray(nrows, 1)
+	// Assign values
+	for row, st := range states {
+		npc := field.Uint64[util_word.BigEndian](uint64(st.pc + 1))
+		// NOTE: +1 because PC==0 reserved for padding.
+		cols[pc] = cols[pc].Set(uint(row), npc)
+		// Check whether this is a terminating state, or not.
+		if st.terminal {
+			cols[ret] = cols[ret].Set(uint(row), one)
+		} else {
+			cols[ret] = cols[ret].Set(uint(row), zero)
+		}
+	}
+}
+
+func (p *FullObserver[W, M]) enterFunction(machine M) {
+	var (
+		depth = p.callstack.Len()
+		// Extract machine frame
+		frame = machine.StackFrame(depth)
+		// Extract executing function
+		fun = machine.Module(frame.Function()).(*function.Function[instruction.Word])
+		// Read arguments
+		inputs = loadWords(0, fun.NumInputs(), frame)
+	)
+	// initialise frame
+	p.callstack.Push(InitialStackFrame(frame.Function(), fun.Registers(), inputs))
+	// sanity check
+	if depth+1 != machine.Depth() {
+		panic("incorrect machine depth")
+	}
+}
+
+func (p *FullObserver[W, M]) leaveFunction(machine M) {
+	// Pop executing stack frame
+	frame := p.callstack.Pop()
+	// Append all rows to the given trace
+	p.trace[frame.id] = append(p.trace[frame.id], frame.states...)
+	// sanity check
+	if p.callstack.Len() != machine.Depth() {
+		panic("incorrect machine depth")
+	}
+}
+
+// StackFrame contains all the state related to a given function invocation
+// which is currently executing.
+type StackFrame[W any] struct {
+	// id of function being called
+	id uint
+	//
+	states []State[W]
+}
+
+// InitialStackFrame constructs the initial frame when a given function is
+// invoked with the given arguments.
+func InitialStackFrame[W any](id uint, registers []register.Register, args []W) StackFrame[W] {
+	var width = uint(len(registers))
+	//
+	return StackFrame[W]{
+		id:     id,
+		states: []State[W]{NewState(0, false, width, args)},
+	}
+}
+
+// State collects together local state necessary for executing a given
+// instruction.
+type State[W any] struct {
+	// Program Counter position.
+	pc uint
+	// Terminal indicates this is a terminating state
+	terminal bool
+	// Values for each register in this state excluding the program counter
+	// (since this is held above).  Thus, this array has one less item than
+	// registers.
+	state []W
+}
+
+// NewState constructs an initial state at the given PC value for an
+// invocation with the given arguments.
+func NewState[W any](pc uint, terminal bool, width uint, values []W) State[W] {
+	var state = make([]W, width)
+	// copy over initial argument values
+	copy(state, values)
+	// Construct state
+	return State[W]{pc, terminal, state}
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+func loadWords[W any](start, end uint, frame machine.Frame[W]) []W {
+	var (
+		n     = end - start
+		words = make([]W, n)
+	)
+	// Read words
+	for i := range n {
+		words[i] = frame.Load(i + start)
+	}
+	// Done
+	return words
+}
+
+func isMultiLineFunction(m machine.Module) bool {
+	if f, ok := m.(*function.Function[instruction.Word]); ok {
+		return !f.IsAtomic()
+	}
+	//
+	return false
+}
+
+// Check whether the next instruction to execute will terminate the enclosing
+// vector instruction.  There are two ways a vector instruction can terminate.
+// Either it returns entirely from the enclosing function, or its jumps to the
+// next instruction.
+func isVectorTerminal[W any](frame machine.Frame[W], m machine.Core[W]) (next, end bool) {
+	var (
+		pc = frame.PC()
+		// Determine enclosing function
+		fun = m.Module(frame.Function()).(*function.Function[instruction.Word])
+		// Determine enclosing vector
+		vector = fun.CodeAt(pc.Macro())
+		// Determine specific (micro) instruction
+		insn = vector.Codes[pc.Micro()]
+	)
+	// See what we've got.
+	switch insn.(type) {
+	case *instruction.Return,
+		*instruction.Fail:
+		return false, true
+	case *instruction.Jump:
+		return true, false
+	default:
+		return false, false
+	}
+}
+
+func traceColumns[W any](regs []register.Register, cols []array.MutArray[W]) []lt.Column[W] {
+	var ltcols = make([]lt.Column[W], len(cols))
+	//
+	for i, c := range cols {
+		var name string
+		// Determine name
+		if i < len(regs) {
+			name = regs[i].Name()
+		} else if i == len(regs) {
+			name = "$pc"
+		} else {
+			name = "$ret"
+		}
+		//
+		ltcols[i] = lt.NewColumn(name, c)
+	}
+	//
+	return ltcols
+}
+
+func initialiseROM[W word.Word[W]](rom *memory.ReadOnly[W]) []State[W] {
+	var (
+		states       []State[W]
+		addressWidth = int(rom.Geometry().AddressLines())
+		dataWidth    = int(rom.Geometry().DataLines())
+		contents     = rom.Contents()
+	)
+	// sanity check (for now)
+	if rom.Geometry().AddressLines() > 1 {
+		panic("support ROM with multiple address lines")
+	}
+	//
+	for i := 0; i < len(contents); i += dataWidth {
+		var (
+			address W
+			data    = contents[i : i+dataWidth]
+			words   = make([]W, rom.Width())
+		)
+		// Configure address line
+		words[0] = address.SetUint64(uint64(i / dataWidth))
+		//
+		copy(words[addressWidth:], data)
+		//
+		states = append(states, NewState(0, false, rom.Width(), words))
+	}
+	//
+	return states
+}

--- a/pkg/zkc/vm/internal/trace/observer.go
+++ b/pkg/zkc/vm/internal/trace/observer.go
@@ -10,21 +10,16 @@
 // specific language governing permissions and limitations under the License.
 //
 // SPDX-License-Identifier: Apache-2.0
-package vm
+package trace
 
-import (
-	"github.com/consensys/go-corset/pkg/zkc/vm/internal/trace"
-)
+import "github.com/consensys/go-corset/pkg/zkc/vm/internal/machine"
 
 // Observer is a generic interface for extract information before and after an
 // execution step of the VM.  For example, to generate debugging information.
-type Observer[W any, M Machine[W]] = trace.Observer[W, M]
-
-// BaseObserver is an observer for a base machin
-type BaseObserver[W Word[W]] = trace.Observer[W, *WordMachine[W]]
-
-// EmptyBaseObserver is an empty observer for a base machine.
-type EmptyBaseObserver = trace.EmptyObserver[Uint, *WordMachine[Uint]]
-
-// TraceObserver is an observer which can be used to extract a full trace.
-type TraceObserver[W Word[W], M Machine[W]] = trace.FullObserver[W, M]
+type Observer[W any, M machine.Core[W]] interface {
+	Initialise(machine M)
+	// PreExecution is called directly before each instruction is executed
+	PreExecution(machine M)
+	// PostExecution is called directly after each instruction is executed.
+	PostExecution(machine M)
+}


### PR DESCRIPTION
This adds support for trace generation using vm execution.  There remain a number of caveats: (i) multi-line functions are not supported; (ii) read-only memories with more than one address line are not supported; other forms of memory do not generate traces; (iii) it does not expand all the way to a raw trace.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new execution mode that records and serializes VM traces, and extends the VM observer/core interfaces; this touches execution flow and module/memory interfaces, so regressions could affect runtime behavior and tooling output.
> 
> **Overview**
> `zkc execute` now supports **trace generation to disk** via a new `--output/-o` flag: without it, execution prints program outputs as before; with it, execution runs under a `vm.TraceObserver` and writes an `.lt` (binary) or `.json` trace file.
> 
> This introduces a formal `Observer` API with an `Initialise()` hook (now invoked by the execute loop), adds a full trace collector (`FullObserver`) exported as `vm.TraceObserver`, and updates the debug trace printer to the new word-instruction function type.
> 
> Separately, it fixes memory kind reporting (`IsStatic`/`IsReadOnly`/`IsWriteOnly`/`IsReadWrite` were incorrectly delegating to `IsPublic`) and expands the VM/module interfaces to expose stack depth/frames and module register metadata needed for trace construction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a9b0252988c9e9c2ef68a919101f1a3facee6f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->