### PR TITLE
feat: support native functions in zkc

### DIFF
--- a/pkg/asm/io/function.go
+++ b/pkg/asm/io/function.go
@@ -113,6 +113,13 @@ func (p *Function[T]) IsSynthetic() bool {
 	return false
 }
 
+// IsNative reports whether this module corresponds to a function backed by
+// a native circuit.  Assembly-level functions are never native; only ZkC
+// modules can be.
+func (p *Function[T]) IsNative() bool {
+	return false
+}
+
 // IsAtomic determines whether or not this is a "one line function".  That is,
 // where every instance of this function occupies exactly one line in the
 // corresponding trace.  This is useful to know, as certain optimisations can be

--- a/pkg/asm/io/function.go
+++ b/pkg/asm/io/function.go
@@ -120,6 +120,12 @@ func (p *Function[T]) IsNative() bool {
 	return false
 }
 
+// IsStatic reports whether this module is a static reference table.
+// Assembly-level functions are never static.
+func (p *Function[T]) IsStatic() bool {
+	return false
+}
+
 // IsAtomic determines whether or not this is a "one line function".  That is,
 // where every instance of this function occupies exactly one line in the
 // corresponding trace.  This is useful to know, as certain optimisations can be

--- a/pkg/asm/program/module.go
+++ b/pkg/asm/program/module.go
@@ -107,6 +107,12 @@ func (p *Module[F, T]) IsSynthetic() bool {
 	return false
 }
 
