### PR TITLE
feat: support basic check command

### DIFF
--- a/pkg/cmd/corset/check.go
+++ b/pkg/cmd/corset/check.go
@@ -24,6 +24,7 @@ import (
 	cmd_util "github.com/consensys/go-corset/pkg/cmd/corset/util"
 	"github.com/consensys/go-corset/pkg/cmd/corset/view"
 	"github.com/consensys/go-corset/pkg/corset"
+	"github.com/consensys/go-corset/pkg/ir"
 	sc "github.com/consensys/go-corset/pkg/schema"
 	"github.com/consensys/go-corset/pkg/schema/constraint"
 	"github.com/consensys/go-corset/pkg/schema/constraint/lookup"
@@ -65,7 +66,7 @@ var checkCmds = []FieldAgnosticCmd{
 }
 
 func runCheckCmd[F field.Element[F]](cmd *cobra.Command, args []string) {
-	var cfg checkConfig
+	var cfg CheckConfig
 
 	if len(args) < 2 {
 		fmt.Println(cmd.UsageString())
@@ -80,21 +81,21 @@ func runCheckCmd[F field.Element[F]](cmd *cobra.Command, args []string) {
 	//
 	batched := GetFlag(cmd, "batched")
 	//
-	cfg.padding.Right = GetUint(cmd, "padding")
-	cfg.report = GetFlag(cmd, "report")
-	cfg.reportPadding = GetUint(cmd, "report-context")
-	cfg.reportLimbs = GetFlag(cmd, "show-limbs")
-	cfg.reportComputed = GetFlag(cmd, "show-computed")
-	cfg.reportCellWidth = GetUint(cmd, "report-cellwidth")
-	cfg.reportTitleWidth = GetUint(cmd, "report-titlewidth")
-	cfg.ansiEscapes = GetFlag(cmd, "ansi-escapes")
+	cfg.Padding.Right = GetUint(cmd, "padding")
+	cfg.Report = GetFlag(cmd, "report")
+	cfg.ReportPadding = GetUint(cmd, "report-context")
+	cfg.ReportLimbs = GetFlag(cmd, "show-limbs")
+	cfg.ReportComputed = GetFlag(cmd, "show-computed")
+	cfg.ReportCellWidth = GetUint(cmd, "report-cellwidth")
+	cfg.ReportTitleWidth = GetUint(cmd, "report-titlewidth")
+	cfg.AnsiEscapes = GetFlag(cmd, "ansi-escapes")
 	// TODO: support true ranges
-	cfg.padding.Left = cfg.padding.Right
+	cfg.Padding.Left = cfg.Padding.Right
 	// Read in constraint files
 	schemas := *getSchemaStack[F](cmd, SCHEMA_DEFAULT_AIR, args[1:]...)
 	// enable / disable coverage
 	if covfile := GetString(cmd, "coverage"); covfile != "" {
-		cfg.coverage = util.Some(covfile)
+		cfg.Coverage = util.Some(covfile)
 	}
 	//
 	tracefile := args[0]
@@ -142,36 +143,35 @@ func writeMemProfile(cmd *cobra.Command) {
 	}
 }
 
-// check config encapsulates certain parameters to be used when
-// checking traces.
-type checkConfig struct {
+// CheckConfig encapsulates certain parameters to be used when checking traces.
+type CheckConfig struct {
 	// Corset source mapping (maybe nil if non available).
-	corsetSourceMap *corset.SourceMap
-	// Specifies whether to use coverage testing and, if so, where to write the
-	// coverage data.
-	coverage util.Option[string]
-	// Specifies the range of padding values to check
-	padding util.Pair[uint, uint]
-	// Specifies whether or not to report details of the failure (e.g. for
+	CorsetSourceMap *corset.SourceMap
+	// Specifies whether to use Coverage testing and, if so, where to write the
+	// Coverage data.
+	Coverage util.Option[string]
+	// Specifies the range of Padding values to check
+	Padding util.Pair[uint, uint]
+	// Specifies whether or not to Report details of the failure (e.g. for
 	// debugging purposes).
-	report bool
+	Report bool
 	// Specifies the number of additional rows to show eitherside of the failing
 	// area. This essentially allows more contextual information to be shown.
-	reportPadding uint
+	ReportPadding uint
 	// Specifies the width of a cell to show.
-	reportCellWidth uint
+	ReportCellWidth uint
 	// Specifies the width of a column title to show.
-	reportTitleWidth uint
+	ReportTitleWidth uint
 	// Specifies whether or not to show raw limbs
-	reportLimbs bool
+	ReportLimbs bool
 	// Specifies whether or not to show raw computed registers
-	reportComputed bool
+	ReportComputed bool
 	// Enable ansi escape codes in reports
-	ansiEscapes bool
+	AnsiEscapes bool
 }
 
 // Check raw constraints using the legacy pipeline.
-func checkWithLegacyPipeline[F field.Element[F]](cfg checkConfig, batched bool, tracefile string,
+func checkWithLegacyPipeline[F field.Element[F]](cfg CheckConfig, batched bool, tracefile string,
 	schemas cmd_util.SchemaStacker[F]) {
 	//
 	var (
@@ -183,7 +183,7 @@ func checkWithLegacyPipeline[F field.Element[F]](cfg checkConfig, batched bool, 
 	//
 	stats := util.NewPerfStats()
 	// Extract debug information (if available)
-	cfg.corsetSourceMap, _ = binfile.GetAttribute[*corset.SourceMap](schemas.BinaryFile())
+	cfg.CorsetSourceMap, _ = binfile.GetAttribute[*corset.SourceMap](schemas.BinaryFile())
 	//
 	stats.Log("Reading constraints file")
 	// Parse trace file(s)
@@ -218,11 +218,11 @@ func checkWithLegacyPipeline[F field.Element[F]](cfg checkConfig, batched bool, 
 	}
 }
 
-func checkTraces[F field.Element[F]](traces []lt.TraceFile, stacker cmd_util.SchemaStacker[F], cfg checkConfig) bool {
+func checkTraces[F field.Element[F]](traces []lt.TraceFile, stacker cmd_util.SchemaStacker[F], cfg CheckConfig) bool {
 	//
 	for _, tf := range traces {
 		//
-		for n := cfg.padding.Left; n <= cfg.padding.Right; n++ {
+		for n := cfg.Padding.Left; n <= cfg.Padding.Right; n++ {
 			// Configure stack.  This is important to ensure true separation
 			// between runs (e.g. for the io.Executor).
 			stack := stacker.Build()
@@ -232,35 +232,47 @@ func checkTraces[F field.Element[F]](traces []lt.TraceFile, stacker cmd_util.Sch
 			schema := stack.ConcreteSchema()
 			// identify schema name
 			ir := stack.ConcreteIrName()
-			// begin performance measurement
-			stats := util.NewPerfStats()
-			trace, errs := builder.Build(schema, tf)
-			// Log cost of expansion
-			stats.Log("Expanding trace columns")
-			// Report any errors
-			reportErrors(ir, errs)
-			// Check whether considered unrecoverable
-			if trace == nil || len(errs) > 0 {
-				return false
-			}
 			//
-			stats = util.NewPerfStats()
-			// Check constraints
-			if errs := sc.Accepts(builder.Parallelism(), builder.BatchSize(), schema, trace); len(errs) > 0 {
-				reportFailures(ir, errs, trace, builder.Mapping(), cfg)
+			if ok := CheckTrace(ir, schema, tf, builder, cfg); !ok {
 				return false
 			}
-
-			stats.Log("Checking constraints")
 		}
 	}
 	// Done
 	return true
 }
 
+// CheckTrace checks a given set of constraints against a given trace file using
+// a configured trace builder and check configuration.
+func CheckTrace[F field.Element[F]](ir string, schema sc.AnySchema[F], tf lt.TraceFile, builder ir.TraceBuilder[F],
+	cfg CheckConfig) bool {
+	// begin performance measurement
+	stats := util.NewPerfStats()
+	trace, errs := builder.Build(schema, tf)
+	// Log cost of expansion
+	stats.Log("Expanding trace columns")
+	// Report any errors
+	reportErrors(ir, errs)
+	// Check whether considered unrecoverable
+	if trace == nil || len(errs) > 0 {
+		return false
+	}
+	//
+	stats = util.NewPerfStats()
+	// Check constraints
+	if errs := sc.Accepts(builder.Parallelism(), builder.BatchSize(), schema, trace); len(errs) > 0 {
+		reportFailures(ir, errs, trace, builder.Mapping(), cfg)
+		return false
+	}
+	//
+	stats.Log("Checking constraints")
+	//
+	return true
+}
+
 // Report constraint failures, whilst providing contextual information (when requested).
 func reportFailures[F field.Element[F]](ir string, failures []sc.Failure, trace tr.Trace[F], mapping module.LimbsMap,
-	cfg checkConfig) {
+	cfg CheckConfig) {
 	//
 	var (
 		errs = make([]error, len(failures))
@@ -272,7 +284,7 @@ func reportFailures[F field.Element[F]](ir string, failures []sc.Failure, trace 
 	// First, log errors
 	reportErrors(ir, errs)
 	// Second, produce report (if requested)
-	if cfg.report {
+	if cfg.Report {
 		for _, f := range failures {
 			reportFailure(f, trace, mapping, cfg)
 		}
@@ -281,7 +293,7 @@ func reportFailures[F field.Element[F]](ir string, failures []sc.Failure, trace 
 
 // Print a human-readable report detailing the given failure
 func reportFailure[F field.Element[F]](failure sc.Failure, trace tr.Trace[F], mapping module.LimbsMap,
-	cfg checkConfig) {
+	cfg CheckConfig) {
 	//
 	if f, ok := failure.(*vanishing.Failure[F]); ok {
 		cells := f.RequiredCells(trace)
@@ -308,18 +320,22 @@ func reportFailure[F field.Element[F]](failure sc.Failure, trace tr.Trace[F], ma
 
 // Print a human-readable report detailing the given failure with a vanishing constraint.
 func reportRelevantCells[F field.Element[F]](cells *set.AnySortedSet[tr.CellRef], trace tr.Trace[F],
-	mapping module.LimbsMap, cfg checkConfig) {
+	mapping module.LimbsMap, cfg CheckConfig) {
 	// Construct trace window
-	window := view.NewBuilder[F](mapping).
-		WithLimbs(cfg.reportLimbs).
-		WithComputed(cfg.reportComputed).
-		WithCellWidth(cfg.reportCellWidth).
-		WithTitleWidth(cfg.reportTitleWidth).
-		WithSourceMap(*cfg.corsetSourceMap).
-		WithFormatting(view.NewCellFormatter(*cells, cfg.ansiEscapes)).
-		Build(trace)
+	builder := view.NewBuilder[F](mapping).
+		WithLimbs(cfg.ReportLimbs).
+		WithComputed(cfg.ReportComputed).
+		WithCellWidth(cfg.ReportCellWidth).
+		WithTitleWidth(cfg.ReportTitleWidth).
+		WithFormatting(view.NewCellFormatter(*cells, cfg.AnsiEscapes))
+		//
+	if cfg.CorsetSourceMap != nil {
+		builder = builder.WithSourceMap(*cfg.CorsetSourceMap)
+	}
+	// Build window
+	window := builder.Build(trace)
 	// Focus window on those cells relevant to the failure
-	window = window.Filter(view.FilterForCells(*cells, cfg.reportPadding))
+	window = window.Filter(view.FilterForCells(*cells, cfg.ReportPadding))
 	// Print all windows
 	for i := range window.Width() {
 		var (

--- a/pkg/cmd/zkc/execute.go
+++ b/pkg/cmd/zkc/execute.go
@@ -17,6 +17,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/consensys/go-corset/pkg/cmd/corset"
+	"github.com/consensys/go-corset/pkg/ir"
+	"github.com/consensys/go-corset/pkg/schema/module"
 	"github.com/consensys/go-corset/pkg/trace/lt"
 	"github.com/consensys/go-corset/pkg/util/field"
 	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
@@ -26,6 +29,7 @@ import (
 	"github.com/consensys/go-corset/pkg/util/source"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/ast"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/codegen"
+	"github.com/consensys/go-corset/pkg/zkc/constraints"
 	"github.com/consensys/go-corset/pkg/zkc/vm"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -51,26 +55,59 @@ var executeCmds = []FieldAgnosticCmd{
 
 func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field field.Config) {
 	var (
-		errors []error
 		// compiler config
 		config = codegen.DEFAULT_CONFIG.
 			Vectorize(GetFlag(cmd, "vectorize")).
 			Field(field)
 		// output file for trace
 		output = GetString(cmd, "output")
+		// check constraints
+		check = GetFlag(cmd, "check")
+		// identify whether tracing required or not.
+		tracing = check || output != ""
+		// machine used for execution
+		wm *vm.WordMachine[vm.Uint]
+		//
+		tf lt.TraceFile
 	)
+	// Construct trace builder
+	builder := ir.NewTraceBuilder[F]().
+		WithValidation(true).
+		WithDefensivePadding(true).
+		WithExpansion(true).
+		WithParallelism(true).
+		WithBatchSize(1024)
 	//
 	input := ParseInputFile(args[0])
 	// Compile source files, or print errors
 	program := CompileSourceFiles(field, args[1:]...)
-	//
-	if output == "" {
-		errors = executeAndPrint("main", config, program, input)
+	// Execute program (in either fast or slow mode)
+	if tracing {
+		wm, tf = executeAndTrace("main", config, program, input)
 	} else {
-		errors = executeAndWrite("main", config, program, input, output)
+		wm = executeNoTrace("main", config, program, input)
 	}
-	// Exit with failure (if errors)
-	if len(errors) > 0 {
+	// Generate output
+	if output == "" {
+		printOutput(program, wm)
+	} else {
+		WriteTraceFile(output, tf)
+	}
+	// Check constraints (if requested)
+	if check {
+		checkConstraints(builder, field, wm, tf)
+	}
+}
+
+func executeNoTrace(mainFn string, config codegen.Config, program ast.Program, input map[string][]byte,
+) *vm.WordMachine[vm.Uint] {
+	//
+	var (
+		wm     *vm.WordMachine[vm.Uint]
+		errors []error
+	)
+	//
+	if wm, errors = executeIrProgram(mainFn, config, program, input, vm.EmptyBaseObserver{}); len(errors) > 0 {
 		// Log errors
 		for _, e := range errors {
 			log.Error(fmt.Sprintf("%s (IR)", e))
@@ -78,17 +115,32 @@ func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 		//
 		os.Exit(4)
 	}
+	// Done
+	return wm
 }
 
-func executeAndPrint(mainFn string, config codegen.Config, program ast.Program, input map[string][]byte) []error {
+func executeAndTrace(mainFn string, config codegen.Config, program ast.Program, input map[string][]byte,
+) (*vm.WordMachine[vm.Uint], lt.TraceFile) {
+	//
 	var (
-		wm     *vm.WordMachine[vm.Uint]
-		errors []error
+		wm       *vm.WordMachine[vm.Uint]
+		errors   []error
+		observer vm.TraceObserver[vm.Uint, *vm.WordMachine[vm.Uint]]
 	)
 	//
-	if wm, errors = executeIrProgram(mainFn, config, program, input, vm.EmptyBaseObserver{}); len(errors) > 0 {
-		return errors
+	if wm, errors = executeIrProgram(mainFn, config, program, input, &observer); len(errors) > 0 {
+		// Log errors
+		for _, e := range errors {
+			log.Error(fmt.Sprintf("%s (IR)", e))
+		}
+		//
+		os.Exit(4)
 	}
+	// Done
+	return wm, observer.Trace(wm)
+}
+
+func printOutput(program ast.Program, wm *vm.WordMachine[vm.Uint]) {
 	// Collect raw outputs from write-once memories
 	rawOutputs := make(map[string][]vm.Uint)
 	//
@@ -107,27 +159,32 @@ func executeAndPrint(mainFn string, config codegen.Config, program ast.Program, 
 	for name, bytes := range encodedOutputs {
 		fmt.Printf("%s = 0x%s\n", name, hex.EncodeToString(bytes))
 	}
-	//
-	return nil
 }
 
-func executeAndWrite(mainFn string, config codegen.Config, prog ast.Program, in map[string][]byte, out string) []error {
+func checkConstraints[F field.Element[F]](builder ir.TraceBuilder[F], config field.Config, wm *vm.WordMachine[vm.Uint],
+	tf lt.TraceFile) {
 	//
-	var (
-		observer vm.TraceObserver[vm.Uint, *vm.WordMachine[vm.Uint]]
-		trace    lt.TraceFile
-	)
-	// Execute and trace
-	wm, errors := executeIrProgram(mainFn, config, prog, in, &observer)
-	// Check for errors
-	if len(errors) == 0 {
-		// Extract trace
-		trace = observer.Trace(wm)
-		// Write trace to output file
-		WriteTraceFile(out, trace)
+	var cfg corset.CheckConfig
+	// Set sensible defaults (for now)
+	cfg.Report = true
+	cfg.ReportCellWidth = 32
+	cfg.ReportTitleWidth = 40
+	cfg.ReportPadding = 2
+	cfg.ReportLimbs = true
+	cfg.ReportComputed = true
+	cfg.AnsiEscapes = true
+	// Lower to field machine
+	fvm := vm.LowerWordMachine[vm.Uint, F](config, wm)
+	// Generate MIR constraints
+	avm := constraints.GenerateMirConstraints(fvm)
+	// Construct limbs map
+	mapping := module.NewLimbsMap[F](config, avm.Modules().Collect()...)
+	// Register mappin
+	builder = builder.WithRegisterMapping(mapping)
+	// check the trace
+	if !corset.CheckTrace("MIR", avm, tf, builder, cfg) {
+		os.Exit(4)
 	}
-	// Done
-	return errors
 }
 
 func executeIrProgram[V vm.BaseObserver[vm.Uint]](mainFn string, config codegen.Config, program ast.Program,
@@ -195,4 +252,5 @@ func execute[W vm.Word[W], V vm.BaseObserver[W]](machine *vm.WordMachine[W], n u
 func init() {
 	rootCmd.AddCommand(executeCmd)
 	executeCmd.Flags().StringP("output", "o", "", "specify output file for writing trace")
+	executeCmd.Flags().BoolP("check", "c", false, "check generated trace against constraints")
 }

--- a/pkg/zkc/constraints/translator.go
+++ b/pkg/zkc/constraints/translator.go
@@ -60,7 +60,7 @@ func translateFunction[F field.Element[F]](ctx schema.ModuleId, fm vm.FieldFunct
 		framing Framing[F]
 	)
 	// Initialise module
-	mod = mod.Init(name, true, true, false, 0)
+	mod = mod.Init(name, false, true, false, 0)
 	// Add all registers
 	mod.AddRegisters(fm.Registers()...)
 	// Add control registers (as required)
@@ -88,7 +88,7 @@ func translateFunction[F field.Element[F]](ctx schema.ModuleId, fm vm.FieldFunct
 		var (
 			handle = fmt.Sprintf("pc%d", pc)
 			// construct translator for this instruction
-			tr = NewVectorTranslator(ctx, uint(pc), vec, framing, mod)
+			tr = NewVectorTranslator(ctx, uint(pc), vec, framing, fm.Registers())
 			// extract logical constraint
 			constraint = tr.translate().AsLogical()
 		)

--- a/pkg/zkc/constraints/vector_translator.go
+++ b/pkg/zkc/constraints/vector_translator.go
@@ -44,7 +44,7 @@ type VectorInsnTranslator[F field.Element[F]] struct {
 	context     schema.ModuleId
 	pc          uint
 	vec         vm.Vector[vm.FieldInstruction]
-	regMap      register.Map
+	registers   []register.Register
 	writeMap    dfa.Result[dfa.Writes]
 	branchTable dfa.Result[dfa.Branch]
 	framing     Framing[F]
@@ -53,12 +53,12 @@ type VectorInsnTranslator[F field.Element[F]] struct {
 // NewVectorTranslator constructs a translator for a specific vector
 // instruction.
 func NewVectorTranslator[F field.Element[F]](ctx schema.ModuleId, pc uint,
-	vec vm.Vector[vm.FieldInstruction], framing Framing[F], mapping register.Map) VectorInsnTranslator[F] {
+	vec vm.Vector[vm.FieldInstruction], framing Framing[F], registers []register.Register) VectorInsnTranslator[F] {
 	// generate writeMap & branch table
 	writeMap, branchTable := vec.BranchTable()
 	//
 	return VectorInsnTranslator[F]{
-		ctx, pc, vec, mapping, writeMap, branchTable, framing,
+		ctx, pc, vec, registers, writeMap, branchTable, framing,
 	}
 }
 
@@ -138,7 +138,7 @@ func (p *VectorInsnTranslator[F]) translate() Expr[F] {
 // which registers are actually used (i.e. live) after this instruction.
 func (p *VectorInsnTranslator[F]) WithConstancyConstraints(writes dfa.Writes, condition Expr[F]) Expr[F] {
 	//
-	for i, reg := range p.regMap.Registers() {
+	for i, reg := range p.registers {
 		var (
 			regId = register.NewId(uint(i))
 			// Value of register on this row of the trace.
@@ -186,7 +186,7 @@ func (p *VectorInsnTranslator[F]) RegisterWidths(regs ...io.RegisterId) []uint {
 // This applies forwarding as appropriate.
 func (p *VectorInsnTranslator[F]) ReadRegister(regId register.Id, forwarding bool) Expr[F] {
 	var (
-		reg = p.regMap.Register(regId)
+		reg = p.Register(regId)
 	)
 	//
 	if reg.IsInput() {
@@ -202,12 +202,12 @@ func (p *VectorInsnTranslator[F]) ReadRegister(regId register.Id, forwarding boo
 
 // Register implementation for RegisterReader interface
 func (p *VectorInsnTranslator[F]) Register(reg register.Id) register.Register {
-	return p.regMap.Register(reg)
+	return p.registers[reg.Unwrap()]
 }
 
 // nolint
 func (p *VectorInsnTranslator[F]) debugString(condition Expr[F]) string {
-	return condition.String(func(r register.Id) string { return p.regMap.Register(r).Name() })
+	return condition.String(func(r register.Id) string { return p.Register(r).Name() })
 }
 
 func joinAssignments(lhs util.Option[dfa.Writes], rhs dfa.Writes) util.Option[dfa.Writes] {

--- a/pkg/zkc/vm/internal/trace/full_observer.go
+++ b/pkg/zkc/vm/internal/trace/full_observer.go
@@ -179,13 +179,9 @@ func (p *FullObserver[W, M]) enterFunction(machine M) {
 		depth = p.callstack.Len()
 		// Extract machine frame
 		frame = machine.StackFrame(depth)
-		// Extract executing function
-		fun = machine.Module(frame.Function()).(*function.Function[instruction.Word])
-		// Read arguments
-		inputs = loadWords(0, fun.NumInputs(), frame)
 	)
-	// initialise frame
-	p.callstack.Push(InitialStackFrame(frame.Function(), inputs))
+	// initialise empty stack frame
+	p.callstack.Push(StackFrame[W]{id: frame.Function()})
 	// sanity check
 	if depth+1 != machine.Depth() {
 		panic("incorrect machine depth")
@@ -210,12 +206,6 @@ type StackFrame[W any] struct {
 	id uint
 	//
 	states []State[W]
-}
-
-// InitialStackFrame constructs the initial frame when a given function is
-// invoked with the given arguments.
-func InitialStackFrame[W any](id uint, args []W) StackFrame[W] {
-	return StackFrame[W]{id: id, states: []State[W]{}}
 }
 
 // State collects together local state necessary for executing a given

--- a/pkg/zkc/vm/internal/trace/full_observer.go
+++ b/pkg/zkc/vm/internal/trace/full_observer.go
@@ -185,7 +185,7 @@ func (p *FullObserver[W, M]) enterFunction(machine M) {
 		inputs = loadWords(0, fun.NumInputs(), frame)
 	)
 	// initialise frame
-	p.callstack.Push(InitialStackFrame(frame.Function(), fun.Registers(), inputs))
+	p.callstack.Push(InitialStackFrame(frame.Function(), inputs))
 	// sanity check
 	if depth+1 != machine.Depth() {
 		panic("incorrect machine depth")
@@ -214,13 +214,8 @@ type StackFrame[W any] struct {
 
 // InitialStackFrame constructs the initial frame when a given function is
 // invoked with the given arguments.
-func InitialStackFrame[W any](id uint, registers []register.Register, args []W) StackFrame[W] {
-	var width = uint(len(registers))
-	//
-	return StackFrame[W]{
-		id:     id,
-		states: []State[W]{NewState(0, false, width, args)},
-	}
+func InitialStackFrame[W any](id uint, args []W) StackFrame[W] {
+	return StackFrame[W]{id: id, states: []State[W]{}}
 }
 
 // State collects together local state necessary for executing a given


### PR DESCRIPTION
This adds support for a basic ZkC check command.  There is a lot more to do to flesh it out, but for now it at least works.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new constraint-checking path for ZKC execution and refactors core tracing/constraint translation inputs; bugs here could cause false positives/negatives or execution failures, but changes are localized to tooling/verification flows.
> 
> **Overview**
> Adds a reusable `corset.CheckTrace` API and exports `CheckConfig` (with nil-safe sourcemap handling) so trace checking can be invoked programmatically rather than only via the CLI.
> 
> Extends `zkc execute` with a `--check/-c` flag that forces trace generation, builds MIR constraints, and validates the produced trace against them (exiting non-zero on failure), while preserving the existing output/trace-writing behavior.
> 
> Adjusts MIR constraint translation to pass explicit register metadata into the vector translator (instead of a `register.Map`) and tweaks module initialization flags, and simplifies the VM trace `FullObserver` stack-frame setup (removing argument/register-derived initial state construction).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48ebda8b95f19db08fe00338e82818704fc6038d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->