### PR TITLE
outline for register splitting

### DIFF
--- a/pkg/cmd/zkc/root.go
+++ b/pkg/cmd/zkc/root.go
@@ -108,6 +108,7 @@ func GetBuildConfig[F field.Element[F]](cmd *cobra.Command, field field.Config) 
 	build.config = codegen.DEFAULT_CONFIG.
 		LowerZkcNative(GetFlag(cmd, "lower-native")).
 		Vectorize(GetFlag(cmd, "vectorize")).
+		SplitRegisters(GetFlag(cmd, "split")).
 		Field(field)
 	// Configure build targets
 	build.ast = GetFlag(cmd, "ast")
@@ -128,5 +129,6 @@ func init() {
 	rootCmd.PersistentFlags().Bool("lower-native", false, "Lower ZkC native functions into arithmetic instructions")
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, "increase logging verbosity")
 	rootCmd.PersistentFlags().Bool("vectorize", true, "Apply instruction vectorization")
+	rootCmd.PersistentFlags().Bool("split", false, "Apply register splitting")
 	rootCmd.PersistentFlags().String("field", "KOALABEAR_16", "prime field to use throughout")
 }

--- a/pkg/zkc/compiler/codegen/compile.go
+++ b/pkg/zkc/compiler/codegen/compile.go
@@ -175,8 +175,14 @@ func (p *Compiler) Compile(declarations []Declaration) (*vm.WordMachine[vm.Uint]
 	if len(errors) == 0 && p.config.vectorize {
 		Vectorize(modules, p.srcmaps)
 	}
+	//
+	wm := vm.NewWordMachine[vm.Uint](p.config.field, modules...)
+	// Apply register splitting (for now)
+	if len(errors) == 0 && p.config.splitting {
+		wm = vm.Subdivide(p.config.field, wm)
+	}
 	// Construct machine
-	return vm.NewWordMachine[vm.Uint](p.config.field, modules...), errors
+	return wm, errors
 }
 
 // compileStaticInitialise evaluates the compile-time constant expressions from a static

--- a/pkg/zkc/compiler/codegen/config.go
+++ b/pkg/zkc/compiler/codegen/config.go
@@ -21,6 +21,7 @@ var DEFAULT_CONFIG = Config{
 	field:          field.KOALABEAR_16,
 	lowerZkcNative: false,
 	vectorize:      true,
+	splitting:      false,
 }
 
 // Config captures the tunable aspects of the ZkC code generator.  Instances
@@ -44,6 +45,8 @@ type Config struct {
 	// the codegen output, which is useful when debugging the codegen or
 	// inspecting the un-merged IR.
 	vectorize bool
+	// splitting controls whether or not register splitting is enabled.
+	splitting bool
 }
 
 // Field sets the target field configuration to use for this compiler.
@@ -51,6 +54,16 @@ func (p Config) Field(field field.Config) Config {
 	var q = p
 	//
 	q.field = field
+	//
+	return q
+}
+
+// SplitRegisters returns a copy of this Config in which register splitting is
+// either enabled (flag=true) or disabled (flag=false).
+func (p Config) SplitRegisters(flag bool) Config {
+	var q = p
+	//
+	q.splitting = flag
 	//
 	return q
 }