+// IsNative implementation for schema.Module interface.  Modules originating
+// from the assembly pipeline are never native.
+func (p *Module[F, T]) IsNative() bool {
+	return false
+}
+
 // Substitute any matchined labelled constants within this module
 func (p *Module[F, T]) Substitute(mapping map[string]F) {
 	// For now, this is a no-operation because assembly has no concept of

--- a/pkg/asm/program/module.go
+++ b/pkg/asm/program/module.go
@@ -113,6 +113,12 @@ func (p *Module[F, T]) IsNative() bool {
 	return false
 }
 
+// IsStatic implementation for schema.Module interface.  Modules originating
+// from the assembly pipeline are never static.
+func (p *Module[F, T]) IsStatic() bool {
+	return false
+}
+
 // Substitute any matchined labelled constants within this module
 func (p *Module[F, T]) Substitute(mapping map[string]F) {
 	// For now, this is a no-operation because assembly has no concept of

--- a/pkg/binfile/binfile.go
+++ b/pkg/binfile/binfile.go
@@ -218,7 +218,7 @@ func (p *Header) IsCompatible() bool {
 // Regardless of version, the file always begins with the ZKBINARY identifier
 // followed by a hand-rolled binary Header.  The encoding of everything after
 // the header is determined by the major version.
-const BINFILE_MAJOR_VERSION uint16 = 10
+const BINFILE_MAJOR_VERSION uint16 = 11
 
 // BINFILE_MINOR_VERSION is the minor version of the binary file format.  Files
 // with a lower minor version remain readable by this implementation, but files

--- a/pkg/cmd/corset/debug/schema.go
+++ b/pkg/cmd/corset/debug/schema.go
@@ -93,7 +93,15 @@ func printModule[F field.Element[F]](module schema.Module[F], sc schema.AnySchem
 	}
 
 	if module.IsSynthetic() {
-		postfix = fmt.Sprintf("%s synthetic", postfix)
+		postfix = fmt.Sprintf("%s :synthetic", postfix)
+	}
+
+	if module.IsNative() {
+		postfix = fmt.Sprintf("%s :native", postfix)
+	}
+
+	if module.IsStatic() {
+		postfix = fmt.Sprintf("%s :static", postfix)
 	}
 	//
 	fmt.Printf("(module%s)\n", postfix)

--- a/pkg/ir/mir/concretize.go
+++ b/pkg/ir/mir/concretize.go
@@ -59,11 +59,15 @@ func concretizeModule[F1 Element[F1], F2 Element[F2]](m Module[F1]) Module[F2] {
 		constraints = concretizeConstraints[F1, F2](m.RawConstraints())
 	)
 	// Initialise new module
-	r = r.Init(m.Name(), m.AllowPadding(), m.IsPublic(), m.IsSynthetic(), m.IsNative(), m.Keys())
+	r = r.Init(m.Name(), m.AllowPadding(), m.IsPublic(), m.IsSynthetic(), m.IsNative(), m.IsStatic(), m.Keys())
 	// Add concretized components
 	r.AddRegisters(m.Registers()...)
 	r.AddAssignments(assignments...)
 	r.AddConstraints(constraints...)
+	// Propagate static contents (if any)
+	if m.IsStatic() {
+		panic("concretizing static modules not supported")
+	}
 	// Done
 	return r
 }

--- a/pkg/ir/mir/concretize.go
+++ b/pkg/ir/mir/concretize.go
@@ -59,7 +59,7 @@ func concretizeModule[F1 Element[F1], F2 Element[F2]](m Module[F1]) Module[F2] {
 		constraints = concretizeConstraints[F1, F2](m.RawConstraints())
 	)
 	// Initialise new module
-	r = r.Init(m.Name(), m.AllowPadding(), m.IsPublic(), m.IsSynthetic(), m.Keys())
+	r = r.Init(m.Name(), m.AllowPadding(), m.IsPublic(), m.IsSynthetic(), m.IsNative(), m.Keys())
 	// Add concretized components
 	r.AddRegisters(m.Registers()...)
 	r.AddAssignments(assignments...)

--- a/pkg/ir/module_builder.go
+++ b/pkg/ir/module_builder.go
@@ -149,6 +149,13 @@ func (p *internalModuleBuilder[F, C, T]) IsSynthetic() bool {
 	return p.synthetic
 }
 
+// IsNative implementation for schema.ModuleView interface.  Modules built via
+// this builder are never native; only the ZkC pipeline produces native
+// modules and it does not go through this builder.
+func (p *internalModuleBuilder[F, C, T]) IsNative() bool {
+	return false
+}
+
 // Width implementation for schema.ModuleView interface.
 func (p *internalModuleBuilder[F, C, T]) Width() uint {
 	return uint(len(p.registers))
@@ -297,6 +304,12 @@ func (p *externalModuleBuilder[F, C, T]) IsPublic() bool {
 
 // IsSynthetic implementation for schema.ModuleView interface.
 func (p *externalModuleBuilder[F, C, T]) IsSynthetic() bool {
+	return false
+}
+
+// IsNative implementation for schema.ModuleView interface.  External modules
+// are never native.
+func (p *externalModuleBuilder[F, C, T]) IsNative() bool {
 	return false
 }
 

--- a/pkg/ir/module_builder.go
+++ b/pkg/ir/module_builder.go
@@ -156,6 +156,13 @@ func (p *internalModuleBuilder[F, C, T]) IsNative() bool {
 	return false
 }
 
+// IsStatic implementation for schema.ModuleView interface.  Modules built via
+// this builder are never static; static modules are produced directly by the
+// ZkC pipeline.
+func (p *internalModuleBuilder[F, C, T]) IsStatic() bool {
+	return false
+}
+
 // Width implementation for schema.ModuleView interface.
 func (p *internalModuleBuilder[F, C, T]) Width() uint {
 	return uint(len(p.registers))
@@ -310,6 +317,12 @@ func (p *externalModuleBuilder[F, C, T]) IsSynthetic() bool {
 // IsNative implementation for schema.ModuleView interface.  External modules
 // are never native.
 func (p *externalModuleBuilder[F, C, T]) IsNative() bool {
+	return false
+}
+
+// IsStatic implementation for schema.ModuleView interface.  External modules
+// are never static.
+func (p *externalModuleBuilder[F, C, T]) IsStatic() bool {
 	return false
 }
 

--- a/pkg/ir/schema_builder.go
+++ b/pkg/ir/schema_builder.go
@@ -26,7 +26,7 @@ import (
 // the various required components.  This provides a useful way for constructing
 // modules once all the various pieces of information have been finalised.
 type BuildableModule[F any, C schema.Constraint[F], M any] interface {
-	Init(name module.Name, padding, public, synthetic, native bool, keys uint) M
+	Init(name module.Name, padding, public, synthetic, native, static bool, keys uint) M
 	// Add one or more assignments to this buildable module
 	AddAssignments(assignments ...schema.Assignment[F])
 	// Add one or more constraints to this buildable module
@@ -54,7 +54,8 @@ func BuildModule[F field.Element[F], C schema.Constraint[F], T term.Expr[F, T], 
 	//
 	var module M
 	// Build it
-	module = module.Init(m.Name(), m.AllowPadding(), m.IsPublic(), m.IsSynthetic(), m.IsNative(), m.Keys())
+	module = module.Init(m.Name(), m.AllowPadding(), m.IsPublic(), m.IsSynthetic(), m.IsNative(),
+		m.IsStatic(), m.Keys())
 	module.AddRegisters(m.Registers()...)
 	module.AddAssignments(m.Assignments()...)
 	module.AddConstraints(m.Constraints()...)

--- a/pkg/ir/schema_builder.go
+++ b/pkg/ir/schema_builder.go
@@ -26,7 +26,7 @@ import (
 // the various required components.  This provides a useful way for constructing
 // modules once all the various pieces of information have been finalised.
 type BuildableModule[F any, C schema.Constraint[F], M any] interface {
-	Init(name module.Name, padding, public, synthetic bool, keys uint) M
+	Init(name module.Name, padding, public, synthetic, native bool, keys uint) M
 	// Add one or more assignments to this buildable module
 	AddAssignments(assignments ...schema.Assignment[F])
 	// Add one or more constraints to this buildable module
@@ -54,7 +54,7 @@ func BuildModule[F field.Element[F], C schema.Constraint[F], T term.Expr[F, T], 
 	//
 	var module M
 	// Build it
-	module = module.Init(m.Name(), m.AllowPadding(), m.IsPublic(), m.IsSynthetic(), m.Keys())
+	module = module.Init(m.Name(), m.AllowPadding(), m.IsPublic(), m.IsSynthetic(), m.IsNative(), m.Keys())
 	module.AddRegisters(m.Registers()...)
 	module.AddAssignments(m.Assignments()...)
 	module.AddConstraints(m.Constraints()...)

--- a/pkg/schema/module.go
+++ b/pkg/schema/module.go
@@ -41,6 +41,11 @@ type ModuleView interface {
 	// Only modules produced by the ZkC pipeline can ever be native; modules
 	// from any other source always return false.
 	IsNative() bool
+	// IsStatic indicates whether this module represents a static reference
+	// table whose contents are fixed at compile time.  Static modules carry
+	// their data in StaticContents() (queried via the field-parameterised
+	// schema.Module interface).
+	IsStatic() bool
 	// Returns the number of registers in this module.
 	Width() uint
 }
@@ -83,22 +88,27 @@ type Module[F any] interface {
 // X'1, Y'0. Y'1 (in that order).  Hence, predicting the new register indices is
 // relatively straightforward.
 type Table[F field.Element[F], C Constraint[F]] struct {
-	name        module.Name
-	padding     bool
-	public      bool
-	synthetic   bool
-	native      bool
-	keys        uint
-	registers   []register.Register
-	constraints []C
-	assignments []Assignment[F]
+	name           module.Name
+	padding        bool
+	public         bool
+	synthetic      bool
+	native         bool
+	static         bool
+	keys           uint
+	registers      []register.Register
+	constraints    []C
+	assignments    []Assignment[F]
+	staticContents []F
 }
 
 // Init implementation for ir.InitModule interface.  The native flag indicates
 // that this module corresponds to a function backed by a native circuit; only
-// the ZkC pipeline should ever pass true.
-func (p *Table[F, C]) Init(name module.Name, padding, public, synthetic, native bool, keys uint) *Table[F, C] {
-	return &Table[F, C]{name, padding, public, synthetic, native, keys, nil, nil, nil}
+// the ZkC pipeline should ever pass true.  The static flag indicates that this
+// module is a static reference table whose contents are fixed at compile time
+// and are populated separately via SetStaticContents.
+func (p *Table[F, C]) Init(name module.Name, padding, public, synthetic, native, static bool,
+	keys uint) *Table[F, C] {
+	return &Table[F, C]{name, padding, public, synthetic, native, static, keys, nil, nil, nil, nil}
 }
 
 // Assignments provides access to those assignments defined as part of this
@@ -175,6 +185,23 @@ func (p *Table[F, C]) IsSynthetic() bool {
 // a native circuit (i.e. declared with the @native annotation in ZkC).
 func (p *Table[F, C]) IsNative() bool {
 	return p.native
+}
+
+// IsStatic reports whether this module is a static reference table whose
+// contents are fixed at compile time.
+func (p *Table[F, C]) IsStatic() bool {
+	return p.static
+}
+
+// StaticContents returns the contents of this static reference table.  It
+// panics if invoked on a non-static module, since no contents are stored in
+// that case.
+func (p *Table[F, C]) StaticContents() []F {
+	if !p.static {
+		panic(fmt.Sprintf("module \"%s\" is not static", p.name))
+	}
+	//
+	return p.staticContents
 }
 
 // RawAssignments provides raw access to those assignments defined as part of this
@@ -256,6 +283,16 @@ func (p *Table[F, C]) AddRegisters(registers ...register.Register) {
 	p.registers = append(p.registers, registers...)
 }
 
+// SetStaticContents sets the contents of this static reference table.  It
+// panics if invoked on a non-static module.
+func (p *Table[F, C]) SetStaticContents(contents []F) {
+	if !p.static {
+		panic(fmt.Sprintf("module \"%s\" is not static", p.name))
+	}
+	//
+	p.staticContents = contents
+}
+
 // ============================================================================
 // Encoding / Decoding
 // ============================================================================
@@ -279,6 +316,14 @@ func (p *Table[F, M]) GobEncode() (data []byte, err error) {
 	}
 	// Native
 	if err := gobEncoder.Encode(p.native); err != nil {
+		return nil, err
+	}
+	// Static
+	if err := gobEncoder.Encode(p.static); err != nil {
+		return nil, err
+	}
+	// Static contents
+	if err := gobEncoder.Encode(p.staticContents); err != nil {
 		return nil, err
 	}
 	// registers
@@ -315,6 +360,14 @@ func (p *Table[F, M]) GobDecode(data []byte) error {
 	}
 	// Native
 	if err := gobDecoder.Decode(&p.native); err != nil {
+		return err
+	}
+	// Static
+	if err := gobDecoder.Decode(&p.static); err != nil {
+		return err
+	}
+	// Static contents
+	if err := gobDecoder.Decode(&p.staticContents); err != nil {
 		return err
 	}
 	// Registers

--- a/pkg/schema/module.go
+++ b/pkg/schema/module.go
@@ -36,6 +36,11 @@ type ModuleView interface {
 	// IsSynthetic modules are generated during compilation, rather than being
 	// provided by the user.
 	IsSynthetic() bool
+	// IsNative indicates whether this module corresponds to a function backed
+	// by a native circuit (i.e. declared with the @native annotation in ZkC).
+	// Only modules produced by the ZkC pipeline can ever be native; modules
+	// from any other source always return false.
+	IsNative() bool
 	// Returns the number of registers in this module.
 	Width() uint
 }
@@ -82,15 +87,18 @@ type Table[F field.Element[F], C Constraint[F]] struct {
 	padding     bool
 	public      bool
 	synthetic   bool
+	native      bool
 	keys        uint
 	registers   []register.Register
 	constraints []C
 	assignments []Assignment[F]
 }
 
-// Init implementation for ir.InitModule interface.
-func (p *Table[F, C]) Init(name module.Name, padding, public, synthetic bool, keys uint) *Table[F, C] {
-	return &Table[F, C]{name, padding, public, synthetic, keys, nil, nil, nil}
+// Init implementation for ir.InitModule interface.  The native flag indicates
+// that this module corresponds to a function backed by a native circuit; only
+// the ZkC pipeline should ever pass true.
+func (p *Table[F, C]) Init(name module.Name, padding, public, synthetic, native bool, keys uint) *Table[F, C] {
+	return &Table[F, C]{name, padding, public, synthetic, native, keys, nil, nil, nil}
 }
 
 // Assignments provides access to those assignments defined as part of this
@@ -161,6 +169,12 @@ func (p *Table[F, C]) IsPublic() bool {
 // provided by the user.
 func (p *Table[F, C]) IsSynthetic() bool {
 	return p.synthetic
+}
+
+// IsNative reports whether this module corresponds to a function backed by
+// a native circuit (i.e. declared with the @native annotation in ZkC).
+func (p *Table[F, C]) IsNative() bool {
+	return p.native
 }
 
 // RawAssignments provides raw access to those assignments defined as part of this
@@ -263,6 +277,10 @@ func (p *Table[F, M]) GobEncode() (data []byte, err error) {
 	if err := gobEncoder.Encode(p.padding); err != nil {
 		return nil, err
 	}
+	// Native
+	if err := gobEncoder.Encode(p.native); err != nil {
+		return nil, err
+	}
 	// registers
 	if err := gobEncoder.Encode(p.registers); err != nil {
 		return nil, err
@@ -293,6 +311,10 @@ func (p *Table[F, M]) GobDecode(data []byte) error {
 	}
 	// Padding
 	if err := gobDecoder.Decode(&p.padding); err != nil {
+		return err
+	}
+	// Native
+	if err := gobDecoder.Decode(&p.native); err != nil {
 		return err
 	}
 	// Registers

--- a/pkg/zkc/compiler/ast/decl/annotation.go
+++ b/pkg/zkc/compiler/ast/decl/annotation.go
@@ -90,6 +90,8 @@ func (k DeclarationKind) String() string {
 var ANNOTATIONS = []Annotation{
 	// #[inline] is permitted only on function declarations.
 	NewAnnotation("inline", "marks a function to be inlined at every call site", FUNCTION_KIND),
+	// #[native] is permitted only on function declarations.
+	NewAnnotation("native", "marks a function as backed by a native circuit", FUNCTION_KIND),
 	// #[bipartite] is permitted only on memory declarations.
 	NewAnnotation("bipartite",
 		"marks a read/write memory to use the bipartite (split heap/stack) layout", MEMORY_KIND),

--- a/pkg/zkc/compiler/codegen/compile.go
+++ b/pkg/zkc/compiler/codegen/compile.go
@@ -242,7 +242,9 @@ func (p *Compiler) compileFunction(id uint, mapping []uint, program []Declaratio
 		bootCode[i] = compiler.compileStatement(uint(i), mapping, stmt)
 	}
 	//
-	return vm.NewFunction(fn.Name(), compiler.registers, bootCode), compiler.errors
+	native := slices.Contains(fn.Annotations(), "native")
+	//
+	return vm.NewFunction(fn.Name(), native, compiler.registers, bootCode), compiler.errors
 }
 
 func toMemoryRegisters(address []VariableDescriptor, datas []VariableDescriptor, env data.ResolvedEnvironment,

--- a/pkg/zkc/compiler/codegen/lowerzkcnative/binarize_bitwise.go
+++ b/pkg/zkc/compiler/codegen/lowerzkcnative/binarize_bitwise.go
@@ -50,7 +50,7 @@ func binarizeBitwiseFunction[W vm.Word[W]](fn *vm.WordFunction) *vm.WordFunction
 		ncode[i] = vectorInstruction{Codes: ncodes}
 	}
 
-	return vm.NewFunction(fn.Name(), registers, ncode)
+	return vm.NewFunction(fn.Name(), fn.IsNative(), registers, ncode)
 }
 
 func binarizeBitwiseCodes[W vm.Word[W]](codes []vm.WordInstruction, registers *[]register.Register,

--- a/pkg/zkc/compiler/codegen/lowerzkcnative/lower_bitwise.go
+++ b/pkg/zkc/compiler/codegen/lowerzkcnative/lower_bitwise.go
@@ -58,7 +58,7 @@ func lowerBitwiseFunction[W vm.Word[W]](fn *vm.WordFunction, helpers *bitwiseHel
 		ncode[i] = vectorInstruction{Codes: ncodes}
 	}
 
-	return vm.NewFunction(fn.Name(), registers, ncode)
+	return vm.NewFunction(fn.Name(), fn.IsNative(), registers, ncode)
 }
 
 func lowerBitwiseCodes[W vm.Word[W]](
@@ -382,7 +382,7 @@ func newDecomposedNaryHelper[W vm.Word[W]](
 
 	b.emit(instruction.NewReturn())
 
-	return vm.NewFunction(helperName(key), b.regs(), []vectorInstruction{{Codes: b.code}})
+	return vm.NewFunction(helperName(key), false, b.regs(), []vectorInstruction{{Codes: b.code}})
 }
 
 type helperBuilder[W vm.Word[W]] struct {

--- a/pkg/zkc/compiler/codegen/lowerzkcnative/lower_comparison.go
+++ b/pkg/zkc/compiler/codegen/lowerzkcnative/lower_comparison.go
@@ -48,7 +48,7 @@ func lowerComparisonFunction[W vm.Word[W]](fn *vm.WordFunction, bandWidth uint) 
 		ncode[i] = vectorInstruction{Codes: ncodes}
 	}
 
-	return vm.NewFunction(fn.Name(), registers, ncode)
+	return vm.NewFunction(fn.Name(), fn.IsNative(), registers, ncode)
 }
 
 func lowerComparisonCodes[W vm.Word[W]](

--- a/pkg/zkc/compiler/codegen/lowerzkcnative/lower_shift.go
+++ b/pkg/zkc/compiler/codegen/lowerzkcnative/lower_shift.go
@@ -164,7 +164,7 @@ func newShlHelper[W vm.Word[W]](key bitwiseHelperKey, selfID uint, amtWidth uint
 	b.emit(instruction.NewCall(selfID, []register.Id{doubled, n1}, []register.Id{out}))
 	b.emit(instruction.NewReturn())
 
-	return vm.NewFunction(helperName(key), b.regs(), []vectorInstruction{{Codes: b.code}})
+	return vm.NewFunction(helperName(key), false, b.regs(), []vectorInstruction{{Codes: b.code}})
 }
 
 // newShrHelper builds a self-recursive module for logical right shift:
@@ -235,5 +235,5 @@ func newShrHelper[W vm.Word[W]](key bitwiseHelperKey, selfID uint, amtWidth uint
 	b.emit(instruction.NewCall(selfID, []register.Id{half, n1}, []register.Id{out}))
 	b.emit(instruction.NewReturn())
 
-	return vm.NewFunction(helperName(key), b.regs(), []vectorInstruction{{Codes: b.code}})
+	return vm.NewFunction(helperName(key), false, b.regs(), []vectorInstruction{{Codes: b.code}})
 }

--- a/pkg/zkc/compiler/codegen/vectorize.go
+++ b/pkg/zkc/compiler/codegen/vectorize.go
@@ -134,7 +134,7 @@ func vectorizeFunction(fn *Function, modules []vm.Module) *Function {
 	// Remove unreachable instructions and rebind jump targets.
 	insns = pruneUnreachableInstructions(insns)
 	//
-	return vm.NewFunction(fn.Name(), fn.Registers(), insns)
+	return vm.NewFunction(fn.Name(), fn.IsNative(), fn.Registers(), insns)
 }
 
 // prepareCode wraps every top-level instruction in a Vector and appends a

--- a/pkg/zkc/compiler/linker.go
+++ b/pkg/zkc/compiler/linker.go
@@ -202,7 +202,10 @@ func (p *Linker) linkFunction(fn decl.UnresolvedFunction) (decl.Resolved, []sour
 	//
 	vars, errs2 := p.linkVariableDeclarations(fn.Variables)
 	//
-	return decl.NewFunction(fn.Name(), effects, vars, codes), append(errs1, errs2...)
+	resolved := decl.NewFunction(fn.Name(), effects, vars, codes)
+	resolved.SetAnnotations(fn.Annotations())
+	//
+	return resolved, append(errs1, errs2...)
 }
 
 func (p *Linker) linkEffect(effect *symbol.Unresolved,

--- a/pkg/zkc/constraints/translator.go
+++ b/pkg/zkc/constraints/translator.go
@@ -67,39 +67,39 @@ func translateStaticMemory[F field.Element[F]](ctx schema.ModuleId, fm vm.InputO
 	panic("support static memory")
 }
 
-func translateReadOnlyMemory[F field.Element[F]](ctx schema.ModuleId, fm vm.InputOutputMemory[F]) mir.Module[F] {
+func translateReadOnlyMemory[F field.Element[F]](_ schema.ModuleId, fm vm.InputOutputMemory[F]) mir.Module[F] {
 	var (
 		mod  *schema.Table[F, mir.Constraint[F]]
 		name = trace.ModuleName{Name: fm.Name(), Multiplier: 1}
 	)
 	// Initialise module
-	mod = mod.Init(name, false, true, false, 0)
+	mod = mod.Init(name, false, true, false, fm.IsNative(), 0)
 	// Add all registers
 	mod.AddRegisters(fm.Registers()...)
 	// TODO: implement ROM constraints
 	return mod
 }
 
-func translateWriteOnceMemory[F field.Element[F]](ctx schema.ModuleId, fm vm.InputOutputMemory[F]) mir.Module[F] {
+func translateWriteOnceMemory[F field.Element[F]](_ schema.ModuleId, fm vm.InputOutputMemory[F]) mir.Module[F] {
 	var (
 		mod  *schema.Table[F, mir.Constraint[F]]
 		name = trace.ModuleName{Name: fm.Name(), Multiplier: 1}
 	)
 	// Initialise module
-	mod = mod.Init(name, false, true, false, 0)
+	mod = mod.Init(name, false, true, false, fm.IsNative(), 0)
 	// Add all registers
 	mod.AddRegisters(fm.Registers()...)
 	// TODO: implement WOM constraints
 	return mod
 }
 
-func translateReadWriteMemory[F field.Element[F]](ctx schema.ModuleId, fm vm.Memory[F]) mir.Module[F] {
+func translateReadWriteMemory[F field.Element[F]](_ schema.ModuleId, fm vm.Memory[F]) mir.Module[F] {
 	var (
 		mod  *schema.Table[F, mir.Constraint[F]]
 		name = trace.ModuleName{Name: fm.Name(), Multiplier: 1}
 	)
 	// Initialise module
-	mod = mod.Init(name, false, true, false, 0)
+	mod = mod.Init(name, false, true, false, fm.IsNative(), 0)
 	// Add all registers
 	mod.AddRegisters(fm.Registers()...)
 	// TODO: implement WOM constraints
@@ -114,9 +114,14 @@ func translateFunction[F field.Element[F]](ctx schema.ModuleId, fm vm.FieldFunct
 		framing Framing[F]
 	)
 	// Initialise module
-	mod = mod.Init(name, false, true, false, 0)
+	mod = mod.Init(name, false, true, false, fm.IsNative(), 0)
 	// Add all registers
 	mod.AddRegisters(fm.Registers()...)
+	// Native functions are backed by an external circuit, so we emit only the
+	// register layout and skip all framing / instruction-level constraints.
+	if fm.IsNative() {
+		return mod
+	}
 	// Add control registers (as required)
 	if !fm.IsAtomic() {
 		var (

--- a/pkg/zkc/constraints/translator.go
+++ b/pkg/zkc/constraints/translator.go
@@ -62,9 +62,19 @@ func translateModule[F field.Element[F]](ctx schema.ModuleId, fm vm.Module) mir.
 	}
 }
 
-func translateStaticMemory[F field.Element[F]](ctx schema.ModuleId, fm vm.InputOutputMemory[F]) mir.Module[F] {
-	// need a way to signal that a given module is static.
-	panic("support static memory")
+func translateStaticMemory[F field.Element[F]](_ schema.ModuleId, fm vm.InputOutputMemory[F]) mir.Module[F] {
+	var (
+		mod  *schema.Table[F, mir.Constraint[F]]
+		name = trace.ModuleName{Name: fm.Name(), Multiplier: 1}
+	)
+	// Initialise module as a static reference table.
+	mod = mod.Init(name, false, true, false, fm.IsNative(), true, 0)
+	// Add all registers
+	mod.AddRegisters(fm.Registers()...)
+	// Populate the table contents from the pre-loaded memory.
+	mod.SetStaticContents(fm.Contents())
+	//
+	return mod
 }
 
 func translateReadOnlyMemory[F field.Element[F]](_ schema.ModuleId, fm vm.InputOutputMemory[F]) mir.Module[F] {
@@ -73,7 +83,7 @@ func translateReadOnlyMemory[F field.Element[F]](_ schema.ModuleId, fm vm.InputO
 		name = trace.ModuleName{Name: fm.Name(), Multiplier: 1}
 	)
 	// Initialise module
-	mod = mod.Init(name, false, true, false, fm.IsNative(), 0)
+	mod = mod.Init(name, false, true, false, fm.IsNative(), false, 0)
 	// Add all registers
 	mod.AddRegisters(fm.Registers()...)
 	// TODO: implement ROM constraints
@@ -86,7 +96,7 @@ func translateWriteOnceMemory[F field.Element[F]](_ schema.ModuleId, fm vm.Input
 		name = trace.ModuleName{Name: fm.Name(), Multiplier: 1}
 	)
 	// Initialise module
-	mod = mod.Init(name, false, true, false, fm.IsNative(), 0)
+	mod = mod.Init(name, false, true, false, fm.IsNative(), false, 0)
 	// Add all registers
 	mod.AddRegisters(fm.Registers()...)
 	// TODO: implement WOM constraints
@@ -99,7 +109,7 @@ func translateReadWriteMemory[F field.Element[F]](_ schema.ModuleId, fm vm.Memor
 		name = trace.ModuleName{Name: fm.Name(), Multiplier: 1}
 	)
 	// Initialise module
-	mod = mod.Init(name, false, true, false, fm.IsNative(), 0)
+	mod = mod.Init(name, false, true, false, fm.IsNative(), false, 0)
 	// Add all registers
 	mod.AddRegisters(fm.Registers()...)
 	// TODO: implement WOM constraints
@@ -114,7 +124,7 @@ func translateFunction[F field.Element[F]](ctx schema.ModuleId, fm vm.FieldFunct
 		framing Framing[F]
 	)
 	// Initialise module
-	mod = mod.Init(name, false, true, false, fm.IsNative(), 0)
+	mod = mod.Init(name, false, true, false, fm.IsNative(), false, 0)
 	// Add all registers
 	mod.AddRegisters(fm.Registers()...)
 	// Native functions are backed by an external circuit, so we emit only the

--- a/pkg/zkc/vm/instruction/base/util.go
+++ b/pkg/zkc/vm/instruction/base/util.go
@@ -28,6 +28,9 @@ type Module interface {
 	// HasRegister checks whether a register with the given name exists and, if
 	// so, returns its register identifier.  Otherwise, it returns false.
 	HasRegister(name string) (register.Id, bool)
+	// IsNative reports whether this module is a function backed by a native
+	// circuit.  Memory modules always return false.
+	IsNative() bool
 	// Access a given register in this module.
 	Register(register.Id) register.Register
 	// Registers providers access to the underlying registers of this map.

--- a/pkg/zkc/vm/internal/function/function.go
+++ b/pkg/zkc/vm/internal/function/function.go
@@ -23,6 +23,10 @@ import (
 type Function[I instruction.Instruction] struct {
 	// Unique name of this function.
 	name string
+	// Native indicates whether this function is backed by a native circuit
+	// (i.e. declared with the @native annotation) rather than by the
+	// instructions in code.
+	native bool
 	// Registers describes zero or more registers of a given width.  Each
 	// register can be designated as an input / output or temporary.
 	registers []register.Register
@@ -35,7 +39,7 @@ type Function[I instruction.Instruction] struct {
 }
 
 // New constructs a new function with the given components.
-func New[I instruction.Instruction](name string, registers []register.Register,
+func New[I instruction.Instruction](name string, native bool, registers []register.Register,
 	code []instruction.Vector[I]) *Function[I] {
 	//
 	var (
@@ -47,7 +51,7 @@ func New[I instruction.Instruction](name string, registers []register.Register,
 		panic("function registers ordered incorrectly")
 	}
 	// All good
-	return &Function[I]{name, registers, numInputs, numOutputs, code}
+	return &Function[I]{name, native, registers, numInputs, numOutputs, code}
 }
 
 // CodeAt returns the ith instruction making up the body of this function.
@@ -66,6 +70,13 @@ func (p *Function[I]) Code() []instruction.Vector[I] {
 // applied for one line functions (e.g. no PC register is required).
 func (p *Function[I]) IsAtomic() bool {
 	return len(p.code) == 1
+}
+
+// IsNative reports whether this function is backed by a native circuit (i.e.
+// declared with the @native annotation) rather than by the instructions in
+// its body.
+func (p *Function[I]) IsNative() bool {
+	return p.native
 }
 
 // HasRegister checks whether a register with the given name exists and, if

--- a/pkg/zkc/vm/internal/memory/bipartite_ram.go
+++ b/pkg/zkc/vm/internal/memory/bipartite_ram.go
@@ -97,6 +97,12 @@ func (p *BiPartiteRandomAccess[W]) Name() string {
 	return p.name
 }
 
+// IsNative implementation for Module interface.  Memory modules are never
+// native.
+func (p *BiPartiteRandomAccess[W]) IsNative() bool {
+	return false
+}
+
 // Geometry implementation for Memory interface.
 func (p *BiPartiteRandomAccess[W]) Geometry() Geometry[W] {
 	return p.geometry

--- a/pkg/zkc/vm/internal/memory/static_array.go
+++ b/pkg/zkc/vm/internal/memory/static_array.go
@@ -72,6 +72,12 @@ func (p *StaticArray[W]) Name() string {
 	return p.name
 }
 
+// IsNative implementation for Module interface.  Memory modules are never
+// native.
+func (p *StaticArray[W]) IsNative() bool {
+	return false
+}
+
 // Initialise implementation for Memory interface.
 func (p *StaticArray[W]) Initialise(contents []W) {
 	p.data = contents

--- a/pkg/zkc/vm/lower.go
+++ b/pkg/zkc/vm/lower.go
@@ -133,7 +133,7 @@ func (p wordToField[W, F]) lowerWordFunction(wf *WordFunction, mapping SystemMap
 		insns[i] = p.lowerWordVector(insn, mapping)
 	}
 	//
-	return NewFunction(wf.Name(), regs, insns)
+	return NewFunction(wf.Name(), wf.IsNative(), regs, insns)
 }
 
 func (p wordToField[W, F]) lowerWordVector(wi Vector[WordInstruction], mapping SystemMap) Vector[FieldInstruction] {

--- a/pkg/zkc/vm/machine.go
+++ b/pkg/zkc/vm/machine.go
@@ -87,10 +87,12 @@ type FieldInstruction = instruction.Field
 // Constructors
 // ============================================================================
 
-// NewFunction constructs a new function with the given components.
-func NewFunction[I instruction.Instruction](name string, registers []register.Register,
+// NewFunction constructs a new function with the given components.  The native
+// flag indicates whether this function is backed by a native circuit (i.e.
+// declared with the @native annotation) rather than by code.
+func NewFunction[I instruction.Instruction](name string, native bool, registers []register.Register,
 	code []instruction.Vector[I]) *Function[I] {
-	return function.New(name, registers, code)
+	return function.New(name, native, registers, code)
 }
 
 // NewWordMachine constructs a new word machine with a given set of modules and


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core schema/module interfaces and VM function construction, plus bumps the binary format major version, so downstream tooling and persisted artifacts may break if not updated. Native functions now skip constraint emission, which could change proving/checking behavior if misapplied.
> 
> **Overview**
> Adds `IsNative()`/`IsStatic()` to `schema.ModuleView` and threads these flags through module builders, MIR concretization, and debug printing, with assembly-origin modules hard-coded to return false.
> 
> Extends `schema.Table` to persist `native`/`static` flags and (for static tables) embedded `staticContents`, including gob encode/decode changes and a `BINFILE_MAJOR_VERSION` bump to `11`.
> 
> Implements ZkC `#[native]` function annotation plumbing: linker now preserves function annotations; codegen marks compiled VM functions as native; lowering/vectorization preserve the native flag; MIR translation skips instruction/framing constraints for native functions; and static memories are translated into static reference tables with preloaded contents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd482e0aea1668a0aaa3f52ee75fed32d484d1a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->