### PR TITLE
fix: incorrect translation of air constraints

### DIFF
--- a/pkg/cmd/zkc/util.go
+++ b/pkg/cmd/zkc/util.go
@@ -13,6 +13,7 @@
 package zkc
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path"
@@ -189,6 +190,9 @@ func WriteBinaryFile[F field.Element[F]](binfile *constraints.BinaryFile[F], fil
 	if bytes, err = binfile.MarshalBinary(); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)
+	} else if path.Ext(filename) == ".hex" {
+		h := fmt.Sprintf("0x%s", hex.EncodeToString(bytes))
+		bytes = []byte(h)
 	}
 	// Write file
 	if err := os.WriteFile(filename, bytes, 0644); err != nil {

--- a/pkg/zkc/constraints/translator.go
+++ b/pkg/zkc/constraints/translator.go
@@ -184,10 +184,13 @@ func initMultiLineFraming[F field.Element[F]](ctx module.Id, pc, ret register.Id
 	var (
 		// determine suitable width of PC register
 		pcWidth = bit.Width(uint(1 + len(fn.Code())))
-		pc_i    = mirc.Variable[register.Id, Expr[F]](pc, 1, 0)
-		pc_im1  = mirc.Variable[register.Id, Expr[F]](pc, 1, -1)
-		ret_i   = mirc.Variable[register.Id, Expr[F]](ret, 1, 0)
-		ret_im1 = mirc.Variable[register.Id, Expr[F]](ret, 1, -1)
+		// set with of RET register
+		retWidth = uint(1)
+		//
+		pc_i    = mirc.Variable[register.Id, Expr[F]](pc, pcWidth, 0)
+		pc_im1  = mirc.Variable[register.Id, Expr[F]](pc, pcWidth, -1)
+		ret_i   = mirc.Variable[register.Id, Expr[F]](ret, retWidth, 0)
+		ret_im1 = mirc.Variable[register.Id, Expr[F]](ret, retWidth, -1)
 		zero    = mirc.Number[register.Id, Expr[F]](0)
 		one     = mirc.Number[register.Id, Expr[F]](1)
 	)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect constraint generation for non-atomic functions by fixing the program-counter variable bit-width, which could alter generated MIR/AIR constraints and downstream proofs. Also adds an alternate `.hex` serialization path for binary outputs, with low behavioral risk but new output format to validate.
> 
> **Overview**
> Fixes an AIR/MIR translation bug in `initMultiLineFraming` by using the computed `pcWidth` when constructing PC register variables (instead of a hardcoded width), keeping framing constraints consistent with the declared PC register size.
> 
> Extends `WriteBinaryFile` to optionally write marshaled binaries as a `0x`-prefixed hex string when the output filename ends in `.hex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 249376e097f7bb498f1d07645fc876cc10b61af5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->