--- a/pkg/zkc/vm/internal/machine/subdivider.go
+++ b/pkg/zkc/vm/internal/machine/subdivider.go
@@ -1,0 +1,126 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package machine
+
+import (
+	"fmt"
+
+	"github.com/consensys/go-corset/pkg/schema/module"
+	"github.com/consensys/go-corset/pkg/schema/register"
+	"github.com/consensys/go-corset/pkg/zkc/vm/instruction"
+	"github.com/consensys/go-corset/pkg/zkc/vm/internal/function"
+	"github.com/consensys/go-corset/pkg/zkc/vm/internal/memory"
+	"github.com/consensys/go-corset/pkg/zkc/vm/internal/word"
+)
+
+// WordInstruction is a useful alias
+type WordInstruction = instruction.Word
+
+// VectorInstruction is a useful alias
+type VectorInstruction = instruction.Vector[WordInstruction]
+
+// Subdivide all modules to meet a given bandwidth and maximum register width.
+// This will split all registers wider than the maximum permitted width into two
+// or more "limbs" (i.e. subregisters which do not exceeded the permitted
+// width). For example, consider a register "r" of width u32. Subdividing this
+// register into registers of at most 8bits will result in four limbs: r'0, r'1,
+// r'2 and r'3 where (by convention) r'0 is the least significant.
+func Subdivide[W word.Word[W]](mapping module.LimbsMap, m *Word[W]) *Word[W] {
+	var (
+		mods = make([]Module, len(m.Modules()))
+	)
+	//
+	for i, ith := range m.Modules() {
+		// Determine limb mapping for this module
+		limbsMap := mapping.Module(uint(i))
+		//
+		mods[i] = subdivideModule[W](limbsMap, ith)
+	}
+	//
+	return NewWord[W](mapping.Field(), mods...)
+}
+
+func subdivideModule[W word.Word[W]](mapping register.LimbsMap, m Module) Module {
+	switch m := m.(type) {
+	case *function.Function[instruction.Word]:
+		return subdivideFunction[W](mapping, *m)
+	case memory.Memory[W]:
+		return subdivideMemory(mapping, m)
+	default:
+		panic("unknown module encountered")
+	}
+}
+
+func subdivideMemory[W word.Word[W]](mapping register.LimbsMap, m memory.Memory[W]) Module {
+	var (
+		registers = mapping.Limbs()
+	)
+	//
+	switch m := m.(type) {
+	case *memory.WriteOnce[W]:
+		return &memory.WriteOnce[W]{
+			StaticArray: memory.NewStaticArray[W](m.Name(), m.Kind(), registers),
+		}
+	case *memory.ReadOnly[W]:
+		return &memory.ReadOnly[W]{
+			StaticArray: memory.NewStaticArray[W](m.Name(), m.Kind(), registers),
+		}
+	case *memory.StaticReadOnly[W]:
+		panic("support subdivision for static ROM")
+	default:
+		panic(fmt.Sprintf("unknown memory \"%s\"", m.Name()))
+	}
+}
+
+func subdivideFunction[W word.Word[W]](mapping register.LimbsMap, m function.Function[instruction.Word]) Module {
+	var (
+		registers = mapping.Limbs()
+		code      = subdivideInstructions[W](mapping, m.Code())
+	)
+	//
+	return function.New(m.Name(), m.IsNative(), registers, code)
+}
+
+func subdivideInstructions[W word.Word[W]](mapping register.LimbsMap, code []VectorInstruction) []VectorInstruction {
+	var ncode = make([]instruction.Vector[instruction.Word], len(code))
+	//
+	for i, c := range code {
+		ncode[i] = subdivideInstruction[W](mapping, c)
+	}
+	//
+	return ncode
+}
+
+func subdivideInstruction[W word.Word[W]](_ register.LimbsMap, vec VectorInstruction) VectorInstruction {
+	var (
+		insns []instruction.Word
+	)
+	//
+	for _, c := range vec.Codes {
+		switch c := c.(type) {
+		case *instruction.Fail:
+			insns = append(insns, c)
+		case *instruction.Jump:
+			insns = append(insns, c)
+		case *instruction.Skip:
+			insns = append(insns, c)
+		case *instruction.Return:
+			insns = append(insns, c)
+		default:
+			panic("unsupported instruction")
+		}
+	}
+
+	//
+	return instruction.NewVector(insns...)
+}

--- a/pkg/zkc/vm/internal/memory/bipartite_ram.go
+++ b/pkg/zkc/vm/internal/memory/bipartite_ram.go
@@ -70,6 +70,11 @@ func NewBiPartiteRandomAccess[W util.Uinter64](name string, registers []register
 	}
 }
 
