### PR TITLE
fix: constant skipped while lowering bitwise operation

### DIFF
--- a/pkg/test/zkc_unit_test.go
+++ b/pkg/test/zkc_unit_test.go
@@ -403,6 +403,10 @@ func Test_ZkcUnit_Bitwise_11(t *testing.T) {
 	checkZkcUnitWithLowerZkcNative(t, "zkc/unit/bitwise_11", field.BLS12_377, field.KOALABEAR_16)
 }
 
+func Test_ZkcUnit_Bitwise_12(t *testing.T) {
+	checkZkcUnitWithLowerZkcNative(t, "zkc/unit/bitwise_12", field.BLS12_377, field.KOALABEAR_16)
+}
+
 // ===================================================================
 // Shift Tests
 // ===================================================================

--- a/pkg/zkc/compiler/codegen/lowerzkcnative/binarize_bitwise.go
+++ b/pkg/zkc/compiler/codegen/lowerzkcnative/binarize_bitwise.go
@@ -119,7 +119,7 @@ func binarizeBitwiseCode[W vm.Word[W]](code vm.WordInstruction, registers *[]reg
 }
 
 // bitwiseIdentity returns the identity element for the given bitwise operation:
-// 0x111... for AND, 0x000... for OR/XOR.
+// 0b111... for AND, 0b000... for OR/XOR.
 func bitwiseIdentity[W vm.Word[W]](op instruction.OpCode, width uint) W {
 	var z W
 

--- a/pkg/zkc/compiler/codegen/lowerzkcnative/binarize_bitwise.go
+++ b/pkg/zkc/compiler/codegen/lowerzkcnative/binarize_bitwise.go
@@ -84,28 +84,42 @@ func binarizeBitwiseCode[W vm.Word[W]](code vm.WordInstruction, registers *[]reg
 		return []vm.WordInstruction{code}
 	}
 
-	if len(sources) <= 2 {
-		return []vm.WordInstruction{code}
-	}
-
 	width := (*registers)[target.Unwrap()].Width()
 	identity := bitwiseIdentity[W](op, width)
 
-	insns := make([]vm.WordInstruction, 0, len(sources)-1)
-	acc := sources[0]
+	insns := make([]vm.WordInstruction, 0, len(sources))
 
-	for _, src := range sources[1 : len(sources)-1] {
-		tmp := allocTmp(registers, width)
-		insns = append(insns, newBinaryBitOp[W](op, tmp, acc, src, identity))
-		acc = tmp
+	// If the constant is not the identity, materialise it as a register and add it to sources.
+	if constant.Cmp(identity) != 0 {
+		cstReg := allocTmp(registers, width)
+		insns = append(insns, instruction.NewIntAdd(cstReg, nil, constant))
+		sources = append(sources, cstReg)
 	}
 
-	insns = append(insns, newBinaryBitOp[W](op, target, acc, sources[len(sources)-1], constant))
+	switch len(sources) {
+	case 0:
+		panic(fmt.Sprintf("unexpected bitwise instruction with no sources: %T", code))
+	case 1:
+		// Trivial assignment: target = sources[0]
+		var zero W
+		return append(insns, instruction.NewIntAdd(target, sources, zero))
+	case 2:
+		// Happy path: just one binary op, possibly with a constant.
+		return append(insns, newBinaryBitOp(op, target, sources[0], sources[1], identity))
+	default:
+		acc := sources[0]
+		for _, src := range sources[1 : len(sources)-1] {
+			tmp := allocTmp(registers, width)
+			insns = append(insns, newBinaryBitOp(op, tmp, acc, src, identity))
+			acc = tmp
+		}
 
-	return insns
+		return append(insns, newBinaryBitOp(op, target, acc, sources[len(sources)-1], identity))
+	}
 }
 
-// bitwiseIdentity returns the identity element for the given bitwise operation.
+// bitwiseIdentity returns the identity element for the given bitwise operation:
+// 0x111... for AND, 0x000... for OR/XOR.
 func bitwiseIdentity[W vm.Word[W]](op instruction.OpCode, width uint) W {
 	var z W
 

--- a/testdata/zkc/unit/bitwise_12.accepts
+++ b/testdata/zkc/unit/bitwise_12.accepts
@@ -1,0 +1,6 @@
+{ "data": "0x0000" }
+{ "data": "0xffff" }
+{ "data": "0x0ff0" }
+{ "data": "0x0f0f" }
+{ "data": "0xff0f" }
+{ "data": "0xabcd" }

--- a/testdata/zkc/unit/bitwise_12.zkc
+++ b/testdata/zkc/unit/bitwise_12.zkc
@@ -1,0 +1,10 @@
+pub input data(address:u8) -> (byte:u8)
+
+fn main() {
+    var a:u8 = data[0]
+    var b:u8 = data[1]
+
+    if (a & b & 0xFF & a) != (a & b) {
+        fail
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches compiler lowering for `AND/OR/XOR`, which can affect generated VM code correctness across programs using chained bitwise expressions with constants.
> 
> **Overview**
> Fixes `lowerzkcnative.BinarizeBitwise` so chained bitwise ops don’t accidentally drop a non-identity constant during left-fold lowering; constants are now materialized into a temp register and included in the fold, with explicit handling for 0/1/2-source cases.
> 
> Adds a regression unit `bitwise_12` (plus accepts) and wires it into `zkc_unit_test.go` to cover expressions like `a & b & 0xFF & a`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bfeec059e351e2a694e39ac6cbafaa0b4d2739d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->