### PR TITLE
feat: change syntax of annotations to "#[name]"

### DIFF
--- a/pkg/cmd/zkc/lsp/hover.go
+++ b/pkg/cmd/zkc/lsp/hover.go
@@ -49,8 +49,8 @@ func HoverFor(
 
 	contents := srcfile.Contents()
 
-	// Annotations (e.g. @inline) take precedence: the cursor may be on the
-	// '@' symbol or on the identifier immediately following it.
+	// Annotations (e.g. #[inline]) take precedence: the cursor may be on any
+	// token in the annotation.
 	if h := hoverAnnotation(tokens, idx, contents); h != nil {
 		return h, nil
 	}
@@ -98,18 +98,11 @@ func HoverFor(
 }
 
 // hoverAnnotation returns hover content if the token at idx is part of an
-// annotation usage — either the '@' symbol itself or the identifier
-// immediately after it. Returns nil otherwise, or when the annotation name is
+// annotation usage. Returns nil otherwise, or when the annotation name is
 // not registered in decl.ANNOTATIONS.
 func hoverAnnotation(tokens []lex.Token, idx int, contents []rune) *protocol.Hover {
-	var nameTok lex.Token
-
-	switch {
-	case tokens[idx].Kind == parser.AT && idx+1 < len(tokens) && tokens[idx+1].Kind == parser.IDENTIFIER:
-		nameTok = tokens[idx+1]
-	case tokens[idx].Kind == parser.IDENTIFIER && idx > 0 && tokens[idx-1].Kind == parser.AT:
-		nameTok = tokens[idx]
-	default:
+	nameTok, ok := annotationNameToken(tokens, idx)
+	if !ok {
 		return nil
 	}
 
@@ -117,7 +110,7 @@ func hoverAnnotation(tokens []lex.Token, idx int, contents []rune) *protocol.Hov
 
 	for _, ann := range decl.ANNOTATIONS {
 		if ann.Name() == name {
-			value := "```zkc\n@" + ann.Name() + "\n```\n\n" + ann.Description()
+			value := "```zkc\n#[" + ann.Name() + "]\n```\n\n" + ann.Description()
 			//
 			return &protocol.Hover{
 				Contents: protocol.MarkupContent{
@@ -129,6 +122,33 @@ func hoverAnnotation(tokens []lex.Token, idx int, contents []rune) *protocol.Hov
 	}
 
 	return nil
+}
+
+func annotationNameToken(tokens []lex.Token, idx int) (lex.Token, bool) {
+	switch tokens[idx].Kind {
+	case parser.HASH:
+		if idx+3 < len(tokens) && tokens[idx+1].Kind == parser.LSQUARE &&
+			tokens[idx+2].Kind == parser.IDENTIFIER && tokens[idx+3].Kind == parser.RSQUARE {
+			return tokens[idx+2], true
+		}
+	case parser.LSQUARE:
+		if idx >= 1 && idx+2 < len(tokens) && tokens[idx-1].Kind == parser.HASH &&
+			tokens[idx+1].Kind == parser.IDENTIFIER && tokens[idx+2].Kind == parser.RSQUARE {
+			return tokens[idx+1], true
+		}
+	case parser.IDENTIFIER:
+		if idx >= 2 && idx+1 < len(tokens) && tokens[idx-2].Kind == parser.HASH &&
+			tokens[idx-1].Kind == parser.LSQUARE && tokens[idx+1].Kind == parser.RSQUARE {
+			return tokens[idx], true
+		}
+	case parser.RSQUARE:
+		if idx >= 3 && tokens[idx-3].Kind == parser.HASH && tokens[idx-2].Kind == parser.LSQUARE &&
+			tokens[idx-1].Kind == parser.IDENTIFIER {
+			return tokens[idx-1], true
+		}
+	}
+
+	return lex.Token{}, false
 }
 
 // hoverLocalVariable searches for a local variable named name inside the

--- a/pkg/zkc/compiler/ast/decl/annotation.go
+++ b/pkg/zkc/compiler/ast/decl/annotation.go
@@ -29,10 +29,10 @@ const (
 )
 
 // Annotation is a schema for a source-level annotation.  It records the
-// annotation's name (without the leading '@') and the set of declaration kinds
-// on which it may legally appear.
+// annotation's name (without the surrounding "#[" and "]") and the set of
+// declaration kinds on which it may legally appear.
 type Annotation struct {
-	// name is the annotation identifier (e.g. "inline" for "@inline").
+	// name is the annotation identifier (e.g. "inline" for "#[inline]").
 	name string
 	// description explains what the annotation is for, used in documentation
 	// and error messages.
@@ -48,7 +48,7 @@ func NewAnnotation(name, description string, permitted DeclarationKind) Annotati
 	return Annotation{name: name, description: description, permitted: permitted}
 }
 
-// Name returns the annotation's name without the leading '@'.
+// Name returns the annotation's name without the surrounding "#[" and "]".
 func (a Annotation) Name() string {
 	return a.name
 }
@@ -88,9 +88,9 @@ func (k DeclarationKind) String() string {
 // describes one valid annotation and the declaration kinds on which it may
 // appear.
 var ANNOTATIONS = []Annotation{
-	// @inline is permitted only on function declarations.
+	// #[inline] is permitted only on function declarations.
 	NewAnnotation("inline", "marks a function to be inlined at every call site", FUNCTION_KIND),
-	// @bipartite is permitted only on memory declarations.
+	// #[bipartite] is permitted only on memory declarations.
 	NewAnnotation("bipartite",
 		"marks a read/write memory to use the bipartite (split heap/stack) layout", MEMORY_KIND),
 }

--- a/pkg/zkc/compiler/parser/lexer.go
+++ b/pkg/zkc/compiler/parser/lexer.go
@@ -145,6 +145,8 @@ const (
 	REM
 	// QMARK signals "?"
 	QMARK
+	// HASH signals "#"
+	HASH
 	// AT signals "@"
 	AT
 	// UNKNOWN signals an unknown chunk of text
@@ -254,6 +256,7 @@ var rules []lex.LexRule[rune] = []lex.LexRule[rune]{
 	lex.Rule(lex.Unit('^'), BITWISE_XOR),
 	lex.Rule(lex.Unit('~'), BITWISE_NOT),
 	lex.Rule(lex.Unit('?'), QMARK),
+	lex.Rule(lex.Unit('#'), HASH),
 	lex.Rule(lex.Unit('@'), AT),
 	lex.Rule(whitespace, WHITESPACE),
 	lex.Rule(newline, NEWLINE),

--- a/pkg/zkc/compiler/parser/parser.go
+++ b/pkg/zkc/compiler/parser/parser.go
@@ -134,7 +134,7 @@ func (p *Parser) parseDeclaration() ([]decl.Declaration[symbol.Unresolved], []so
 		annotations []lex.Token
 		kind        decl.DeclarationKind
 	)
-	// Parse any leading annotations (e.g. @inline), checking that each
+	// Parse any leading annotations (e.g. #[inline]), checking that each
 	// name is known.
 	if annotations, errors = p.parseAnnotations(); len(errors) > 0 {
 		return nil, errors
@@ -178,19 +178,24 @@ func (p *Parser) parseDeclaration() ([]decl.Declaration[symbol.Unresolved], []so
 	return components, errors
 }
 
-// parseAnnotations parses zero or more leading annotations of the form "@ident"
+// parseAnnotations parses zero or more leading annotations of the form "#[ident]"
 // that precede a top-level declaration.  It returns the identifier tokens (for
 // source-location-aware error reporting) and reports an error immediately if an
 // annotation name is not found in decl.ANNOTATIONS.
 func (p *Parser) parseAnnotations() ([]lex.Token, []source.SyntaxError) {
 	var toks []lex.Token
 	//
-	for p.lookahead().Kind == AT {
-		// consume '@'
-		p.index++
-		// expect an identifier immediately after '@'
+	for p.lookahead().Kind == HASH {
+		if _, errs := p.expect(HASH); len(errs) > 0 {
+			return nil, errs
+		} else if _, errs := p.expect(LSQUARE); len(errs) > 0 {
+			return nil, errs
+		}
+		// expect an identifier immediately after '#['
 		tok, errs := p.expect(IDENTIFIER)
 		if len(errs) > 0 {
+			return nil, errs
+		} else if _, errs := p.expect(RSQUARE); len(errs) > 0 {
 			return nil, errs
 		}
 		// Validate that the annotation name is registered.

--- a/testdata/zkc/invalid/basic_23.zkc
+++ b/testdata/zkc/invalid/basic_23.zkc
@@ -1,4 +1,4 @@
-//error:9:2-8:not permitted on include declaration
+//error:9:3-9:not permitted on include declaration
 //error:10:9-30:failed to match anything
 //error:5:7-11:unknown symbol
 fn f(x:u32) -> (r:u32) {
@@ -6,5 +6,5 @@ fn f(x:u32) -> (r:u32) {
   return
 }
 
-@inline
+#[inline]
 include "__nonexistent__.zkc"

--- a/testdata/zkc/unit/basic_30.zkc
+++ b/testdata/zkc/unit/basic_30.zkc
@@ -1,5 +1,5 @@
 pub input data(address:u8) -> (byte:u8)
-@bipartite
+#[bipartite]
 memory ram(address:u8) -> (byte:u8)
 
 fn main<ram>() {

--- a/testdata/zkc/unit/basic_31.zkc
+++ b/testdata/zkc/unit/basic_31.zkc
@@ -1,5 +1,5 @@
 pub input data(address:u8) -> (byte:u8)
-@bipartite
+#[bipartite]
 memory ram(address:u64) -> (byte:u8)
 
 fn main<ram>() {


### PR DESCRIPTION
The syntax now matches Rust.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core lexing/parsing around top-level declarations by introducing a new `#` token and a new annotation grammar, which can break existing source files and tooling if any `@`-based paths remain.
> 
> **Overview**
> Updates ZKC annotation syntax from `@name` to Rust-style `#[name]`.
> 
> This adds a `HASH` token to the lexer, updates `parseAnnotations` to consume `#[ident]`, and adjusts LSP hover detection/formatting to recognize any token within an annotation (via `annotationNameToken`) and display `#[...]` in hover text. Test fixtures and related annotation docs/error spans are updated to match the new syntax.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 061d7dc4bc772358a020cf5442a11dce8e947283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->