### PR TITLE
feat: refactor module.StaticContents() API

### DIFF
--- a/pkg/asm/compiler/mir.go
+++ b/pkg/asm/compiler/mir.go
@@ -40,7 +40,7 @@ type MirModule[F field.Element[F]] struct {
 // Initialise this module
 func (p MirModule[F]) Initialise(mid uint, fn MicroComponent) MirModule[F] {
 	builder := ir.NewModuleBuilder[F, mir.Constraint[F], mir.Term[F]](
-		fn.Name(), mid, false, fn.IsPublic(), false, fn.NumInputs())
+		fn.Name(), mid, false, fn.IsPublic(), false, false, false, fn.NumInputs())
 	//
 	switch fn := fn.(type) {
 	case *MicroFunction:

--- a/pkg/asm/program/module.go
+++ b/pkg/asm/program/module.go
@@ -122,7 +122,7 @@ func (p *Module[F, T]) IsStatic() bool {
 // StaticContents implementation for schema.Module interface.  Modules
 // originating from the assembly pipeline are never static, hence this function
 // always panics.
-func (p *Module[F, T]) StaticContents() []F {
+func (p *Module[F, T]) StaticContents() [][]F {
 	panic("non-static modules have no contents")
 }
 

--- a/pkg/cmd/corset/debug/schema.go
+++ b/pkg/cmd/corset/debug/schema.go
@@ -138,7 +138,7 @@ func printStaticContents[F field.Element[F]](module schema.Module[F]) {
 		//
 		fmt.Println("(contents")
 		//
-		for i, row := range module.StaticContents() {
+		for i, row := range contents {
 			fmt.Print("   (")
 			//
 			for j, v := range row {

--- a/pkg/cmd/corset/debug/schema.go
+++ b/pkg/cmd/corset/debug/schema.go
@@ -111,6 +111,8 @@ func printModule[F field.Element[F]](module schema.Module[F], sc schema.AnySchem
 	printRegisters(module, "inputs", func(r register.Register) bool { return r.IsInput() })
 	printRegisters(module, "outputs", func(r register.Register) bool { return r.IsOutput() })
 	printRegisters(module, "computed", func(r register.Register) bool { return r.IsComputed() })
+	// Print static contents (if applicable)
+	printStaticContents(module)
 	// Print computations
 	for i := module.Assignments(); i.HasNext(); {
 		ith := i.Next()
@@ -127,6 +129,34 @@ func printModule[F field.Element[F]](module schema.Module[F], sc schema.AnySchem
 		}
 		//
 		fmt.Print(text)
+	}
+}
+
+func printStaticContents[F field.Element[F]](module schema.Module[F]) {
+	if module.IsStatic() {
+		var contents = module.StaticContents()
+		//
+		fmt.Println("(contents")
+		//
+		for i, row := range module.StaticContents() {
+			fmt.Print("   (")
+			//
+			for j, v := range row {
+				if j != 0 {
+					fmt.Print(", ")
+				}
+				//
+				fmt.Printf("0x%s", v.Text(16))
+			}
+			//
+			if i+1 != len(contents) {
+				fmt.Println("),")
+			} else {
+				fmt.Println(")")
+			}
+		}
+		//
+		fmt.Println(")")
 	}
 }
 

--- a/pkg/corset/compiler/translator.go
+++ b/pkg/corset/compiler/translator.go
@@ -120,7 +120,7 @@ func (t *translator) translateModules(circuit *ast.Circuit) {
 // one HIR module.
 func (t *translator) translateModule(name string) {
 	// Always include module with base multiplier (even if empty).
-	t.schema.NewModule(module.NewName(name, 1), true, true, false, 0)
+	t.schema.NewModule(module.NewName(name, 1), true, true, false, false, false, 0)
 	// Initialise the corresponding family of HIR modules.
 	for _, regIndex := range t.env.RegistersOf(name) {
 		var (
@@ -132,7 +132,7 @@ func (t *translator) translateModule(name string) {
 		// Check whether module created this already (or not)
 		if _, ok := t.schema.HasModule(moduleName); !ok {
 			// No, therefore create new module.
-			t.schema.NewModule(moduleName, true, true, false, 0)
+			t.schema.NewModule(moduleName, true, true, false, false, false, 0)
 		}
 	}
 	// Translate all corset registers in this module into HIR registers across

--- a/pkg/ir/air/gadgets/bitwidth.go
+++ b/pkg/ir/air/gadgets/bitwidth.go
@@ -169,7 +169,7 @@ func (p *BitwidthGadget[F]) applyRecursiveBitwidthGadget(ref register.Ref, bitwi
 func (p *BitwidthGadget[F]) constructTypeProof(handle module.Name, bitwidth uint) sc.ModuleId {
 	var (
 		// Create new module for this type proof
-		mid    = p.schema.NewModule(handle, false, false, true, 0)
+		mid    = p.schema.NewModule(handle, false, false, true, false, false, 0)
 		module = p.schema.Module(mid)
 		// Determine limb widths.
 		loWidth, hiWidth = determineLimbSplit(bitwidth)

--- a/pkg/ir/hir/lower.go
+++ b/pkg/ir/hir/lower.go
@@ -61,7 +61,7 @@ func NewMirLowering[E register.ConstMap](externs []E, modules []Module) MirLower
 	)
 	// Initialise MIR modules
 	for _, m := range modules {
-		mirSchema.NewModule(m.Name(), m.AllowPadding(), m.IsPublic(), m.IsSynthetic(), m.Keys())
+		mirSchema.NewModule(m.Name(), m.AllowPadding(), m.IsPublic(), m.IsSynthetic(), m.IsStatic(), m.IsNative(), m.Keys())
 	}
 	//
 	return MirLowering{

--- a/pkg/ir/mir/lower.go
+++ b/pkg/ir/mir/lower.go
@@ -63,7 +63,7 @@ func NewAirLowering[F field.Element[F]](fieldBandwidth uint, mirSchema Schema[F]
 	)
 	// Initialise AIR modules
 	for _, m := range mirSchema.RawModules() {
-		airSchema.NewModule(m.Name(), m.AllowPadding(), m.IsPublic(), m.IsSynthetic(), m.Keys())
+		airSchema.NewModule(m.Name(), m.AllowPadding(), m.IsPublic(), m.IsSynthetic(), m.IsStatic(), m.IsNative(), m.Keys())
 	}
 	//
 	return AirLowering[F]{
@@ -106,6 +106,10 @@ func (p *AirLowering[F]) InitialiseModule(index uint) {
 	)
 	// Initialise registers in AIR module
 	airModule.NewRegisters(mirModule.Registers()...)
+	// Initialise static contents (if applicable)
+	if mirModule.IsStatic() {
+		airModule.SetStaticContents(mirModule.StaticContents())
+	}
 }
 
 // LowerModule lowers the given MIR module into the corresponding AIR module.

--- a/pkg/ir/mir/subdivide.go
+++ b/pkg/ir/mir/subdivide.go
@@ -79,6 +79,10 @@ func Subdivide[F field.Element[F], E register.ConstMap](mapping module.LimbsMap,
 		}
 		// Initialise all register limbs.
 		module.NewRegisters(limbsMap.Registers()...)
+		// Assign static contents (if applicable)
+		if m.IsStatic() {
+			module.SetStaticContents(m.StaticContents())
+		}
 	}
 	// Construct subdivider
 	subdivider := &Subdivider[F]{builder, mapping}

--- a/pkg/ir/mir/subdivide.go
+++ b/pkg/ir/mir/subdivide.go
@@ -67,8 +67,9 @@ func Subdivide[F field.Element[F], E register.ConstMap](mapping module.LimbsMap,
 	for i, m := range mods {
 		// original registers.
 		var (
-			eid      = uint(i + len(externs))
-			mid      = builder.NewModule(m.Name(), m.AllowPadding(), m.IsPublic(), m.IsSynthetic(), 0)
+			eid = uint(i + len(externs))
+			mid = builder.NewModule(m.Name(), m.AllowPadding(), m.IsPublic(), m.IsSynthetic(),
+				m.IsStatic(), m.IsNative(), 0)
 			module   = builder.Module(mid)
 			limbsMap = mapping.Module(mid).LimbsMap()
 		)

--- a/pkg/ir/module_builder.go
+++ b/pkg/ir/module_builder.go
@@ -62,6 +62,12 @@ type ModuleBuilder[F field.Element[F], C schema.Constraint[F], T term.Expr[F, T]
 	// which is always zero.  If no such register exists already, one is
 	// created.
 	ConstRegister(constant uint8) register.Id
+	// SetStaticContents sets the contents of this static reference table.  It
+	// panics if invoked on a non-static module.
+	SetStaticContents(contents [][]F)
+	// StaticContents returns the static contents for a static reference table.  It
+	// panics if invoked on a non-static module.
+	StaticContents() (contents [][]F)
 }
 
 // ============================================================================
@@ -70,10 +76,12 @@ type ModuleBuilder[F field.Element[F], C schema.Constraint[F], T term.Expr[F, T]
 
 // NewModuleBuilder constructs a new builder for a module with the given name.
 func NewModuleBuilder[F field.Element[F], C schema.Constraint[F], T term.Expr[F, T]](name module.Name,
-	mid schema.ModuleId, padding, public, synthetic bool, keys uint) ModuleBuilder[F, C, T] {
+	mid schema.ModuleId, padding, public, synthetic, static, native bool, keys uint) ModuleBuilder[F, C, T] {
 	//
 	regmap := make(map[string]uint, 0)
-	return &internalModuleBuilder[F, C, T]{name, mid, padding, public, synthetic, keys, regmap, nil, nil, nil}
+
+	return &internalModuleBuilder[F, C, T]{name, mid, padding, public, synthetic, static, native,
+		keys, regmap, nil, nil, nil, nil}
 }
 
 type internalModuleBuilder[F field.Element[F], C schema.Constraint[F], T term.Expr[F, T]] struct {
@@ -87,6 +95,10 @@ type internalModuleBuilder[F field.Element[F], C schema.Constraint[F], T term.Ex
 	public bool
 	// Indicates whether this is a synthetic module or not
 	synthetic bool
+	// Indicates whether this is a static module or not
+	static bool
+	// Indicates whether this is a native module or not
+	native bool
 	// Number of key columns
 	keys uint
 	// Maps register names (including aliases) to the register number.
@@ -97,6 +109,8 @@ type internalModuleBuilder[F field.Element[F], C schema.Constraint[F], T term.Ex
 	constraints []C
 	// Assignments for computed registers
 	assignments []schema.Assignment[F]
+	// Static contents for ref tables
+	staticContents [][]F
 }
 
 // AddAssignment implementation for ModuleBuilder interface.
@@ -153,14 +167,14 @@ func (p *internalModuleBuilder[F, C, T]) IsSynthetic() bool {
 // this builder are never native; only the ZkC pipeline produces native
 // modules and it does not go through this builder.
 func (p *internalModuleBuilder[F, C, T]) IsNative() bool {
-	return false
+	return p.native
 }
 
 // IsStatic implementation for schema.ModuleView interface.  Modules built via
 // this builder are never static; static modules are produced directly by the
 // ZkC pipeline.
 func (p *internalModuleBuilder[F, C, T]) IsStatic() bool {
-	return false
+	return p.static
 }
 
 // Width implementation for schema.ModuleView interface.
@@ -241,6 +255,24 @@ func (p *internalModuleBuilder[F, C, T]) ConstRegister(constant uint8) register.
 	}
 	// If not, create a new one.
 	return p.NewRegister(register.NewConst(constant))
+}
+
+func (p *internalModuleBuilder[F, C, T]) SetStaticContents(contents [][]F) {
+	if !p.IsStatic() {
+		panic("cannot set static contents for non-static module")
+	} else if p.staticContents != nil {
+		panic("cannot reassign static-contents")
+	}
+	//
+	p.staticContents = contents
+}
+
+func (p *internalModuleBuilder[F, C, T]) StaticContents() (contents [][]F) {
+	if !p.IsStatic() {
+		panic("cannot set static contents for non-static module")
+	}
+	//
+	return p.staticContents
 }
 
 // ============================================================================
@@ -365,6 +397,14 @@ func (p *externalModuleBuilder[F, C, T]) Register(rid register.Id) register.Regi
 // Registers implementation for register.Map interface.
 func (p *externalModuleBuilder[F, C, T]) Registers() []register.Register {
 	return p.module.Registers()
+}
+
+func (p *externalModuleBuilder[F, C, T]) SetStaticContents(contents [][]F) {
+	panic("cannot set static contents for external module")
+}
+
+func (p *externalModuleBuilder[F, C, T]) StaticContents() (contents [][]F) {
+	panic("cannot get static contents for external module")
 }
 
 func (p *externalModuleBuilder[F, C, T]) String() string {

--- a/pkg/ir/schema_builder.go
+++ b/pkg/ir/schema_builder.go
@@ -33,6 +33,8 @@ type BuildableModule[F any, C schema.Constraint[F], M any] interface {
 	AddConstraints(constraints ...C)
 	// Add one or more registers to this buildable module.
 	AddRegisters(registers ...register.Register)
+	// Set contents for static module
+	SetStaticContents(contents [][]F)
 }
 
 // BuildSchema builds all modules defined within a give SchemaBuilder instance.
@@ -59,6 +61,10 @@ func BuildModule[F field.Element[F], C schema.Constraint[F], T term.Expr[F, T], 
 	module.AddRegisters(m.Registers()...)
 	module.AddAssignments(m.Assignments()...)
 	module.AddConstraints(m.Constraints()...)
+	// set static contents (if applicable)
+	if m.IsStatic() {
+		module.SetStaticContents(m.StaticContents())
+	}
 	// Done
 	return module
 }
@@ -104,14 +110,15 @@ func NewSchemaBuilder[F field.Element[F], C schema.Constraint[F], T term.Expr[F,
 
 // NewModule constructs a new, empty module and returns its unique module
 // identifier.
-func (p *SchemaBuilder[F, C, T]) NewModule(name module.Name, padding, public, synthetic bool, keys uint) uint {
+func (p *SchemaBuilder[F, C, T]) NewModule(name module.Name, padding, public, synthetic, static, native bool,
+	keys uint) uint {
 	var mid = uint(len(p.externs) + len(p.modules))
 	// Sanity check this module is not already declared
 	if _, ok := p.modmap[name]; ok {
 		panic(fmt.Sprintf("module \"%s\" already declared", name))
 	}
 	//
-	p.modules = append(p.modules, NewModuleBuilder[F, C, T](name, mid, padding, public, synthetic, keys))
+	p.modules = append(p.modules, NewModuleBuilder[F, C, T](name, mid, padding, public, synthetic, static, native, keys))
 	p.modmap[name] = mid
 	//
 	return mid

--- a/pkg/schema/module.go
+++ b/pkg/schema/module.go
@@ -73,10 +73,11 @@ type Module[F any] interface {
 	// that they can be used in conjunction with Find.
 	Keys() uint
 	// StaticContents returns the contents of this module, assuming it
-	// corresponds with a static reference table.  Specifically, this will panic
-	// when IsStatic() is false (i.e. since only static modules can have
-	// contents).
-	StaticContents() []F
+	// corresponds with a static reference table.  Each entry in the entries
+	// array returned should have Width() elements and correspond to a row in
+	// the static module.  NOTE: this will panic when IsStatic() is false (i.e.
+	// since only static modules can have contents).
+	StaticContents() (entries [][]F)
 	// Substitute any matchined labelled constants within this module
 	Substitute(map[string]F)
 }
@@ -103,7 +104,7 @@ type Table[F field.Element[F], C Constraint[F]] struct {
 	registers      []register.Register
 	constraints    []C
 	assignments    []Assignment[F]
-	staticContents []F
+	staticContents [][]F
 }
 
 // Init implementation for ir.InitModule interface.  The native flag indicates
@@ -201,7 +202,7 @@ func (p *Table[F, C]) IsStatic() bool {
 // StaticContents returns the contents of this static reference table.  It
 // panics if invoked on a non-static module, since no contents are stored in
 // that case.
-func (p *Table[F, C]) StaticContents() []F {
+func (p *Table[F, C]) StaticContents() [][]F {
 	if !p.static {
 		panic(fmt.Sprintf("module \"%s\" is not static", p.name))
 	}
@@ -290,7 +291,7 @@ func (p *Table[F, C]) AddRegisters(registers ...register.Register) {
 
 // SetStaticContents sets the contents of this static reference table.  It
 // panics if invoked on a non-static module.
-func (p *Table[F, C]) SetStaticContents(contents []F) {
+func (p *Table[F, C]) SetStaticContents(contents [][]F) {
 	if !p.static {
 		panic(fmt.Sprintf("module \"%s\" is not static", p.name))
 	}

--- a/pkg/zkc/constraints/translator.go
+++ b/pkg/zkc/constraints/translator.go
@@ -73,17 +73,21 @@ func translateModule[F field.Element[F]](ctx schema.ModuleId, fm vm.Module) mir.
 	}
 }
 
-func translateStaticMemory[F field.Element[F]](_ schema.ModuleId, fm vm.InputOutputMemory[F]) mir.Module[F] {
+func translateStaticMemory[F field.Element[F]](_ schema.ModuleId, m vm.InputOutputMemory[F]) mir.Module[F] {
 	var (
-		mod  *schema.Table[F, mir.Constraint[F]]
-		name = trace.ModuleName{Name: fm.Name(), Multiplier: 1}
+		mod      *schema.Table[F, mir.Constraint[F]]
+		name     = trace.ModuleName{Name: m.Name(), Multiplier: 1}
+		nInputs  = m.Geometry().AddressLines()
+		nOutputs = m.Geometry().DataLines()
+		inputs   = m.Registers()[:nInputs]
+		outputs  = m.Registers()[nInputs : nInputs+nOutputs]
 	)
 	// Initialise module as a static reference table.
-	mod = mod.Init(name, false, true, false, fm.IsNative(), true, 0)
+	mod = mod.Init(name, false, true, false, m.IsNative(), true, 0)
 	// Add all registers
-	mod.AddRegisters(fm.Registers()...)
+	mod.AddRegisters(m.Registers()...)
 	// Populate the table contents from the pre-loaded memory.
-	mod.SetStaticContents(fm.Contents())
+	mod.SetStaticContents(foldContents(inputs, outputs, m.Contents()))
 	//
 	return mod
 }

--- a/pkg/zkc/constraints/util.go
+++ b/pkg/zkc/constraints/util.go
@@ -58,7 +58,7 @@ func foldContents[F field.Element[F]](inputs, outputs []register.Register, conte
 		if ith == nil {
 			ith = make([]F, nInputs+nOutputs)
 			fillAddressLine(row, ith, inputs)
-			rows[i] = ith
+			rows[row] = ith
 		}
 		//
 		ith[output] = contents[i]

--- a/pkg/zkc/constraints/util.go
+++ b/pkg/zkc/constraints/util.go
@@ -30,3 +30,49 @@ func newLimbsMap(config field.Config, modules ...vm.Module) module.LimbsMap {
 	// compatibility.
 	return module.NewLimbsMap[uint](config, ms...)
 }
+
+// FoldContents folds the contents of a memory into a multi-dimensional representation.
+func foldContents[F field.Element[F]](inputs, outputs []register.Register, contents []F) [][]F {
+	var (
+		nInputs  = len(inputs)
+		nOutputs = len(outputs)
+		nRows    = len(contents) / nOutputs
+	)
+	// Compute upper bound
+	if nRows*nOutputs != len(contents) {
+		nRows++
+	}
+	//
+	rows := make([][]F, nRows)
+	//
+	for i := 0; i < len(contents); i++ {
+		var (
+			// Determine table row
+			row = uint(i / nOutputs)
+			// Determine output index
+			output = nInputs + (i % nOutputs)
+			// Extract row data
+			ith = rows[row]
+		)
+		// Construct row (if not previously constructed)
+		if ith == nil {
+			ith = make([]F, nInputs+nOutputs)
+			fillAddressLine(row, ith, inputs)
+			rows[i] = ith
+		}
+		//
+		ith[output] = contents[i]
+	}
+	//
+	return rows
+}
+
+func fillAddressLine[F field.Element[F]](index uint, row []F, inputs []register.Register) {
+	var address F
+	//
+	if len(inputs) != 1 {
+		panic("support multi-address static memories")
+	}
+	//
+	row[0] = address.SetUint64(uint64(index))
+}


### PR DESCRIPTION
This refactors the module.StaticContents() API for MIR/AIR modules, such that they now return an array of arrays ([][]F) rather than a straight-line array ([]F).  This is necessary so that each entry in the resulting array can correspond to exactly one row in the final table.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `schema.Module`/builder API shape for `StaticContents` and threads new `static`/`native` flags through multiple compiler/lowering stages, which could break callers or alter static table initialization if any path is missed.
> 
> **Overview**
> Refactors the static module contents API so `StaticContents()`/`SetStaticContents()` operate on **row-oriented** data (`[][]F`) instead of a flat `[]F`, and updates `schema.Table` and assembly module wrappers accordingly.
> 
> Propagates static/native module metadata through `ir.SchemaBuilder`/`ModuleBuilder` creation and the HIR→MIR→AIR lowering/subdivision flows, ensuring static tables carry their contents into AIR.
> 
> Updates ZkC static memory translation to **fold** linear memory contents into per-row entries (including address columns), and extends the debug schema printer to display `(contents ...)` for static modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bc5119b96e81126e8cfb308bd5e5119932527eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->