### PR TITLE
feat: very minor fixes

### DIFF
--- a/pkg/cmd/zkc/compile.go
+++ b/pkg/cmd/zkc/compile.go
@@ -111,7 +111,7 @@ func runCompileCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 	if GetFlag(cmd, "verbose") {
 		log.SetLevel(log.DebugLevel)
 	}
-	// Configure target fieldgitggggggg
+	// Configure target field
 	build.field = field
 	// Configure compiler config
 	build.config = codegen.DEFAULT_CONFIG.

--- a/pkg/cmd/zkc/execute.go
+++ b/pkg/cmd/zkc/execute.go
@@ -96,7 +96,7 @@ func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 	// =====================================================
 	// Check Constraints
 	// =====================================================
-	if check {
+	if check && len(errors) == 0 {
 		checkConstraints(binfile, trace, traceConfig)
 	}
 	// =====================================================

--- a/pkg/zkc/vm/word.go
+++ b/pkg/zkc/vm/word.go
@@ -115,22 +115,38 @@ func DecodeBytes[W Word[W]](bytes []byte, registers []register.Register) []W {
 // | 0x31 | 0xf0 | 0x0e | 0x1d |
 func EncodeBytes[W Word[W]](values []W, registers []register.Register) []byte {
 	var (
-		bitwidth   = bitwidthOf(registers)
-		nElems     = uint(len(values))
-		totalBits  = nElems * bitwidth
-		totalBytes = (totalBits + 7) / 8
-		result     = make([]byte, totalBytes)
-		n          = bit.BytesRequiredFor(bitwidth)
-		buf        = make([]byte, n)
-		offset     uint
+		nRegs     = uint(len(registers))
+		nElems    = uint(len(values))
+		bitOffset uint
+		// total bitwidth of round
+		bitwidth = bitwidthOf(registers)
+		// buffer size required to hold a round
+		n = bit.BytesRequiredFor(bitwidth)
+		// create buffer
+		buf = make([]byte, n)
+		// Determine number of (full) rounds
+		nRounds = nElems / nRegs
+		// Initial total bits calculation
+		totalBits = nRounds * bitwidth
 	)
+	// Update total bits calc for odd number of elements.
+	for i := (nRounds * nRegs); i < nElems; i++ {
+		totalBits += registers[i].Width()
+	}
+	// Determine required size result buffer
+	totalBytes := (totalBits + 7) / 8
+	// Allocate result buffer
+	result := make([]byte, totalBytes)
 	//
 	for i := 0; i < len(values); {
-		for _, r := range registers {
-			var val = values[i]
-			EncodeUnsignedInt(r.Width(), val.BigInt(), buf)
-			bit.BigEndianCopy(buf, 0, result, offset, r.Width())
-			offset += r.Width()
+		for j := 0; j < len(registers) && i < len(values); j++ {
+			var (
+				reg = registers[j]
+				val = values[i]
+			)
+			EncodeUnsignedInt(reg.Width(), val.BigInt(), buf)
+			bit.BigEndianCopy(buf, 0, result, bitOffset, reg.Width())
+			bitOffset += reg.Width()
 			i = i + 1
 		}
 	}

--- a/pkg/zkc/vm/word.go
+++ b/pkg/zkc/vm/word.go
@@ -125,15 +125,17 @@ func EncodeBytes[W Word[W]](values []W, registers []register.Register) []byte {
 		offset     uint
 	)
 	//
-	for _, v := range values {
+	for i := 0; i < len(values); {
 		for _, r := range registers {
-			EncodeUnsignedInt(r.Width(), v.BigInt(), buf)
+			var val = values[i]
+			EncodeUnsignedInt(r.Width(), val.BigInt(), buf)
 			bit.BigEndianCopy(buf, 0, result, offset, r.Width())
 			offset += r.Width()
+			i = i + 1
 		}
 	}
 	//
-	return buf
+	return result
 }
 
 // ============================================================================


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches VM byte-packing logic and changes when constraint checking runs; encoding bugs could affect trace/binary interoperability, though the surface area is small and well-scoped.
> 
> **Overview**
> Fixes `vm.EncodeBytes` to correctly size the output buffer, handle non-full register rounds, and return the encoded result (instead of the scratch buffer), preventing incorrect byte packing.
> 
> Updates `zkc execute --check` to only run constraint checks when execution/tracing produced no errors, and cleans up a minor comment typo in `zkc compile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffcc85ed19922b62a255a51c67058d342b200b19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->