### PR TITLE
feat: constraint gen for destruct and subtract

### DIFF
--- a/pkg/test/zkc_unit_test.go
+++ b/pkg/test/zkc_unit_test.go
@@ -43,8 +43,7 @@ func Test_ZkcUnit_Basic_05(t *testing.T) {
 }
 
 func Test_ZkcUnit_Basic_06(t *testing.T) {
-	// TODO: support subtraction for constraints
-	checkZkcUnit(t, "zkc/unit/basic_06", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/basic_06", util.DEFAULT_CONFIG.Constraints(true))
 }
 func Test_ZkcUnit_Basic_07(t *testing.T) {
 	checkZkcUnit(t, "zkc/unit/basic_07", util.DEFAULT_CONFIG.Constraints(true))
@@ -55,41 +54,42 @@ func Test_ZkcUnit_Basic_08(t *testing.T) {
 }
 
 func Test_ZkcUnit_Basic_09(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/basic_09", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Basic_10(t *testing.T) {
-	// TODO: support bitwise ops for constraints
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/basic_10", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Basic_11(t *testing.T) {
-	// TODO: support comparisons for constraints
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/basic_11", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Basic_12(t *testing.T) {
-	// TODO: support comparisons for constraints
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/basic_12", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Basic_13(t *testing.T) {
-	// TODO: support comparators for constraints
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/basic_13", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Basic_14(t *testing.T) {
-	// TODO: support destruct for constraints
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/basic_14", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Basic_15(t *testing.T) {
-	// TODO: support casts for constraints
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/basic_15", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Basic_16(t *testing.T) {
-	// TODO: support casts for constraints
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/basic_16", util.DEFAULT_CONFIG)
 }
 
@@ -117,8 +117,8 @@ func Test_ZkcUnit_Basic_22(t *testing.T) {
 }
 
 func Test_ZkcUnit_Basic_23(t *testing.T) {
-	// TODO: unknown problem
-	checkZkcUnit(t, "zkc/unit/basic_23", util.DEFAULT_CONFIG)
+	// TODO: bitwise destruct
+	checkZkcUnit(t, "zkc/unit/basic_23", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Basic_24(t *testing.T) {
@@ -129,17 +129,17 @@ func Test_ZkcUnit_Basic_25(t *testing.T) {
 	checkZkcUnit(t, "zkc/unit/basic_25", util.DEFAULT_CONFIG.Constraints(true))
 }
 func Test_ZkcUnit_Basic_26(t *testing.T) {
-	// TODO: support comparisons for constraints
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/basic_26", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Basic_27(t *testing.T) {
-	// TODO: support comparisons for constraints
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/basic_27", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Basic_28(t *testing.T) {
-	// TODO: support comparisons for constraints
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/basic_28", util.DEFAULT_CONFIG)
 }
 
@@ -152,7 +152,7 @@ func Test_ZkcUnit_Basic_30(t *testing.T) {
 }
 
 func Test_ZkcUnit_Basic_31(t *testing.T) {
-	// TODO: support casts for constraints
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/basic_31", util.DEFAULT_CONFIG)
 }
 
@@ -165,30 +165,35 @@ func Test_ZkcUnit_Basic_32(t *testing.T) {
 // ===================================================================
 
 func Test_ZkcUnit_IfElse_01(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/ifelse_01", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/ifelse_01", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_IfElse_02(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/ifelse_02", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/ifelse_02", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_IfElse_03(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/ifelse_03", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_IfElse_04(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/ifelse_04", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_IfElse_05(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/ifelse_05", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_IfElse_06(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/ifelse_06", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_IfElse_07(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/ifelse_07", util.DEFAULT_CONFIG)
 }
 
@@ -197,19 +202,20 @@ func Test_ZkcUnit_IfElse_07(t *testing.T) {
 // ===================================================================
 
 func Test_ZkcUnit_Const_01(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/const_01", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/const_01", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Const_02(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/const_02", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/const_02", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Const_03(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/const_03", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Const_04(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/const_04", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/const_04", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 // ===================================================================
@@ -217,39 +223,39 @@ func Test_ZkcUnit_Const_04(t *testing.T) {
 // ===================================================================
 
 func Test_ZkcUnit_FixedArray_01(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/fixed_array_01", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/fixed_array_01", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_FixedArray_02(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/fixed_array_02", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/fixed_array_02", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_FixedArray_03(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/fixed_array_03", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/fixed_array_03", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_FixedArray_04(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/fixed_array_04", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/fixed_array_04", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_FixedArray_05(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/fixed_array_05", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/fixed_array_05", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_FixedArray_06(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/fixed_array_06", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/fixed_array_06", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_FixedArray_07(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/fixed_array_07", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/fixed_array_07", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_FixedArray_08(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/fixed_array_08", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/fixed_array_08", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_FixedArray_09(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/fixed_array_09", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/fixed_array_09", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 // see #1711
@@ -272,43 +278,43 @@ func Test_ZkcUnit_FixedArray_09(t *testing.T) {
 // ===================================================================
 
 func Test_ZkcUnit_Type_01(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/type_01", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/type_01", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Type_02(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/type_02", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/type_02", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Type_03(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/type_03", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/type_03", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Type_04(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/type_04", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/type_04", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Type_05(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/type_05", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/type_05", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Type_06(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/type_06", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/type_06", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Type_07(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/type_07", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/type_07", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Type_08(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/type_08", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/type_08", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Type_09(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/type_09", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/type_09", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Type_10(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/type_10", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/type_10", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 // ===================================================================
@@ -316,11 +322,11 @@ func Test_ZkcUnit_Type_10(t *testing.T) {
 // ===================================================================
 
 func Test_ZkcUnit_Cfg_01(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/cfg_01", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/cfg_01", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Cfg_02(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/cfg_02", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/cfg_02", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 // ===================================================================
@@ -328,30 +334,35 @@ func Test_ZkcUnit_Cfg_02(t *testing.T) {
 // ===================================================================
 
 func Test_ZkcUnit_While_01(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/while_01", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/while_01", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_While_02(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/while_02", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_While_03(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/while_03", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_For_01(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/for_01", util.DEFAULT_CONFIG)
+	// TODO: bitwise destruct
+	checkZkcUnit(t, "zkc/unit/for_01", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_For_02(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/for_02", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/for_02", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_For_03(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/for_03", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_For_04(t *testing.T) {
+	// TODO: duplicate variable declaration #1801
 	checkZkcUnit(t, "zkc/unit/for_04", util.DEFAULT_CONFIG)
 }
 
@@ -360,6 +371,7 @@ func Test_ZkcUnit_For_04(t *testing.T) {
 // ===================================================================
 
 func Test_ZkcUnit_Break_01(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/break_01", util.DEFAULT_CONFIG)
 }
 
@@ -368,6 +380,7 @@ func Test_ZkcUnit_Break_01(t *testing.T) {
 // ===================================================================
 
 func Test_ZkcUnit_Continue_01(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/continue_01", util.DEFAULT_CONFIG)
 }
 
@@ -376,51 +389,56 @@ func Test_ZkcUnit_Continue_01(t *testing.T) {
 // ===================================================================
 
 func Test_ZkcUnit_Bitwise_01(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/bitwise_01", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/bitwise_01", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Bitwise_02(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/bitwise_02", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/bitwise_02", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Bitwise_03(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/bitwise_03", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/bitwise_03", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Bitwise_04(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/bitwise_04", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/bitwise_04", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Bitwise_05(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/bitwise_05", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Bitwise_06(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/bitwise_06", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Bitwise_07(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/bitwise_07", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Bitwise_08(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/bitwise_08", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Bitwise_09(t *testing.T) {
+	// TODO: duplicate module #1802
 	checkZkcUnit(t, "zkc/unit/bitwise_09", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Bitwise_10(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/bitwise_10", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/bitwise_10", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Bitwise_11(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/bitwise_11", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/bitwise_11", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Bitwise_12(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/bitwise_12", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/bitwise_12", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 // ===================================================================
@@ -428,46 +446,50 @@ func Test_ZkcUnit_Bitwise_12(t *testing.T) {
 // ===================================================================
 
 func Test_ZkcUnit_Shift_01(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/shift_01", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/shift_01", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Shift_02(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/shift_02", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/shift_02", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Shift_03(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/shift_03", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Shift_04(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/shift_04", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Shift_05(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/shift_05", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/shift_05", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Shift_06(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/shift_06", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/shift_06", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Shift_07(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/shift_07", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/shift_07", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Shift_08(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/shift_08", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Shift_09(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/shift_09", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/shift_09", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Shift_10(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/shift_10", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/shift_10", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Shift_11(t *testing.T) {
+	// TODO: unexpected instruction #1803
 	checkZkcUnit(t, "zkc/unit/shift_11", util.DEFAULT_CONFIG)
 }
 
@@ -492,23 +514,23 @@ func Test_ZkcUnit_SwitchEndian(t *testing.T) {
 // ===================================================================
 
 func Test_ZkcUnit_Cast_01(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/cast_01", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/cast_01", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Cast_02(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/cast_02", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/cast_02", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Cast_03(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/cast_03", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/cast_03", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Cast_04(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/cast_04", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/cast_04", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Cast_05(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/cast_05", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/cast_05", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 // ===================================================================
@@ -560,23 +582,23 @@ func Test_ZkcUnit_Call_02(t *testing.T) {
 // ===================================================================
 
 func Test_ZkcUnit_Ternary_01(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/ternary_01", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/ternary_01", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Ternary_02(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/ternary_02", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/ternary_02", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Ternary_03(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/ternary_03", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/ternary_03", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Ternary_04(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/ternary_04", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/ternary_04", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Ternary_05(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/ternary_05", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/ternary_05", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 // ===================================================================
@@ -584,38 +606,40 @@ func Test_ZkcUnit_Ternary_05(t *testing.T) {
 // ===================================================================
 
 func Test_ZkcUnit_Switch_01(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/switch_01", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/switch_01", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Switch_02(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/switch_02", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/switch_02", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Switch_03(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/switch_03", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/switch_03", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Switch_04(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/switch_04", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/switch_04", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Switch_05(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/switch_05", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/switch_05", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Switch_06(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/switch_06", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/switch_06", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Switch_07(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/switch_07", util.DEFAULT_CONFIG)
 }
 
 func Test_ZkcUnit_Switch_08(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/switch_08", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/switch_08", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_Switch_09(t *testing.T) {
+	// TODO: register splitting
 	checkZkcUnit(t, "zkc/unit/switch_09", util.DEFAULT_CONFIG)
 }
 
@@ -656,23 +680,23 @@ func Test_ZkcUnit_Include_02(t *testing.T) {
 // ===================================================================
 
 func Test_ZkcUnit_SkipIf_01(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/skip_if_01", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/skip_if_01", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_SkipIf_02(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/skip_if_02", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/skip_if_02", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_SkipIf_03(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/skip_if_03", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/skip_if_03", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_SkipIf_04(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/skip_if_04", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/skip_if_04", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 func Test_ZkcUnit_SkipIf_05(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/skip_if_05", util.DEFAULT_CONFIG)
+	checkZkcUnit(t, "zkc/unit/skip_if_05", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 // ===================================================================

--- a/pkg/zkc/constraints/insn_translator.go
+++ b/pkg/zkc/constraints/insn_translator.go
@@ -17,7 +17,6 @@ import (
 
 	mirc "github.com/consensys/go-corset/pkg/asm/compiler"
 	"github.com/consensys/go-corset/pkg/asm/io/micro/dfa"
-	"github.com/consensys/go-corset/pkg/schema/agnostic"
 	"github.com/consensys/go-corset/pkg/schema/register"
 	"github.com/consensys/go-corset/pkg/util/field"
 	"github.com/consensys/go-corset/pkg/zkc/vm/instruction"
@@ -66,19 +65,11 @@ func (p *InstructionTranslator[F]) WriteAndShiftRegisters(targets ...register.Id
 
 func (p *InstructionTranslator[F]) translateAssignment(insn instruction.FieldAssign[F]) Expr[F] {
 	var (
-		// Determine sign of polynomial
-		_, signed = agnostic.WidthOfPolynomial(insn.Source, func(r register.Id) uint {
-			return p.reader.Register(r).Width()
-		})
 		// build rhs
 		rhs = p.translatePolynomial(insn.Source)
 		// build lhs (must be after rhs)
-		lhs = p.WriteAndShiftRegisters(insn.Target)
+		lhs = p.WriteAndShiftRegisters(insn.Target.Registers()...)
 	)
-	// Construct equation
-	if signed {
-		panic("signed assignments not implemented")
-	}
 	//
 	return mirc.Sum(lhs).Equals(mirc.Sum(rhs))
 }

--- a/pkg/zkc/vm/instruction/field.go
+++ b/pkg/zkc/vm/instruction/field.go
@@ -35,6 +35,6 @@ type Field interface {
 type FieldAssign[F field.Element[F]] = finsn.Assign[F]
 
 // NewFieldAssign constructs a new field assignment instruction.
-func NewFieldAssign[F field.Element[F]](target register.Id, source finsn.Polynomial) *FieldAssign[F] {
-	return &FieldAssign[F]{Target: target, Source: source}
+func NewFieldAssign[F field.Element[F]](targets register.Vector, source finsn.Polynomial) *FieldAssign[F] {
+	return &FieldAssign[F]{Target: targets, Source: source}
 }

--- a/pkg/zkc/vm/instruction/field/assign.go
+++ b/pkg/zkc/vm/instruction/field/assign.go
@@ -33,7 +33,7 @@ type Monomial = poly.Monomial[register.Id]
 // registers.
 type Assign[F field.Element[F]] struct {
 	// Target register for assignment
-	Target register.Id
+	Target register.Vector
 	// Source registers for assignment
 	Source Polynomial
 }
@@ -59,12 +59,12 @@ func (p *Assign[F]) Uses() []register.Id {
 
 // Definitions implementation for Instruction interface.
 func (p *Assign[F]) Definitions() []register.Id {
-	return []register.Id{p.Target}
+	return p.Target.Registers()
 }
 
 func (p *Assign[F]) String(mapping base.SystemMap) string {
 	var (
-		lhs = base.RegistersToString(mapping, p.Target)
+		lhs = base.RegistersToString(mapping, p.Target.Registers()...)
 		rhs = poly.String(p.Source, func(r register.Id) string {
 			return mapping.Register(r).Name()
 		})

--- a/pkg/zkc/vm/lower.go
+++ b/pkg/zkc/vm/lower.go
@@ -176,6 +176,9 @@ func (p wordToField[W, F]) lowerWordInstruction(wi WordInstruction, mapping Syst
 	case opcode.BIT_CONCAT:
 		var insn = wi.(*instruction.BitConcat[W])
 		return p.lowerBitwiseConcatenation(insn.Target, insn.Sources, mapping)
+	case opcode.BIT_DESTRUCT:
+		var insn = wi.(*instruction.Destruct)
+		return p.lowerBitwiseDestruct(insn.Targets, insn.Source, mapping)
 	case opcode.HINT_DIVISION:
 		return wi.(*instruction.FieldHint)
 	case opcode.INT_CAST:
@@ -230,7 +233,7 @@ func (p wordToField[W, F]) lowerArithInstruction(lhs register.Id, rhs []register
 		terms = append(terms, poly.NewMonomial[register.Id](*n))
 	}
 	// Done
-	return instruction.NewFieldAssign[F](lhs, f(terms...))
+	return instruction.NewFieldAssign[F](register.NewVector(lhs), f(terms...))
 }
 
 func (p wordToField[W, F]) lowerFieldInstruction(lhs register.Id, rhs []register.Id, c W,
@@ -257,7 +260,7 @@ func (p wordToField[W, F]) lowerFieldInstruction(lhs register.Id, rhs []register
 		terms = append(terms, poly.NewMonomial[register.Id](*n))
 	}
 	// Done
-	return instruction.NewFieldAssign[F](lhs, f(terms...))
+	return instruction.NewFieldAssign[F](register.NewVector(lhs), f(terms...))
 }
 
 func (p wordToField[W, F]) lowerBitwiseConcatenation(lhs register.Id, rhs []register.Id, mapping instruction.SystemMap,
@@ -281,7 +284,19 @@ func (p wordToField[W, F]) lowerBitwiseConcatenation(lhs register.Id, rhs []regi
 		acc = acc.Lsh(acc, width)
 	}
 	//
-	return instruction.NewFieldAssign[F](lhs, sum(terms...))
+	return instruction.NewFieldAssign[F](register.NewVector(lhs), sum(terms...))
+}
+
+func (p wordToField[W, F]) lowerBitwiseDestruct(lhs []register.Id, rhs register.Id, mapping instruction.SystemMap,
+) (fi FieldInstruction) {
+	var (
+		one = big.NewInt(1)
+		r   Polynomial
+	)
+	//
+	r = r.Set(poly.NewMonomial(*one, rhs))
+	//
+	return instruction.NewFieldAssign[F](register.NewVector(lhs...), r)
 }
 
 func (p wordToField[W, F]) lowerCastInstruction(lhs register.Id, rhs register.Id) (fi FieldInstruction) {
@@ -290,7 +305,7 @@ func (p wordToField[W, F]) lowerCastInstruction(lhs register.Id, rhs register.Id
 		e   Polynomial
 	)
 	//
-	return instruction.NewFieldAssign[F](lhs, e.Set(poly.NewMonomial(*one, rhs)))
+	return instruction.NewFieldAssign[F](register.NewVector(lhs), e.Set(poly.NewMonomial(*one, rhs)))
 }
 
 func checkRegisterWidths(registerWidth uint, regs ...register.Register) {
@@ -311,7 +326,17 @@ func sum(terms ...Monomial) Polynomial {
 }
 
 func subtract(terms ...Monomial) Polynomial {
-	panic("todo")
+	var p Polynomial
+	//
+	for i, m := range terms {
+		if i == 0 {
+			p = p.Set(m)
+		} else {
+			p.SubTerm(m)
+		}
+	}
+	//
+	return p
 }
 
 func product(terms ...Monomial) Polynomial {


### PR DESCRIPTION
This puts in place constraint generation for bitwise destruct and the field subtraction operation.  This also enables constraint checking for a large number of tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core VM lowering and constraint translation to support new instruction shapes and subtraction, which can affect correctness of generated constraints across many programs. Broadly enabling constraint checks in many unit tests increases coverage but may surface regressions in constraint generation/runtime assumptions.
> 
> **Overview**
> Adds constraint-generation support for **bitwise destruct** and **subtraction** by lowering `BIT_DESTRUCT` into a field assignment over a *vector* of target registers and implementing polynomial `subtract()` in `vm/lower.go`.
> 
> Refactors field assignments to target `register.Vector` (instead of a single `register.Id`) and updates the constraint `InstructionTranslator` to write/shift multiple target registers accordingly, removing the previous (unimplemented) signed-assignment check.
> 
> Enables constraint validation (`DEFAULT_CONFIG.Constraints(true)`) for a large set of `zkc_unit_test.go` cases, while marking remaining unsupported scenarios (e.g., register splitting) with TODOs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d11392f5487967a8041b6dafed1fda5702bd795d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->