+// Kind implementation for memory interface.
+func (p *BiPartiteRandomAccess[W]) Kind() Kind {
+	return p.kind
+}
+
 // IsPublic implementation for memory interface.
 func (p *BiPartiteRandomAccess[W]) IsPublic() bool {
 	return p.kind.IsPublic()

--- a/pkg/zkc/vm/internal/memory/memory.go
+++ b/pkg/zkc/vm/internal/memory/memory.go
@@ -30,6 +30,8 @@ type Memory[W util.Uinter64] interface {
 	base.Module
 	// Geometry defines the geometry of this RAM.
 	Geometry() Geometry[W]
+	// Kind returns the underlying kind of memory
+	Kind() Kind
 	// IsPublic indicates whether this is a public input or output.
 	IsPublic() bool
 	// IsStatic indicates a static (read-only) memory.  That is a ROM which never

--- a/pkg/zkc/vm/internal/memory/static_array.go
+++ b/pkg/zkc/vm/internal/memory/static_array.go
@@ -44,6 +44,11 @@ func NewStaticArray[W util.Uinter64](name string, kind Kind, registers []registe
 	return StaticArray[W]{kind, geometry, name, init}
 }
 
+// Kind implementation for memory interface.
+func (p *StaticArray[W]) Kind() Kind {
+	return p.kind
+}
+
 // IsPublic implementation for memory interface.
 func (p *StaticArray[W]) IsPublic() bool {
 	return p.kind.IsPublic()

--- a/pkg/zkc/vm/subdivide.go
+++ b/pkg/zkc/vm/subdivide.go
@@ -1,0 +1,45 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package vm
+
+import (
+	"github.com/consensys/go-corset/pkg/schema/module"
+	"github.com/consensys/go-corset/pkg/schema/register"
+	"github.com/consensys/go-corset/pkg/trace"
+	"github.com/consensys/go-corset/pkg/util/collection/array"
+	"github.com/consensys/go-corset/pkg/util/field"
+	"github.com/consensys/go-corset/pkg/zkc/vm/internal/machine"
+)
+
+// Subdivide all modules to meet a given bandwidth and maximum register width.
+// This will split all registers wider than the maximum permitted width into two
+// or more "limbs" (i.e. subregisters which do not exceeded the permitted
+// width). For example, consider a register "r" of width u32. Subdividing this
+// register into registers of at most 8bits will result in four limbs: r'0, r'1,
+// r'2 and r'3 where (by convention) r'0 is the least significant.
+func Subdivide[W Word[W]](cfg field.Config, wm *WordMachine[W]) *WordMachine[W] {
+	// Construct a suitable limbs mapping
+	var limbsMap = newLimbsMap(cfg, wm.Modules()...)
+	// Invoke subdivision algorithm
+	return machine.Subdivide(limbsMap, wm)
+}
+
+func newLimbsMap(config field.Config, modules ...Module) module.LimbsMap {
+	var ms []register.Map = array.Map(modules, func(_ uint, m Module) register.Map {
+		name := trace.ModuleName{Name: m.Name(), Multiplier: 1}
+		return register.ArrayMap(name, m.Registers()...)
+	})
+	// NOTE: generic parameter is meaningless, and only retained for backwards
+	// compatibility.
+	return module.NewLimbsMap[uint](config, ms...)
+}


### PR DESCRIPTION
This puts in place a very rough outline for register splitting.  At this stage, only a very small number of instructions are being split.  The goal is to flesh this out successive instructions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new compilation pass that rewrites VM modules/register layouts when enabled, which can impact program semantics and downstream tooling despite being gated behind a flag and currently supporting only a subset of instructions.
> 
> **Overview**
> Introduces an **optional register-splitting/subdivision pass** in the ZkC compilation pipeline, gated by a new `--split` CLI flag and a `Config` option (`SplitRegisters`).
> 
> When enabled, codegen now builds the `WordMachine` and then runs `vm.Subdivide`, which constructs a limbs mapping and rewrites modules via a new internal `machine.Subdivide` implementation. Memory types were updated to expose `Kind()` so subdivision can re-materialize memories while preserving their kind.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a72baba42ce0c7668222f71ef6f09521c168d20d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->