### PR TITLE
fix(typo): fix typo in error message when passing another flag than wir

### DIFF
--- a/pkg/cmd/zkc/compile.go
+++ b/pkg/cmd/zkc/compile.go
@@ -83,7 +83,7 @@ func writeArtifacts[F field.Element[F]](filename string, build BuildConfig[F], a
 		// Write to disk
 		WriteBinaryFile(binfile, filename)
 	} else {
-		log.Error("must use --wir/fir/air to write binary file")
+		log.Error("must use --wir to write binary file")
 		os.Exit(5)
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only updates a user-facing log message when attempting to write a binary without the required `--wir` artifact, with no functional behavior changes.
> 
> **Overview**
> When `zkc compile --output ...` is used without producing WIR, the error message is corrected to state that `--wir` is required (instead of implying `--fir/--air` would work).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9426a30fd010e74ba3d3ffee875dc664781cda73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->