### PR TITLE
feat: support marshalling / unmarshalling `constraints.BinaryFile`

### DIFF
--- a/pkg/asm/program/module.go
+++ b/pkg/asm/program/module.go
@@ -119,6 +119,13 @@ func (p *Module[F, T]) IsStatic() bool {
 	return false
 }
 
+// StaticContents implementation for schema.Module interface.  Modules
+// originating from the assembly pipeline are never static, hence this function
+// always panics.
+func (p *Module[F, T]) StaticContents() []F {
+	panic("non-static modules have no contents")
+}
+
 // Substitute any matchined labelled constants within this module
 func (p *Module[F, T]) Substitute(mapping map[string]F) {
 	// For now, this is a no-operation because assembly has no concept of

--- a/pkg/cmd/zkc/compile.go
+++ b/pkg/cmd/zkc/compile.go
@@ -15,6 +15,7 @@ package zkc
 import (
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/consensys/go-corset/pkg/cmd/corset/debug"
 	"github.com/consensys/go-corset/pkg/ir/air"
@@ -158,19 +159,35 @@ func Build[F field.Element[F]](build BuildConfig, args ...string) BuildArtifacts
 		// AIR Constraints
 		air air.Schema[F]
 	)
-	// Compile source files, or print errors
-	ast = CompileSourceFiles(build.field, args...)
-	// Word-level Intermediate Representation
-	if deps.wir {
-		// Compile the AST into the top-level word machine
-		wir, errs = ast.Compile(build.config)
-		//
-		if len(errs) > 0 {
-			for _, err := range errs {
-				printSyntaxError(&err)
-			}
+	// Check whether prebuilt binary supplied on command-line.
+	if len(args) > 0 && path.Ext(args[0]) == ".bin" {
+		// Sanity check exactly one prebuilt binary provide.
+		if len(args) != 1 {
+			log.Error("require exactly one prebuilt binary")
+			os.Exit(6)
+		} else if build.ast {
+			log.Error("cannot extract AST from prebuilt binary")
+			os.Exit(7)
+		}
+		// Single (binary) file supplied
+		wm := ReadBinaryFile[F](args[0]).WordMachine()
+		// Assign over
+		wir = &wm
+	} else {
+		// Compile source files, or print errors
+		ast = CompileSourceFiles(build.field, args...)
+		// Word-level Intermediate Representation
+		if deps.wir {
+			// Compile the AST into the top-level word machine
+			wir, errs = ast.Compile(build.config)
 			//
-			os.Exit(4)
+			if len(errs) > 0 {
+				for _, err := range errs {
+					printSyntaxError(&err)
+				}
+				//
+				os.Exit(4)
+			}
 		}
 	}
 	// Field-level Intermediate Representation

--- a/pkg/cmd/zkc/util.go
+++ b/pkg/cmd/zkc/util.go
@@ -196,3 +196,23 @@ func WriteBinaryFile[F field.Element[F]](binfile *constraints.BinaryFile[F], fil
 		os.Exit(1)
 	}
 }
+
+// ReadBinaryFile reads a binary constraints file from disk
+func ReadBinaryFile[F field.Element[F]](filename string) *constraints.BinaryFile[F] {
+	var binf constraints.BinaryFile[F]
+	// Read schema file
+	data, err := os.ReadFile(filename)
+	// Handle errors
+	if err == nil {
+		err = binf.UnmarshalBinary(data)
+	}
+	// Return if no errors
+	if err == nil {
+		return &binf
+	}
+	// Handle error & exit
+	fmt.Println(err)
+	os.Exit(2)
+	// unreachable
+	return &binf
+}

--- a/pkg/schema/module.go
+++ b/pkg/schema/module.go
@@ -72,6 +72,11 @@ type Module[F any] interface {
 	// always the first n columns in a module.  Such columns have the property
 	// that they can be used in conjunction with Find.
 	Keys() uint
+	// StaticContents returns the contents of this module, assuming it
+	// corresponds with a static reference table.  Specifically, this will panic
+	// when IsStatic() is false (i.e. since only static modules can have
+	// contents).
+	StaticContents() []F
 	// Substitute any matchined labelled constants within this module
 	Substitute(map[string]F)
 }

--- a/pkg/zkc/constraints/binary_file.go
+++ b/pkg/zkc/constraints/binary_file.go
@@ -105,8 +105,8 @@ func (p *BinaryFile[F]) Field() field.Config {
 	return p.config
 }
 
-// Constraints returns the arithmetic constraints encoded in this file.
-func (p *BinaryFile[F]) Constraints() air.Schema[F] {
+// AirConstraints returns the arithmetic (AIR) constraints encoded in this file.
+func (p *BinaryFile[F]) AirConstraints() air.Schema[F] {
 	// Check cache
 	if p.cache.HasValue() {
 		return p.cache.Unwrap()
@@ -127,11 +127,16 @@ func (p *BinaryFile[F]) Constraints() air.Schema[F] {
 	return air
 }
 
+// WordMachine returns the top-level word machine encoded in this file.
+func (p *BinaryFile[F]) WordMachine() vm.WordMachine[vm.Uint] {
+	return p.machine
+}
+
 // Check a given trace against the constraints embodied in this constraints
 // file, potentially producing one (or more) constraint failures.
 func (p *BinaryFile[F]) Check(tr trace.Trace[F], config TraceConfig) []schema.Failure {
 	var (
-		sc    = p.Constraints()
+		sc    = p.AirConstraints()
 		stats = util.NewPerfStats()
 	)
 	// Check constraints
@@ -186,7 +191,7 @@ func (p *BinaryFile[F]) Trace(input map[string][]byte, config TraceConfig) (tr t
 		errs = append(errs, err)
 	} else {
 		// Extract AIR constraints
-		constraints := p.Constraints()
+		constraints := p.AirConstraints()
 		// Construct trace builder
 		builder := ir.NewTraceBuilder[F]().
 			WithValidation(config.validate).

--- a/pkg/zkc/constraints/binary_file_test.go
+++ b/pkg/zkc/constraints/binary_file_test.go
@@ -1,0 +1,76 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package constraints_test
+
+import (
+	"bytes"
+	"encoding/gob"
+	"math/big"
+	"testing"
+
+	"github.com/consensys/go-corset/pkg/schema/register"
+	"github.com/consensys/go-corset/pkg/util/field"
+	"github.com/consensys/go-corset/pkg/util/field/koalabear"
+	"github.com/consensys/go-corset/pkg/zkc/constraints"
+	"github.com/consensys/go-corset/pkg/zkc/vm"
+	"github.com/consensys/go-corset/pkg/zkc/vm/instruction"
+)
+
+// Smoke test for the Base machine round-trip: encode an empty WordMachine,
+// decode it, and verify it survives.
+func Test_ZkcMachine_GobRoundTripEmpty(t *testing.T) {
+	original := vm.NewWordMachine[vm.Uint](field.KOALABEAR_16)
+	//
+	var buffer bytes.Buffer
+	if err := gob.NewEncoder(&buffer).Encode(original); err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	//
+	var decoded vm.WordMachine[vm.Uint]
+	if err := gob.NewDecoder(&buffer).Decode(&decoded); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	//
+	if len(decoded.Modules()) != 0 {
+		t.Errorf("modules: got %d, want 0", len(decoded.Modules()))
+	}
+}
+
+// End-to-end test: build a small WordMachine with one function, encode it
+// inside a BinaryFile via MarshalBinary, decode via UnmarshalBinary, and
+// verify the decoded function/module survived.
+func Test_ZkcBinaryFile_RoundTrip(t *testing.T) {
+	var (
+		field = field.KOALABEAR_16
+		regs  = []register.Register{
+			register.NewInput("x", 8, *big.NewInt(0)),
+			register.NewOutput("y", 8, *big.NewInt(0)),
+		}
+		code = []instruction.Vector[instruction.Word]{
+			instruction.NewVector[instruction.Word](instruction.NewReturn()),
+		}
+		fn      = vm.NewFunction[instruction.Word]("main", false, regs, code)
+		machine = vm.NewWordMachine[vm.Uint](field, fn)
+		binfile = constraints.NewBinaryFile[koalabear.Element](nil, nil, field, *machine)
+	)
+	//
+	data, err := binfile.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary failed: %v", err)
+	}
+	//
+	var decoded constraints.BinaryFile[koalabear.Element]
+	if err := decoded.UnmarshalBinary(data); err != nil {
+		t.Fatalf("UnmarshalBinary failed: %v", err)
+	}
+}

--- a/pkg/zkc/vm/instruction/base.go
+++ b/pkg/zkc/vm/instruction/base.go
@@ -22,17 +22,6 @@ import (
 	"github.com/consensys/go-corset/pkg/zkc/vm/instruction/opcode"
 )
 
-func init() {
-	gob.Register(Instruction(&Call{}))
-	gob.Register(Instruction(&Fail{}))
-	gob.Register(Instruction(&Jump{}))
-	gob.Register(Instruction(&MemRead{}))
-	gob.Register(Instruction(&MemWrite{}))
-	gob.Register(Instruction(&Return{}))
-	gob.Register(Instruction(&Skip{}))
-	gob.Register(Instruction(&SkipIf{}))
-}
-
 // FormattedChunk is a convenient alias
 type FormattedChunk = base.FormattedChunk
 
@@ -212,4 +201,16 @@ func (p *systemMap) Registers() []register.Register {
 
 func (p *systemMap) String() string {
 	return p.regs.String()
+}
+
+func init() {
+	gob.Register(Instruction(&Call{}))
+	gob.Register(Instruction(&Debug{}))
+	gob.Register(Instruction(&Fail{}))
+	gob.Register(Instruction(&Jump{}))
+	gob.Register(Instruction(&MemRead{}))
+	gob.Register(Instruction(&MemWrite{}))
+	gob.Register(Instruction(&Return{}))
+	gob.Register(Instruction(&Skip{}))
+	gob.Register(Instruction(&SkipIf{}))
 }

--- a/pkg/zkc/vm/instruction/base.go
+++ b/pkg/zkc/vm/instruction/base.go
@@ -13,12 +13,25 @@
 package instruction
 
 import (
+	"encoding/gob"
+
 	"github.com/consensys/go-corset/pkg/schema/register"
 	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/field"
 	"github.com/consensys/go-corset/pkg/zkc/vm/instruction/base"
 	"github.com/consensys/go-corset/pkg/zkc/vm/instruction/opcode"
 )
+
+func init() {
+	gob.Register(Instruction(&Call{}))
+	gob.Register(Instruction(&Fail{}))
+	gob.Register(Instruction(&Jump{}))
+	gob.Register(Instruction(&MemRead{}))
+	gob.Register(Instruction(&MemWrite{}))
+	gob.Register(Instruction(&Return{}))
+	gob.Register(Instruction(&Skip{}))
+	gob.Register(Instruction(&SkipIf{}))
+}
 
 // FormattedChunk is a convenient alias
 type FormattedChunk = base.FormattedChunk

--- a/pkg/zkc/vm/internal/function/function.go
+++ b/pkg/zkc/vm/internal/function/function.go
@@ -13,6 +13,9 @@
 package function
 
 import (
+	"bytes"
+	"encoding/gob"
+
 	"github.com/consensys/go-corset/pkg/schema/register"
 	"github.com/consensys/go-corset/pkg/util/collection/array"
 	"github.com/consensys/go-corset/pkg/util/collection/set"
@@ -131,4 +134,63 @@ func (p *Function[I]) Registers() []register.Register {
 // Width returns the number of registers in this module.'
 func (p *Function[I]) Width() uint {
 	return uint(len(p.registers))
+}
+
+// ============================================================================
+// Encoding / Decoding
+// ============================================================================
+
+// nolint
+func (p *Function[I]) GobEncode() ([]byte, error) {
+	var buffer bytes.Buffer
+	gobEncoder := gob.NewEncoder(&buffer)
+	//
+	if err := gobEncoder.Encode(p.name); err != nil {
+		return nil, err
+	}
+	//
+	if err := gobEncoder.Encode(p.native); err != nil {
+		return nil, err
+	}
+	//
+	if err := gobEncoder.Encode(p.registers); err != nil {
+		return nil, err
+	}
+	//
+	if err := gobEncoder.Encode(p.code); err != nil {
+		return nil, err
+	}
+	//
+	return buffer.Bytes(), nil
+}
+
+// nolint
+func (p *Function[I]) GobDecode(data []byte) error {
+	var (
+		buffer     = bytes.NewBuffer(data)
+		gobDecoder = gob.NewDecoder(buffer)
+	)
+	//
+	if err := gobDecoder.Decode(&p.name); err != nil {
+		return err
+	}
+	//
+	if err := gobDecoder.Decode(&p.native); err != nil {
+		return err
+	}
+	//
+	if err := gobDecoder.Decode(&p.registers); err != nil {
+		return err
+	}
+	//
+	if err := gobDecoder.Decode(&p.code); err != nil {
+		return err
+	}
+	// Recompute internal values
+	p.numInputs = array.CountMatching(p.registers,
+		func(r register.Register) bool { return r.IsInput() })
+	p.numOutputs = array.CountMatching(p.registers,
+		func(r register.Register) bool { return r.IsOutput() })
+	// Done
+	return nil
 }

--- a/pkg/zkc/vm/internal/function/function_test.go
+++ b/pkg/zkc/vm/internal/function/function_test.go
@@ -1,0 +1,85 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package function_test
+
+import (
+	"bytes"
+	"encoding/gob"
+	"math/big"
+	"testing"
+
+	"github.com/consensys/go-corset/pkg/schema/register"
+	"github.com/consensys/go-corset/pkg/zkc/vm/instruction"
+	"github.com/consensys/go-corset/pkg/zkc/vm/internal/function"
+
+	// Side-effect import: registers concrete Word[Uint] instruction types with
+	// gob so that gob.Register-dependent encode paths work.
+	_ "github.com/consensys/go-corset/pkg/zkc/vm"
+)
+
+func Test_ZkcFunction_GobRoundTrip(t *testing.T) {
+	var (
+		regs = []register.Register{
+			register.NewInput("x", 8, *big.NewInt(0)),
+			register.NewInput("y", 8, *big.NewInt(0)),
+			register.NewOutput("z", 8, *big.NewInt(0)),
+			register.NewComputed("t", 8, *big.NewInt(0)),
+		}
+		code = []instruction.Vector[instruction.Word]{
+			instruction.NewVector[instruction.Word](instruction.NewReturn()),
+		}
+		original = function.New("f", true, regs, code)
+	)
+	//
+	var buffer bytes.Buffer
+	if err := gob.NewEncoder(&buffer).Encode(original); err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	//
+	var decoded function.Function[instruction.Word]
+	if err := gob.NewDecoder(&buffer).Decode(&decoded); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	//
+	if decoded.Name() != "f" {
+		t.Errorf("name: got %q, want %q", decoded.Name(), "f")
+	}
+	//
+	if !decoded.IsNative() {
+		t.Errorf("native: got false, want true")
+	}
+	//
+	if decoded.NumInputs() != 2 {
+		t.Errorf("numInputs: got %d, want 2", decoded.NumInputs())
+	}
+	//
+	if decoded.NumOutputs() != 1 {
+		t.Errorf("numOutputs: got %d, want 1", decoded.NumOutputs())
+	}
+	//
+	if decoded.Width() != 4 {
+		t.Errorf("width: got %d, want 4", decoded.Width())
+	}
+	//
+	if len(decoded.Code()) != 1 {
+		t.Fatalf("code length: got %d, want 1", len(decoded.Code()))
+	}
+	//
+	if len(decoded.Code()[0].Codes) != 1 {
+		t.Fatalf("vector length: got %d, want 1", len(decoded.Code()[0].Codes))
+	}
+	//
+	if _, ok := decoded.Code()[0].Codes[0].(*instruction.Return); !ok {
+		t.Errorf("first instruction: got %T, want *instruction.Return", decoded.Code()[0].Codes[0])
+	}
+}

--- a/pkg/zkc/vm/internal/machine/base.go
+++ b/pkg/zkc/vm/internal/machine/base.go
@@ -13,6 +13,8 @@
 package machine
 
 import (
+	"bytes"
+	"encoding/gob"
 	"errors"
 	"fmt"
 	"strings"
@@ -154,6 +156,46 @@ func (p *Base[W, I, T]) Depth() uint {
 // StackFrame returns the nth stack frame, where n==0 returns the root frame.
 func (p *Base[W, I, T]) StackFrame(n uint) Frame[W] {
 	return p.callstack[n]
+}
+
+// ============================================================================
+// Encoding / Decoding
+// ============================================================================
+
+// nolint
+func (p *Base[W, I, T]) GobEncode() ([]byte, error) {
+	var buffer bytes.Buffer
+	gobEncoder := gob.NewEncoder(&buffer)
+	//
+	if err := gobEncoder.Encode(p.modules); err != nil {
+		return nil, err
+	}
+	//
+	if err := gobEncoder.Encode(&p.executor); err != nil {
+		return nil, err
+	}
+	// Callstack is execution state and is not persisted.
+	return buffer.Bytes(), nil
+}
+
+// nolint
+func (p *Base[W, I, T]) GobDecode(data []byte) error {
+	var (
+		buffer     = bytes.NewBuffer(data)
+		gobDecoder = gob.NewDecoder(buffer)
+	)
+	//
+	if err := gobDecoder.Decode(&p.modules); err != nil {
+		return err
+	}
+	//
+	if err := gobDecoder.Decode(&p.executor); err != nil {
+		return err
+	}
+	// Callstack starts empty; populated only by Boot/Enter at execution time.
+	p.callstack = nil
+	//
+	return nil
 }
 
 // ========================================================

--- a/pkg/zkc/vm/internal/machine/field.go
+++ b/pkg/zkc/vm/internal/machine/field.go
@@ -39,3 +39,17 @@ type FieldExecutor[F field.Element[F]] struct {
 func (p FieldExecutor[F]) Execute(insn instruction.Field, frame []F, regs []register.Register) (err error) {
 	panic("got here")
 }
+
+// FieldExecutor carries no state, but it still needs an explicit gob
+// implementation because gob refuses to encode a struct with no exported
+// fields.
+
+// nolint
+func (p *FieldExecutor[F]) GobEncode() ([]byte, error) {
+	return nil, nil
+}
+
+// nolint
+func (p *FieldExecutor[F]) GobDecode(_ []byte) error {
+	return nil
+}

--- a/pkg/zkc/vm/internal/machine/word.go
+++ b/pkg/zkc/vm/internal/machine/word.go
@@ -13,6 +13,8 @@
 package machine
 
 import (
+	"bytes"
+	"encoding/gob"
 	"errors"
 	"fmt"
 
@@ -47,6 +49,28 @@ type WordExecutor[W word.Word[W]] struct {
 	// Prime modulus is needed only for simulating the execution of native field
 	// instructions.
 	modulus W
+}
+
+// nolint
+func (p *WordExecutor[W]) GobEncode() ([]byte, error) {
+	var buffer bytes.Buffer
+	gobEncoder := gob.NewEncoder(&buffer)
+	//
+	if err := gobEncoder.Encode(&p.modulus); err != nil {
+		return nil, err
+	}
+	//
+	return buffer.Bytes(), nil
+}
+
+// nolint
+func (p *WordExecutor[W]) GobDecode(data []byte) error {
+	var (
+		buffer     = bytes.NewBuffer(data)
+		gobDecoder = gob.NewDecoder(buffer)
+	)
+	//
+	return gobDecoder.Decode(&p.modulus)
 }
 
 // Execute implementation for Executor interface.

--- a/pkg/zkc/vm/internal/memory/bipartite_ram.go
+++ b/pkg/zkc/vm/internal/memory/bipartite_ram.go
@@ -13,6 +13,9 @@
 package memory
 
 import (
+	"bytes"
+	"encoding/gob"
+
 	"github.com/consensys/go-corset/pkg/schema/register"
 	"github.com/consensys/go-corset/pkg/util"
 )
@@ -228,4 +231,66 @@ func (p *BiPartiteRandomAccess[W]) readUpper(pos uint64) W {
 	}
 	//
 	return zero
+}
+
+// ============================================================================
+// Encoding / Decoding
+// ============================================================================
+
+// nolint
+func (p *BiPartiteRandomAccess[W]) GobEncode() ([]byte, error) {
+	var buffer bytes.Buffer
+	gobEncoder := gob.NewEncoder(&buffer)
+	//
+	if err := gobEncoder.Encode(&p.kind); err != nil {
+		return nil, err
+	}
+	//
+	if err := gobEncoder.Encode(&p.geometry); err != nil {
+		return nil, err
+	}
+	//
+	if err := gobEncoder.Encode(p.name); err != nil {
+		return nil, err
+	}
+	//
+	if err := gobEncoder.Encode(p.lower); err != nil {
+		return nil, err
+	}
+	//
+	if err := gobEncoder.Encode(p.upper); err != nil {
+		return nil, err
+	}
+	//
+	return buffer.Bytes(), nil
+}
+
+// nolint
+func (p *BiPartiteRandomAccess[W]) GobDecode(data []byte) error {
+	var (
+		buffer     = bytes.NewBuffer(data)
+		gobDecoder = gob.NewDecoder(buffer)
+	)
+	//
+	if err := gobDecoder.Decode(&p.kind); err != nil {
+		return err
+	}
+	//
+	if err := gobDecoder.Decode(&p.geometry); err != nil {
+		return err
+	}
+	//
+	if err := gobDecoder.Decode(&p.name); err != nil {
+		return err
+	}
+	//
+	if err := gobDecoder.Decode(&p.lower); err != nil {
+		return err
+	}
+	//
+	if err := gobDecoder.Decode(&p.upper); err != nil {
+		return err
+	}
+	//
+	return nil
 }

--- a/pkg/zkc/vm/internal/memory/geometry.go
+++ b/pkg/zkc/vm/internal/memory/geometry.go
@@ -13,6 +13,10 @@
 package memory
 
 import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+
 	"github.com/consensys/go-corset/pkg/schema/register"
 	"github.com/consensys/go-corset/pkg/util"
 )
@@ -114,4 +118,50 @@ func (p Geometry[W]) FrameDecode(frame []W, address []register.Id) (start, end u
 	start = index * uint64(p.numOutputs)
 
 	return start, start + uint64(p.numOutputs)
+}
+
+// ============================================================================
+// Encoding / Decoding
+// ============================================================================
+
+// nolint
+func (p *Geometry[W]) GobEncode() ([]byte, error) {
+	var buffer bytes.Buffer
+	gobEncoder := gob.NewEncoder(&buffer)
+	//
+	if err := gobEncoder.Encode(p.registers); err != nil {
+		return nil, err
+	}
+	//
+	return buffer.Bytes(), nil
+}
+
+// nolint
+func (p *Geometry[W]) GobDecode(data []byte) error {
+	var (
+		buffer     = bytes.NewBuffer(data)
+		gobDecoder = gob.NewDecoder(buffer)
+	)
+	//
+	if err := gobDecoder.Decode(&p.registers); err != nil {
+		return err
+	}
+	// Recompute internal values, mirroring NewGeometry.
+	var index = 0
+	//
+	for index < len(p.registers) && p.registers[index].IsInput() {
+		p.numInputs++
+		index++
+	}
+	//
+	for index < len(p.registers) && p.registers[index].IsOutput() {
+		p.numOutputs++
+		index++
+	}
+	//
+	if index != len(p.registers) {
+		return fmt.Errorf("unexpected non-input/output registers")
+	}
+	//
+	return nil
 }

--- a/pkg/zkc/vm/internal/memory/geometry.go
+++ b/pkg/zkc/vm/internal/memory/geometry.go
@@ -15,10 +15,10 @@ package memory
 import (
 	"bytes"
 	"encoding/gob"
-	"fmt"
 
 	"github.com/consensys/go-corset/pkg/schema/register"
 	"github.com/consensys/go-corset/pkg/util"
+	"github.com/consensys/go-corset/pkg/util/collection/array"
 )
 
 // Geometry is responsible for translating multi-word addresses into a
@@ -42,24 +42,11 @@ type Geometry[W util.Uinter64] struct {
 
 // NewGeometry constructs a new geometry from a given set of registers.
 func NewGeometry[W util.Uinter64](registers []register.Register) Geometry[W] {
-	var (
-		index           = 0
-		inputs, outputs = uint(0), uint(0)
-	)
-	//
-	for index < len(registers) && registers[index].IsInput() {
-		inputs++
-		index++
-	}
-	//
-	for index < len(registers) && registers[index].IsOutput() {
-		outputs++
-		index++
-	}
-	//
-	if index != len(registers) {
-		panic("unexpected non-input/output registers")
-	}
+	// Compute internal values
+	inputs := array.CountMatching(registers,
+		func(r register.Register) bool { return r.IsInput() })
+	outputs := array.CountMatching(registers,
+		func(r register.Register) bool { return r.IsOutput() })
 	// Done
 	return Geometry[W]{registers, inputs, outputs}
 }
@@ -146,22 +133,11 @@ func (p *Geometry[W]) GobDecode(data []byte) error {
 	if err := gobDecoder.Decode(&p.registers); err != nil {
 		return err
 	}
-	// Recompute internal values, mirroring NewGeometry.
-	var index = 0
-	//
-	for index < len(p.registers) && p.registers[index].IsInput() {
-		p.numInputs++
-		index++
-	}
-	//
-	for index < len(p.registers) && p.registers[index].IsOutput() {
-		p.numOutputs++
-		index++
-	}
-	//
-	if index != len(p.registers) {
-		return fmt.Errorf("unexpected non-input/output registers")
-	}
+	// Recompute internal values
+	p.numInputs = array.CountMatching(p.registers,
+		func(r register.Register) bool { return r.IsInput() })
+	p.numOutputs = array.CountMatching(p.registers,
+		func(r register.Register) bool { return r.IsOutput() })
 	//
 	return nil
 }

--- a/pkg/zkc/vm/internal/memory/memory.go
+++ b/pkg/zkc/vm/internal/memory/memory.go
@@ -13,6 +13,9 @@
 package memory
 
 import (
+	"bytes"
+	"encoding/gob"
+
 	"github.com/consensys/go-corset/pkg/schema/register"
 	"github.com/consensys/go-corset/pkg/util"
 	"github.com/consensys/go-corset/pkg/zkc/vm/instruction/base"
@@ -98,6 +101,60 @@ func (p Kind) IsWriteOnly() bool {
 // reads / writes.  Observe that RAM is always private.
 func (p Kind) IsReadWrite() bool {
 	return p.read && p.write
+}
+
+// ============================================================================
+// Encoding / Decoding
+// ============================================================================
+
+// nolint
+func (p *Kind) GobEncode() ([]byte, error) {
+	var buffer bytes.Buffer
+	gobEncoder := gob.NewEncoder(&buffer)
+	//
+	if err := gobEncoder.Encode(p.public); err != nil {
+		return nil, err
+	}
+	//
+	if err := gobEncoder.Encode(p.static); err != nil {
+		return nil, err
+	}
+	//
+	if err := gobEncoder.Encode(p.read); err != nil {
+		return nil, err
+	}
+	//
+	if err := gobEncoder.Encode(p.write); err != nil {
+		return nil, err
+	}
+	//
+	return buffer.Bytes(), nil
+}
+
+// nolint
+func (p *Kind) GobDecode(data []byte) error {
+	var (
+		buffer     = bytes.NewBuffer(data)
+		gobDecoder = gob.NewDecoder(buffer)
+	)
+	//
+	if err := gobDecoder.Decode(&p.public); err != nil {
+		return err
+	}
+	//
+	if err := gobDecoder.Decode(&p.static); err != nil {
+		return err
+	}
+	//
+	if err := gobDecoder.Decode(&p.read); err != nil {
+		return err
+	}
+	//
+	if err := gobDecoder.Decode(&p.write); err != nil {
+		return err
+	}
+	//
+	return nil
 }
 
 var (

--- a/pkg/zkc/vm/internal/memory/memory_gob_test.go
+++ b/pkg/zkc/vm/internal/memory/memory_gob_test.go
@@ -1,0 +1,159 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package memory_test
+
+import (
+	"bytes"
+	"encoding/gob"
+	"math/big"
+	"testing"
+
+	"github.com/consensys/go-corset/pkg/schema/register"
+	"github.com/consensys/go-corset/pkg/zkc/vm/instruction/base"
+	"github.com/consensys/go-corset/pkg/zkc/vm/internal/memory"
+	"github.com/consensys/go-corset/pkg/zkc/vm/internal/word"
+
+	// Side-effect import: registers concrete memory[Uint] types as
+	// base.Module so they can be encoded through the Module interface.
+	_ "github.com/consensys/go-corset/pkg/zkc/vm"
+)
+
+func sampleRegs() []register.Register {
+	return []register.Register{
+		register.NewInput("addr", 4, *big.NewInt(0)),
+		register.NewOutput("data0", 8, *big.NewInt(0)),
+		register.NewOutput("data1", 8, *big.NewInt(0)),
+	}
+}
+
+func Test_ZkcMemory_StaticArrayRoundTrip(t *testing.T) {
+	var (
+		regs     = sampleRegs()
+		original = memory.NewStaticArray[word.Uint]("rom", memory.PUBLIC_STATIC_MEMORY, regs)
+	)
+	//
+	var buffer bytes.Buffer
+	if err := gob.NewEncoder(&buffer).Encode(&original); err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	//
+	var decoded memory.StaticArray[word.Uint]
+	if err := gob.NewDecoder(&buffer).Decode(&decoded); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	//
+	if decoded.Name() != "rom" {
+		t.Errorf("name: got %q, want %q", decoded.Name(), "rom")
+	}
+	//
+	if !decoded.IsPublic() || !decoded.IsStatic() || !decoded.IsReadOnly() {
+		t.Errorf("kind: lost PUBLIC_STATIC_MEMORY flags")
+	}
+	//
+	if decoded.Width() != 3 {
+		t.Errorf("width: got %d, want 3", decoded.Width())
+	}
+	//
+	if decoded.Geometry().AddressLines() != 1 {
+		t.Errorf("address lines: got %d, want 1", decoded.Geometry().AddressLines())
+	}
+	//
+	if decoded.Geometry().DataLines() != 2 {
+		t.Errorf("data lines: got %d, want 2", decoded.Geometry().DataLines())
+	}
+}
+
+func Test_ZkcMemory_ReadOnlyWithDataRoundTrip(t *testing.T) {
+	var (
+		regs     = sampleRegs()
+		original = memory.NewStaticArray[word.Uint]("rom", memory.PUBLIC_STATIC_MEMORY, regs)
+		one      word.Uint
+		two      word.Uint
+	)
+	//
+	original.Initialise([]word.Uint{one.SetUint64(0xdeadbeef), two.SetUint64(0xcafebabe)})
+	//
+	var buffer bytes.Buffer
+	if err := gob.NewEncoder(&buffer).Encode(&original); err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	//
+	var decoded memory.StaticArray[word.Uint]
+	if err := gob.NewDecoder(&buffer).Decode(&decoded); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	//
+	if got := decoded.Registers(); len(got) != 3 {
+		t.Errorf("registers: got %d, want 3", len(got))
+	}
+}
+
+func Test_ZkcMemory_ModuleInterfaceRoundTrip(t *testing.T) {
+	// Construct one of each memory shape.
+	rom := &memory.ReadOnly[word.Uint]{
+		StaticArray: memory.NewStaticArray[word.Uint]("rom", memory.PUBLIC_READ_ONLY_MEMORY, sampleRegs()),
+	}
+	wom := &memory.WriteOnce[word.Uint]{
+		StaticArray: memory.NewStaticArray[word.Uint]("wom", memory.PUBLIC_WRITE_ONCE_MEMORY, sampleRegs()),
+	}
+	srom := &memory.StaticReadOnly[word.Uint]{
+		ReadOnly: memory.ReadOnly[word.Uint]{
+			StaticArray: memory.NewStaticArray[word.Uint]("srom", memory.PUBLIC_STATIC_MEMORY, sampleRegs()),
+		},
+	}
+	ra := &memory.RandomAccess[word.Uint]{
+		StaticArray: memory.NewStaticArray[word.Uint]("ra", memory.RANDOM_ACCESS_MEMORY, sampleRegs()),
+	}
+	bram := memory.NewBiPartiteRandomAccess[word.Uint]("bram", sampleRegs())
+	input := []base.Module{rom, wom, srom, ra, bram}
+	//
+	var buffer bytes.Buffer
+	if err := gob.NewEncoder(&buffer).Encode(input); err != nil {
+		t.Fatalf("encode failed: %v", err)
+	}
+	//
+	var decoded []base.Module
+	if err := gob.NewDecoder(&buffer).Decode(&decoded); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	//
+	if len(decoded) != 5 {
+		t.Fatalf("decoded length: got %d, want 5", len(decoded))
+	}
+	//
+	if _, ok := decoded[0].(*memory.ReadOnly[word.Uint]); !ok {
+		t.Errorf("decoded[0]: got %T, want *memory.ReadOnly[word.Uint]", decoded[0])
+	}
+	//
+	if _, ok := decoded[1].(*memory.WriteOnce[word.Uint]); !ok {
+		t.Errorf("decoded[1]: got %T, want *memory.WriteOnce[word.Uint]", decoded[1])
+	}
+	//
+	if _, ok := decoded[2].(*memory.StaticReadOnly[word.Uint]); !ok {
+		t.Errorf("decoded[2]: got %T, want *memory.StaticReadOnly[word.Uint]", decoded[2])
+	}
+	//
+	if _, ok := decoded[3].(*memory.RandomAccess[word.Uint]); !ok {
+		t.Errorf("decoded[3]: got %T, want *memory.RandomAccess[word.Uint]", decoded[3])
+	}
+	//
+	if _, ok := decoded[4].(*memory.BiPartiteRandomAccess[word.Uint]); !ok {
+		t.Errorf("decoded[4]: got %T, want *memory.BiPartiteRandomAccess[word.Uint]", decoded[4])
+	}
+	//
+	for i, name := range []string{"rom", "wom", "srom", "ra", "bram"} {
+		if decoded[i].Name() != name {
+			t.Errorf("decoded[%d].Name(): got %q, want %q", i, decoded[i].Name(), name)
+		}
+	}
+}

--- a/pkg/zkc/vm/internal/memory/static_array.go
+++ b/pkg/zkc/vm/internal/memory/static_array.go
@@ -13,6 +13,8 @@
 package memory
 
 import (
+	"bytes"
+	"encoding/gob"
 	"slices"
 
 	"github.com/consensys/go-corset/pkg/schema/register"
@@ -149,4 +151,58 @@ func expand[T any](slice []T, n uint64) []T {
 	}
 	//
 	return slices.Grow(slice, int(n-m))[:n]
+}
+
+// ============================================================================
+// Encoding / Decoding
+// ============================================================================
+
+// nolint
+func (p *StaticArray[W]) GobEncode() ([]byte, error) {
+	var buffer bytes.Buffer
+	gobEncoder := gob.NewEncoder(&buffer)
+	//
+	if err := gobEncoder.Encode(&p.kind); err != nil {
+		return nil, err
+	}
+	//
+	if err := gobEncoder.Encode(&p.geometry); err != nil {
+		return nil, err
+	}
+	//
+	if err := gobEncoder.Encode(p.name); err != nil {
+		return nil, err
+	}
+	//
+	if err := gobEncoder.Encode(p.data); err != nil {
+		return nil, err
+	}
+	//
+	return buffer.Bytes(), nil
+}
+
+// nolint
+func (p *StaticArray[W]) GobDecode(data []byte) error {
+	var (
+		buffer     = bytes.NewBuffer(data)
+		gobDecoder = gob.NewDecoder(buffer)
+	)
+	//
+	if err := gobDecoder.Decode(&p.kind); err != nil {
+		return err
+	}
+	//
+	if err := gobDecoder.Decode(&p.geometry); err != nil {
+		return err
+	}
+	//
+	if err := gobDecoder.Decode(&p.name); err != nil {
+		return err
+	}
+	//
+	if err := gobDecoder.Decode(&p.data); err != nil {
+		return err
+	}
+	//
+	return nil
 }

--- a/pkg/zkc/vm/internal/word/uint.go
+++ b/pkg/zkc/vm/internal/word/uint.go
@@ -256,6 +256,20 @@ func (p Uint) Text(base int) string {
 	return p.value.Text(base)
 }
 
+// ============================================================================
+// Encoding / Decoding
+// ============================================================================
+
+// nolint
+func (p Uint) GobEncode() ([]byte, error) {
+	return p.value.GobEncode()
+}
+
+// nolint
+func (p *Uint) GobDecode(data []byte) error {
+	return p.value.GobDecode(data)
+}
+
 // ReadBitSlice reads a slice of bits starting at a given offset in a give
 // value.  For example, consider the value is 10111000 and we have offset=1 and
 // width=4, then the result is 1100.

--- a/pkg/zkc/vm/word.go
+++ b/pkg/zkc/vm/word.go
@@ -13,13 +13,43 @@
 package vm
 
 import (
+	"encoding/gob"
 	"math/big"
 
 	"github.com/consensys/go-corset/pkg/schema/register"
 	"github.com/consensys/go-corset/pkg/util/collection/array"
 	"github.com/consensys/go-corset/pkg/util/collection/bit"
+	"github.com/consensys/go-corset/pkg/zkc/vm/instruction"
+	"github.com/consensys/go-corset/pkg/zkc/vm/internal/function"
+	"github.com/consensys/go-corset/pkg/zkc/vm/internal/memory"
 	"github.com/consensys/go-corset/pkg/zkc/vm/internal/word"
 )
+
+func init() {
+	gob.Register(instruction.Word(&instruction.IntAdd[Uint]{}))
+	gob.Register(instruction.Word(&instruction.IntSub[Uint]{}))
+	gob.Register(instruction.Word(&instruction.IntMul[Uint]{}))
+	gob.Register(instruction.Word(&instruction.IntDiv[Uint]{}))
+	gob.Register(instruction.Word(&instruction.IntRem[Uint]{}))
+	gob.Register(instruction.Word(&instruction.IntAddModP[Uint]{}))
+	gob.Register(instruction.Word(&instruction.IntSubModP[Uint]{}))
+	gob.Register(instruction.Word(&instruction.IntMulModP[Uint]{}))
+	gob.Register(instruction.Word(&instruction.BitAnd[Uint]{}))
+	gob.Register(instruction.Word(&instruction.BitNot[Uint]{}))
+	gob.Register(instruction.Word(&instruction.BitOr[Uint]{}))
+	gob.Register(instruction.Word(&instruction.BitXor[Uint]{}))
+	gob.Register(instruction.Word(&instruction.BitShl[Uint]{}))
+	gob.Register(instruction.Word(&instruction.BitShr[Uint]{}))
+	gob.Register(instruction.Word(&instruction.BitConcat[Uint]{}))
+	gob.Register(instruction.Word(&instruction.Destruct{}))
+	gob.Register(instruction.Word(&instruction.Cast{}))
+	gob.Register(instruction.Module(&function.Function[instruction.Word]{}))
+	gob.Register(instruction.Module(&memory.RandomAccess[Uint]{}))
+	gob.Register(instruction.Module(&memory.ReadOnly[Uint]{}))
+	gob.Register(instruction.Module(&memory.WriteOnce[Uint]{}))
+	gob.Register(instruction.Module(&memory.StaticReadOnly[Uint]{}))
+	gob.Register(instruction.Module(&memory.BiPartiteRandomAccess[Uint]{}))
+}
 
 // Word abstracts the data type (a.k.a the "machine word") used for holding
 // values within the machine.  The reason for abstracting this concept is to


### PR DESCRIPTION
This puts together GOB encoders / decoders for machine.Base, such that it can be marshalled / unmarshalled as part of a binary constraints file.  This additional required GOB encoders / decoders for various other components, such as vm.Function, vm.Memory and the various vm.Instruction interfaces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces gob serialization for core VM structures and changes the `schema.Module` interface, which can affect binary compatibility and runtime decoding across the toolchain.
> 
> **Overview**
> Adds end-to-end support for reading/writing precompiled `.bin` constraint packages by making `constraints.BinaryFile` (and its embedded `vm.WordMachine`) gob-serializable and adding `ReadBinaryFile()` plus `compile` support for `.bin` inputs.
> 
> Implements explicit gob encode/decode paths for core VM components (machine base/executors, functions, memories, and word types) and registers concrete instruction/module types with gob to allow interface-based decoding. Also updates `schema.Module` to expose `StaticContents()` (with an explicit panic implementation for non-static asm modules) and renames `BinaryFile.Constraints()` to `AirConstraints()`, with new round-trip tests covering machine, function, memory, and binary file encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 280508459a3a90d6b382734a25bf3fb8d7f3055d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->