### PR TITLE
fix: lazy ternary (djp)

### DIFF
--- a/pkg/cmd/zkc/compile.go
+++ b/pkg/cmd/zkc/compile.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/consensys/go-corset/pkg/cmd/corset/debug"
 	"github.com/consensys/go-corset/pkg/schema/register"
-	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/field"
 	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
 	"github.com/consensys/go-corset/pkg/util/field/gf251"
@@ -305,8 +304,7 @@ func writeIntermediateRepresentation[W vm.BaseWord[W], I vm.Instruction, T vm.Ex
 		case vm.Memory[W]:
 			writeIrMemory(m)
 		case *vm.Function[I]:
-			name := trace.ModuleName{Name: m.Name(), Multiplier: 1}
-			mapping := instruction.NewSystemMap(register.ArrayMap(name, m.Registers()...), machine.Modules())
+			mapping := instruction.NewSystemMap(m.RegisterMap(), machine.Modules())
 			writeIrFunction[W](m, mapping)
 		}
 	}

--- a/pkg/cmd/zkc/debug/observer.go
+++ b/pkg/cmd/zkc/debug/observer.go
@@ -92,8 +92,7 @@ func (p *TraceObserver[W]) writeState(machine *vm.WordMachine[W]) {
 	var (
 		n      = machine.Depth()
 		frame  = machine.StackFrame(n - 1)
-		name   = trace.ModuleName{Name: p.fun.Name(), Multiplier: 1}
-		base   = instruction.NewSystemMap(register.ArrayMap(name, p.fun.Registers()...), machine.Modules())
+		base   = instruction.NewSystemMap(p.fun.RegisterMap(), machine.Modules())
 		values = make(map[uint]string)
 	)
 	// Collect register values. In PostExecution, sources still hold their pre-execution values

--- a/pkg/schema/register/vector.go
+++ b/pkg/schema/register/vector.go
@@ -13,6 +13,7 @@
 package register
 
 import (
+	"fmt"
 	"slices"
 	"strings"
 )
@@ -78,7 +79,11 @@ func (p Vector) String(fn Map) string {
 			builder.WriteString("::")
 		}
 		//
-		builder.WriteString(fn.Register(ith).Name())
+		if fn == nil {
+			fmt.Fprintf(&builder, "?%d", ith.Unwrap())
+		} else {
+			builder.WriteString(fn.Register(ith).Name())
+		}
 	}
 	//
 	return builder.String()

--- a/pkg/test/zkc_unit_test.go
+++ b/pkg/test/zkc_unit_test.go
@@ -205,6 +205,10 @@ func Test_ZkcUnit_IfElse_07(t *testing.T) {
 	checkZkcUnit(t, "zkc/unit/ifelse_07", util.DEFAULT_CONFIG)
 }
 
+func Test_ZkcUnit_IfElse_08(t *testing.T) {
+	checkZkcUnit(t, "zkc/unit/ifelse_08", util.DEFAULT_CONFIG.Constraints(true))
+}
+
 // ===================================================================
 // Constant Tests
 // ===================================================================
@@ -611,6 +615,10 @@ func Test_ZkcUnit_Ternary_04(t *testing.T) {
 
 func Test_ZkcUnit_Ternary_05(t *testing.T) {
 	checkZkcUnit(t, "zkc/unit/ternary_05", util.DEFAULT_CONFIG.Constraints(true))
+}
+
+func Test_ZkcUnit_Ternary_06(t *testing.T) {
+	checkZkcUnit(t, "zkc/unit/ternary_06", util.DEFAULT_CONFIG.Constraints(true))
 }
 
 // ===================================================================

--- a/pkg/zkc/compiler/codegen/lowerzkcnative/binarize_bitwise.go
+++ b/pkg/zkc/compiler/codegen/lowerzkcnative/binarize_bitwise.go
@@ -22,6 +22,9 @@ import (
 	"github.com/consensys/go-corset/pkg/zkc/vm/instruction/opcode"
 )
 
+// RegisterAllocator provides a simple means of allocating new registers
+type RegisterAllocator = register.Allocator[int]
+
 // BinarizeBitwise splits any AND/OR/XOR instruction with more than two source
 // registers into a left-fold chain of binary instructions.  This must run
 // before LowerBitwise so that the helper modules it generates never need more
@@ -40,31 +43,21 @@ func BinarizeBitwise[W vm.Word[W]](modules []vm.Module) []vm.Module {
 
 func binarizeBitwiseFunction[W vm.Word[W]](fn *vm.WordFunction) *vm.WordFunction {
 	var (
-		code      = fn.Code()
-		ncode     = make([]vectorInstruction, len(code))
-		registers = append([]register.Register{}, fn.Registers()...)
+		code  = fn.Code()
+		ncode = make([]vectorInstruction, len(code))
+		alloc = register.NewAllocator[int](fn.RegisterMap())
 	)
 
 	for i, insn := range code {
-		ncodes := binarizeBitwiseCodes[W](insn.Codes, &registers)
-		ncode[i] = vectorInstruction{Codes: ncodes}
+		ncode[i] = insn.Map(func(_ uint, ith vm.WordInstruction) []vm.WordInstruction {
+			return binarizeBitwiseCode[W](ith, alloc)
+		})
 	}
 
-	return vm.NewFunction(fn.Name(), fn.IsNative(), registers, ncode)
+	return vm.NewFunction(fn.Name(), fn.IsNative(), alloc.Registers(), ncode)
 }
 
-func binarizeBitwiseCodes[W vm.Word[W]](codes []vm.WordInstruction, registers *[]register.Register,
-) []vm.WordInstruction {
-	ncodes := make([]vm.WordInstruction, 0, len(codes))
-
-	for _, code := range codes {
-		ncodes = append(ncodes, binarizeBitwiseCode[W](code, registers)...)
-	}
-
-	return ncodes
-}
-
-func binarizeBitwiseCode[W vm.Word[W]](code vm.WordInstruction, registers *[]register.Register,
+func binarizeBitwiseCode[W vm.Word[W]](code vm.WordInstruction, registers RegisterAllocator,
 ) []vm.WordInstruction {
 	var (
 		op       instruction.OpCode
@@ -84,14 +77,14 @@ func binarizeBitwiseCode[W vm.Word[W]](code vm.WordInstruction, registers *[]reg
 		return []vm.WordInstruction{code}
 	}
 
-	width := (*registers)[target.Unwrap()].Width()
+	width := registers.Register(target).Width()
 	identity := bitwiseIdentity[W](op, width)
 
 	insns := make([]vm.WordInstruction, 0, len(sources))
 
 	// If the constant is not the identity, materialise it as a register and add it to sources.
 	if constant.Cmp(identity) != 0 {
-		cstReg := allocTmp(registers, width)
+		cstReg := registers.Allocate("", width)
 		insns = append(insns, instruction.NewIntAdd(cstReg, nil, constant))
 		sources = append(sources, cstReg)
 	}
@@ -109,7 +102,7 @@ func binarizeBitwiseCode[W vm.Word[W]](code vm.WordInstruction, registers *[]reg
 	default:
 		acc := sources[0]
 		for _, src := range sources[1 : len(sources)-1] {
-			tmp := allocTmp(registers, width)
+			tmp := registers.Allocate("", width)
 			insns = append(insns, newBinaryBitOp(op, tmp, acc, src, identity))
 			acc = tmp
 		}

--- a/pkg/zkc/compiler/codegen/lowerzkcnative/lower_bitwise.go
+++ b/pkg/zkc/compiler/codegen/lowerzkcnative/lower_bitwise.go
@@ -47,43 +47,30 @@ func LowerBitwise[W vm.Word[W]](modules []vm.Module) []vm.Module {
 func lowerBitwiseFunction[W vm.Word[W]](fn *vm.WordFunction, helpers *bitwiseHelpers[W],
 ) *vm.WordFunction {
 	var (
-		code      = fn.Code()
-		ncode     = make([]vectorInstruction, len(code))
-		registers = append([]register.Register{}, fn.Registers()...)
+		code  = fn.Code()
+		ncode = make([]vectorInstruction, len(code))
+		alloc = register.NewAllocator[int](fn.RegisterMap())
 	)
 
 	for i, insn := range code {
-		ncodes := lowerBitwiseCodes(insn.Codes, &registers, helpers)
-		ncode[i] = vectorInstruction{Codes: ncodes}
+		ncode[i] = insn.Map(func(_ uint, ith vm.WordInstruction) []vm.WordInstruction {
+			return lowerBitwiseCode(ith, alloc, helpers)
+		})
 	}
 
-	return vm.NewFunction(fn.Name(), fn.IsNative(), registers, ncode)
-}
-
-func lowerBitwiseCodes[W vm.Word[W]](
-	codes []vm.WordInstruction,
-	registers *[]register.Register,
-	helpers *bitwiseHelpers[W],
-) []vm.WordInstruction {
-	ncodes := make([]vm.WordInstruction, 0, len(codes))
-
-	for _, code := range codes {
-		ncodes = append(ncodes, lowerBitwiseCode(code, registers, helpers)...)
-	}
-
-	return ncodes
+	return vm.NewFunction(fn.Name(), fn.IsNative(), alloc.Registers(), ncode)
 }
 
 func lowerBitwiseCode[W vm.Word[W]](
 	code vm.WordInstruction,
-	registers *[]register.Register,
+	registers RegisterAllocator,
 	helpers *bitwiseHelpers[W],
 ) []vm.WordInstruction {
 	if !isBitwiseOpcode(code.OpCode()) {
 		return []vm.WordInstruction{code}
 	}
 
-	origWidth, isPowerOfTwo := lowerableWidth(*registers, code.Definitions()[0])
+	origWidth, isPowerOfTwo := lowerableWidth(registers, code.Definitions()[0])
 
 	p := origWidth
 	if !isPowerOfTwo {
@@ -132,7 +119,7 @@ func bitwiseCall(
 	target register.Id,
 	sources []register.Id,
 	origWidth, p uint,
-	registers *[]register.Register,
+	registers RegisterAllocator,
 ) []vm.WordInstruction {
 	if origWidth == p {
 		return []vm.WordInstruction{
@@ -144,12 +131,12 @@ func bitwiseCall(
 
 	pSources := make([]register.Id, len(sources))
 	for i, src := range sources {
-		pTmp := allocTmp(registers, p)
+		pTmp := registers.Allocate("", p)
 		insns = append(insns, instruction.NewCast(pTmp, src, p))
 		pSources[i] = pTmp
 	}
 
-	pResult := allocTmp(registers, p)
+	pResult := registers.Allocate("", p)
 	insns = append(insns, instruction.NewCall(id, pSources, []register.Id{pResult}))
 	insns = append(insns, instruction.NewCast(target, pResult, origWidth))
 
@@ -161,7 +148,7 @@ func bitwiseCall(
 func bitwiseInlineNot[W vm.Word[W]](
 	target, source register.Id,
 	width uint,
-	registers *[]register.Register,
+	registers RegisterAllocator,
 ) []vm.WordInstruction {
 	maskBig := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), width), big.NewInt(1))
 
@@ -170,22 +157,12 @@ func bitwiseInlineNot[W vm.Word[W]](
 	mask := zeroW.SetBigInt(maskBig)
 	zero := vm.Uint64[W](0)
 
-	maskReg := allocTmp(registers, width)
+	maskReg := registers.Allocate("", width)
 
 	return []vm.WordInstruction{
 		instruction.NewIntAdd(maskReg, nil, mask),
 		instruction.NewIntSub(target, []register.Id{maskReg, source}, zero),
 	}
-}
-
-func allocTmp(registers *[]register.Register, width uint) register.Id {
-	var padding big.Int
-
-	id := register.NewId(uint(len(*registers)))
-	name := fmt.Sprintf("$%d", len(*registers))
-	*registers = append(*registers, register.NewComputed(name, width, padding))
-
-	return id
 }
 
 func nextPowerOfTwo(w uint) uint {
@@ -197,8 +174,8 @@ func nextPowerOfTwo(w uint) uint {
 	return p
 }
 
-func lowerableWidth(registers []register.Register, target register.Id) (uint, bool) {
-	reg := registers[target.Unwrap()]
+func lowerableWidth(registers register.Map, target register.Id) (uint, bool) {
+	reg := registers.Register(target)
 
 	if reg.IsNative() {
 		panic("unexpected native register in bitwise lowering")

--- a/pkg/zkc/compiler/codegen/lowerzkcnative/lower_comparison.go
+++ b/pkg/zkc/compiler/codegen/lowerzkcnative/lower_comparison.go
@@ -37,35 +37,23 @@ func LowerComparisons[W vm.Word[W]](modules []vm.Module) []vm.Module {
 
 func lowerComparisonFunction[W vm.Word[W]](fn *vm.WordFunction) *vm.WordFunction {
 	var (
-		code      = fn.Code()
-		ncode     = make([]vectorInstruction, len(code))
-		registers = append([]register.Register{}, fn.Registers()...)
+		code  = fn.Code()
+		ncode = make([]vectorInstruction, len(code))
+		alloc = register.NewAllocator[int](fn.RegisterMap())
 	)
 
 	for i, insn := range code {
-		ncodes := lowerComparisonCodes[W](insn.Codes, &registers)
-		ncode[i] = vectorInstruction{Codes: ncodes}
+		ncode[i] = insn.Map(func(_ uint, ith vm.WordInstruction) []vm.WordInstruction {
+			return lowerComparisonCode[W](ith, alloc)
+		})
 	}
 
-	return vm.NewFunction(fn.Name(), fn.IsNative(), registers, ncode)
-}
-
-func lowerComparisonCodes[W vm.Word[W]](
-	codes []vm.WordInstruction,
-	registers *[]register.Register,
-) []vm.WordInstruction {
-	ncodes := make([]vm.WordInstruction, 0, len(codes))
-
-	for _, code := range codes {
-		ncodes = append(ncodes, lowerComparisonCode[W](code, registers)...)
-	}
-
-	return ncodes
+	return vm.NewFunction(fn.Name(), fn.IsNative(), alloc.Registers(), ncode)
 }
 
 func lowerComparisonCode[W vm.Word[W]](
 	code vm.WordInstruction,
-	registers *[]register.Register,
+	registers RegisterAllocator,
 ) []vm.WordInstruction {
 	si, ok := code.(*instruction.SkipIf)
 	if !ok || !isRelationalCondition(si.Cond) {
@@ -100,25 +88,24 @@ func isRelationalCondition(cond opcode.Condition) bool {
 //	SkipIf(EQ/NEQ, sign, zero, skip)
 func lowerRelationalSkipIf[W vm.Word[W]](
 	si *instruction.SkipIf,
-	registers *[]register.Register,
+	registers RegisterAllocator,
 ) []vm.WordInstruction {
 	lhs, rhs, skipOnZero := normalizeRelational(si)
-
-	lhsWidth := (*registers)[lhs.Unwrap()].Width()
-	rhsWidth := (*registers)[rhs.Unwrap()].Width()
+	lhsWidth := registers.Register(lhs).Width()
+	rhsWidth := registers.Register(rhs).Width()
 
 	castBandWidth := max(lhsWidth, rhsWidth) + 1
 
 	zero := vm.Uint64[W](0)
 	one := vm.Uint64[W](1)
 
-	bWide := allocTmp(registers, castBandWidth)
-	oneReg := allocTmp(registers, 1)
-	biased := allocTmp(registers, castBandWidth)
-	diff := allocTmp(registers, castBandWidth)
-	lo := allocTmp(registers, castBandWidth-1)
-	sign := allocTmp(registers, 1)
-	zeroReg := allocTmp(registers, 1)
+	bWide := registers.Allocate("", castBandWidth)
+	oneReg := registers.Allocate("", 1)
+	biased := registers.Allocate("", castBandWidth)
+	diff := registers.Allocate("", castBandWidth)
+	lo := registers.Allocate("", castBandWidth-1)
+	sign := registers.Allocate("", 1)
+	zeroReg := registers.Allocate("", 1)
 
 	// rhs is always cast to castBandWidth
 	castRhs := []vm.WordInstruction{
@@ -133,7 +120,7 @@ func lowerRelationalSkipIf[W vm.Word[W]](
 			instruction.NewBitConcat[W](biased, []register.Id{lhs, oneReg}),
 		}
 	} else {
-		aBase := allocTmp(registers, castBandWidth-1)
+		aBase := registers.Allocate("", castBandWidth-1)
 		castLhs = []vm.WordInstruction{
 			instruction.NewCast(aBase, lhs, castBandWidth-1),
 			instruction.NewBitConcat[W](biased, []register.Id{aBase, oneReg}),

--- a/pkg/zkc/compiler/codegen/lowerzkcnative/lower_division.go
+++ b/pkg/zkc/compiler/codegen/lowerzkcnative/lower_division.go
@@ -47,35 +47,23 @@ func LowerDivisions[W vm.Word[W]](modules []vm.Module) []vm.Module {
 
 func lowerDivisionFunction[W vm.Word[W]](fn *vm.WordFunction) *vm.WordFunction {
 	var (
-		code      = fn.Code()
-		ncode     = make([]vectorInstruction, len(code))
-		registers = append([]register.Register{}, fn.Registers()...)
+		code  = fn.Code()
+		ncode = make([]vectorInstruction, len(code))
+		alloc = register.NewAllocator[int](fn.RegisterMap())
 	)
 
 	for i, insn := range code {
-		ncodes := lowerDivisionCodes[W](insn.Codes, &registers)
-		ncode[i] = vectorInstruction{Codes: ncodes}
+		ncode[i] = insn.Map(func(_ uint, ith vm.WordInstruction) []vm.WordInstruction {
+			return lowerDivisionCode[W](ith, alloc)
+		})
 	}
 
-	return vm.NewFunction(fn.Name(), fn.IsNative(), registers, ncode)
-}
-
-func lowerDivisionCodes[W vm.Word[W]](
-	codes []vm.WordInstruction,
-	registers *[]register.Register,
-) []vm.WordInstruction {
-	ncodes := make([]vm.WordInstruction, 0, len(codes))
-
-	for _, code := range codes {
-		ncodes = append(ncodes, lowerDivisionCode[W](code, registers)...)
-	}
-
-	return ncodes
+	return vm.NewFunction(fn.Name(), fn.IsNative(), alloc.Registers(), ncode)
 }
 
 func lowerDivisionCode[W vm.Word[W]](
 	code vm.WordInstruction,
-	registers *[]register.Register,
+	registers RegisterAllocator,
 ) []vm.WordInstruction {
 	switch code.OpCode() {
 	case opcode.INT_DIV:
@@ -92,16 +80,16 @@ func lowerDivisionCode[W vm.Word[W]](
 // expandDivision replaces INT_DIV(q, x, y) with the hint+validation sequence.
 // sum holds q*y and must be 2*nX bits so the product is exact: a cheating prover
 // could otherwise pick q' = q + 2^nX, satisfying q'*y + r ≡ x (mod 2^nX).
-func expandDivision[W vm.Word[W]](q, x, y register.Id, registers *[]register.Register) []vm.WordInstruction {
+func expandDivision[W vm.Word[W]](q, x, y register.Id, registers RegisterAllocator) []vm.WordInstruction {
 	var (
-		nX      = (*registers)[x.Unwrap()].Width()
+		nX      = registers.Register(x).Width()
 		zero    = vm.Uint64[W](0)
 		one     = vm.Uint64[W](1)
-		wideQ   = allocTmp(registers, 2*nX)
-		rTmp    = allocTmp(registers, 2*nX)
-		wideX   = allocTmp(registers, 2*nX)
-		wideY   = allocTmp(registers, 2*nX)
-		product = allocTmp(registers, 2*nX)
+		wideQ   = registers.Allocate("", 2*nX)
+		rTmp    = registers.Allocate("", 2*nX)
+		wideX   = registers.Allocate("", 2*nX)
+		wideY   = registers.Allocate("", 2*nX)
+		product = registers.Allocate("", 2*nX)
 	)
 
 	return []vm.WordInstruction{
@@ -119,16 +107,16 @@ func expandDivision[W vm.Word[W]](q, x, y register.Id, registers *[]register.Reg
 // expandRemainder replaces INT_REM(r, x, y) with the hint+validation sequence.
 // sum holds qTmp*y and must be 2*nX bits so the product is exact: a cheating prover
 // could otherwise pick q' = q + 2^nX, satisfying q'*y + r ≡ x (mod 2^nX).
-func expandRemainder[W vm.Word[W]](r, x, y register.Id, registers *[]register.Register) []vm.WordInstruction {
+func expandRemainder[W vm.Word[W]](r, x, y register.Id, registers RegisterAllocator) []vm.WordInstruction {
 	var (
-		nX      = (*registers)[x.Unwrap()].Width()
+		nX      = registers.Register(x).Width()
 		zero    = vm.Uint64[W](0)
 		one     = vm.Uint64[W](1)
-		qTmp    = allocTmp(registers, 2*nX)
-		wideR   = allocTmp(registers, 2*nX)
-		wideX   = allocTmp(registers, 2*nX)
-		wideY   = allocTmp(registers, 2*nX)
-		product = allocTmp(registers, 2*nX)
+		qTmp    = registers.Allocate("", 2*nX)
+		wideR   = registers.Allocate("", 2*nX)
+		wideX   = registers.Allocate("", 2*nX)
+		wideY   = registers.Allocate("", 2*nX)
+		product = registers.Allocate("", 2*nX)
 	)
 
 	return []vm.WordInstruction{

--- a/pkg/zkc/compiler/codegen/lowerzkcnative/lower_shift.go
+++ b/pkg/zkc/compiler/codegen/lowerzkcnative/lower_shift.go
@@ -41,7 +41,7 @@ func scanShiftAmountWidths[W vm.Word[W]](modules []vm.Module) map[shiftKey]uint 
 			continue
 		}
 
-		regs := fn.Registers()
+		regs := fn.RegisterMap()
 
 		for _, vec := range fn.Code() {
 			for _, insn := range vec.Codes {
@@ -61,7 +61,7 @@ func scanShiftAmountWidths[W vm.Word[W]](modules []vm.Module) map[shiftKey]uint 
 
 				origWidth, _ := lowerableWidth(regs, targetID)
 				key := shiftKey{opcode: op, width: origWidth}
-				amountWidth := regs[amountID.Unwrap()].Width()
+				amountWidth := regs.Register(amountID).Width()
 
 				if existing, seen := result[key]; !seen || amountWidth > existing {
 					result[key] = amountWidth
@@ -82,15 +82,15 @@ func bitwiseShiftCall(
 	id uint,
 	target, value, amount register.Id,
 	amtWidth uint,
-	registers *[]register.Register,
+	registers RegisterAllocator,
 ) []vm.WordInstruction {
-	if (*registers)[amount.Unwrap()].Width() == amtWidth {
+	if registers.Register(amount).Width() == amtWidth {
 		return []vm.WordInstruction{
 			instruction.NewCall(id, []register.Id{value, amount}, []register.Id{target}),
 		}
 	}
 
-	wAmount := allocTmp(registers, amtWidth)
+	wAmount := registers.Allocate("", amtWidth)
 
 	return []vm.WordInstruction{
 		instruction.NewCast(wAmount, amount, amtWidth),

--- a/pkg/zkc/compiler/codegen/statement.go
+++ b/pkg/zkc/compiler/codegen/statement.go
@@ -341,22 +341,27 @@ func (p *StmtCompiler) isFieldOperation(target register.Id) bool {
 func (p *StmtCompiler) compileTernary(e *expr.Ternary[symbol.Resolved], mapping []uint, target register.Id,
 ) []Instruction {
 	cmp := e.Cond.(*expr.Cmp[symbol.Resolved])
-	// Eagerly evaluate both branches into temporaries.
+	// Lazily compile both arms — their instructions are placed inside the
+	// conditionally-skipped regions below, so only the taken arm runs.
 	trueRegs, trueInsns := p.compileArgs(mapping, e.IfTrue)
 	falseRegs, falseInsns := p.compileArgs(mapping, e.IfFalse)
-	// Evaluate condition operands.
+	// Evaluate condition operands (always runs).
 	condRegs, condInsns := p.compileArgs(mapping, cmp.Left, cmp.Right)
 	// Selection sequence:
-	//   skip_if(cond, lhs, rhs, 2)      if TRUE skip false-copy + skip(1)
-	//   add(target, [falseReg], 0)       false branch (skipped when TRUE)
-	//   skip(1)                          skip over true branch
-	//   add(target, [trueReg], 0)        true branch  (returned as final insn)
-	insns := append(trueInsns, falseInsns...)
-	insns = append(insns, condInsns...)
+	//   condInsns                                  always
+	//   skip_if(cond, lhs, rhs, |falseInsns|+2)    if TRUE skip false arm
+	//   falseInsns                                 (skipped on TRUE)
+	//   add(target, [falseReg], 0)
+	//   skip(|trueInsns|+1)                        jump past true arm
+	//   trueInsns                                  (skipped on FALSE)
+	//   add(target, [trueReg], 0)
+	insns := append([]Instruction{}, condInsns...)
 	insns = append(insns, instruction.NewSkipIf(
-		opcode.Condition(cmp.Operator), condRegs[0], condRegs[1], 2))
+		opcode.Condition(cmp.Operator), condRegs[0], condRegs[1], uint(len(falseInsns))+2))
+	insns = append(insns, falseInsns...)
 	insns = append(insns, p.newLoad(target, []register.Id{falseRegs[0]}))
-	insns = append(insns, &instruction.Skip{Skip: 1})
+	insns = append(insns, &instruction.Skip{Skip: uint(len(trueInsns)) + 1})
+	insns = append(insns, trueInsns...)
 	//
 	return append(insns, p.newLoad(target, []register.Id{trueRegs[0]}))
 }

--- a/pkg/zkc/compiler/codegen/vectorize.go
+++ b/pkg/zkc/compiler/codegen/vectorize.go
@@ -17,8 +17,6 @@ import (
 	"math"
 	"slices"
 
-	"github.com/consensys/go-corset/pkg/schema/register"
-	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/collection/array"
 	"github.com/consensys/go-corset/pkg/util/collection/stack"
 	"github.com/consensys/go-corset/pkg/util/source"
@@ -113,8 +111,7 @@ func vectorizeFunction(fn *Function, modules []vm.Module) *Function {
 	// control-flow explicit so that LastJump can drive the merge loop.
 	prepared := prepareCode(original)
 	// Build a system map for register-conflict reporting.
-	name := trace.ModuleName{Name: fn.Name(), Multiplier: 1}
-	mapping := instruction.NewSystemMap(register.ArrayMap(name, fn.Registers()...), modules)
+	mapping := instruction.NewSystemMap(fn.RegisterMap(), modules)
 	//
 	var (
 		insns    = make([]VectorInstruction, n)

--- a/pkg/zkc/vm/instruction/base/op_io.go
+++ b/pkg/zkc/vm/instruction/base/op_io.go
@@ -117,19 +117,27 @@ func (p *OpIo) String(mapping SystemMap) string {
 			builder.WriteString(" = ")
 		}
 		//
-		fmt.Fprintf(&builder, "%s(%s)", mapping.Module(p.Id).Name(),
+		fmt.Fprintf(&builder, "%s(%s)", getModuleName(mapping, p.Id),
 			RegistersToString(mapping, p.Arguments...))
 	case opcode.MEMORY_READ:
 		builder.WriteString(RegistersToString(mapping, array.Reverse(p.Returns)...))
 		builder.WriteString(" = ")
 		//
-		fmt.Fprintf(&builder, "%s[%s]", mapping.Module(p.Id).Name(),
+		fmt.Fprintf(&builder, "%s[%s]", getModuleName(mapping, p.Id),
 			RegistersToString(mapping, p.Arguments...))
 	case opcode.MEMORY_WRITE:
-		fmt.Fprintf(&builder, "%s[%s] = %s", mapping.Module(p.Id).Name(),
+		fmt.Fprintf(&builder, "%s[%s] = %s", getModuleName(mapping, p.Id),
 			RegistersToString(mapping, array.Reverse(p.Arguments)...),
 			RegistersToString(mapping, p.Returns...))
 	}
 	//
 	return builder.String()
+}
+
+func getModuleName(mapping SystemMap, id uint) string {
+	if mapping == nil {
+		return "??"
+	}
+	//
+	return mapping.Module(id).Name()
 }

--- a/pkg/zkc/vm/instruction/base/util.go
+++ b/pkg/zkc/vm/instruction/base/util.go
@@ -51,8 +51,12 @@ type SystemMap interface {
 func RegistersToString(env register.Map, regs ...register.Id) string {
 	var (
 		builder strings.Builder
-		n       = uint(len(env.Registers()))
+		n       uint
 	)
+	// support nil environment (for debugging)
+	if env != nil {
+		n = uint(len(env.Registers()))
+	}
 	//
 	for i := 0; i < len(regs); i++ {
 		var rid = regs[i]
@@ -78,7 +82,7 @@ func ExpressionToString[W word.Word[W]](op string, regs []register.Id, constant 
 	for i := 0; i < len(regs); i++ {
 		var rid = regs[i]
 		//
-		builder.WriteString(env.Register(rid).Name())
+		builder.WriteString(RegistersToString(env, rid))
 		builder.WriteString(" ")
 		builder.WriteString(op)
 		builder.WriteString(" ")
@@ -102,7 +106,7 @@ func ExpressionToStringWithoutConst(op string, regs []register.Id, env register.
 			builder.WriteString(" ")
 		}
 		//
-		builder.WriteString(env.Register(rid).Name())
+		builder.WriteString(RegistersToString(env, rid))
 	}
 	//
 	return builder.String()

--- a/pkg/zkc/vm/instruction/vector.go
+++ b/pkg/zkc/vm/instruction/vector.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/consensys/go-corset/pkg/asm/io/micro/dfa"
+	"github.com/consensys/go-corset/pkg/util/collection/array"
 	"github.com/consensys/go-corset/pkg/util/field"
 	"github.com/consensys/go-corset/pkg/util/logical"
 	"github.com/consensys/go-corset/pkg/zkc/vm/instruction/opcode"
@@ -76,14 +77,14 @@ func NewVector[I Instruction](insns ...I) Vector[I] {
 }
 
 // IsEmpty simply identifies whether this instruction is a no-op (or not).
-func (p *Vector[W]) IsEmpty() bool {
+func (p *Vector[I]) IsEmpty() bool {
 	return len(p.Codes) == 0
 }
 
 // Validate that this micro-instruction is well-formed.  For example, each
 // micro-instruction contained within must be well-formed, and the overall
 // requirements for a vector instruction must be met, etc.
-func (p *Vector[W]) Validate(field field.Config, mapping SystemMap) []error {
+func (p *Vector[I]) Validate(field field.Config, mapping SystemMap) []error {
 	// Construct write map
 	var (
 		errors   []error
@@ -122,8 +123,135 @@ func (p *Vector[W]) Validate(field field.Config, mapping SystemMap) []error {
 	return errors
 }
 
+// Map applies a function over each instruction in the vector which returns zero
+// or more registers.  For example, the function could return nothing whenever
+// it sees a "skip 0" operation (since this is a no-op).  A key feature of this
+// function, however, is that it updates skip offsets correctly account the
+// changes in width of instructions.  For example, consider this scenario:
+//
+// > skip_if x == 0 2 ; skip 0 ; ret ; jmp 1
+//
+// Then applying a map to remove "skip 0" instructions yields the following:
+//
+// > skip_if x == 0 1 ; ret ; jmp 1
+//
+// Specifically, we that the offset for the skip_if has been updated to reflect
+// its new branch destination.  Observer, however, that the mapping process can
+// fail if the mapping function is ill-behaved.  Consider this simple example:
+//
+// > skip 1 ; ret ; jmp 1
+//
+// Applying a mapping function which removed the "jmp 1" (for whatever reason)
+// would lead to an invalid instruction and, hence, a mapping failure.
+// Currently, mapping failures simply result in panics.
+func (p *Vector[I]) Map(fun func(uint, I) []I) Vector[I] {
+	var (
+		packets [][]I  = make([][]I, len(p.Codes))
+		mapping []uint = make([]uint, len(p.Codes)+1)
+		offset         = uint(0)
+	)
+	// first, build all packets and the offset map
+	for i, insn := range p.Codes {
+		ith := fun(uint(i), insn)
+		// record package
+		packets[i] = ith
+		// update mapping
+		mapping[i] = offset
+		// update offset
+		offset += uint(len(ith))
+	}
+	// assign offset to end-of-vector to support instructions which "skip of the
+	// end".  Such instructions can arise before vectorisation is applied.
+	mapping[len(p.Codes)] = offset
+	// reset offset
+	offset = 0
+	// recalculate skip offsets
+	for i, pkt := range packets {
+		// remap any skips which "escape" the packet.
+		remapPacket(uint(i), offset, pkt, mapping)
+		//
+		offset += uint(len(pkt))
+	}
+	// flatten packets
+	insns := array.FlatMap(packets, func(pkt []I) []I { return pkt })
+	// done
+	return NewVector(insns...)
+}
+
+// Remap all skip instructions within given "packet" of instructions.  There are
+// two cases to consider: an internal or external skip.  Here, the latter are
+// subject to remapping whilst the former are not. To understand this consider a
+// mapping to remove "skip 0" in the following:
+//
+// > skip_if x == 0 2 ; skip 0 ; ret ; jmp 1
+//
+// The packets generated for this would be:
+//
+// > [skip_if x == 0 2][][ret][jmp 1]
+//
+// You can see the second packet is empty, which is how the "skip 0" ends up
+// being removed.  Now, looking at the first packet.  This contains only a
+// single skip instruction and, hence, the target of that skip lies outside the
+// packet itself.  In such case, we refer to the skip as an "external" skip.
+//
+// Finally, to understand internal skips.  These are skips introduced by the
+// mapping function itself to implement conditional logic within the new
+// instructions.  As such, they should not be remapped as they should already
+// have correct skip offsets.
+func remapPacket[I Instruction](oldOffset, newOffset uint, packet []I, mapping []uint) {
+	var (
+		n = uint(len(packet))
+	)
+	//
+	for i, insn := range packet {
+		if skip, ok := isExternalSkip(n-uint(i), insn); ok {
+			// determine new target
+			target := mapping[oldOffset+skip+1]
+			// Remap
+			packet[i] = remapSkip(target, newOffset+uint(i), insn)
+		}
+	}
+}
+
+func isExternalSkip[I Instruction](n uint, insn I) (uint, bool) {
+	var (
+		c    any = insn
+		skip uint
+	)
+	// extract skip offset
+	switch insn := c.(type) {
+	case *Skip:
+		skip = insn.Skip
+	case *SkipIf:
+		skip = insn.Skip
+	default:
+		return 0, false
+	}
+	//
+	return skip, skip >= n
+}
+
+func remapSkip[I Instruction](target, offset uint, insn I) I {
+	var (
+		c     any = insn
+		skip      = target - offset - 1
+		ninsn any
+	)
+	// reconstruct skip
+	switch insn := c.(type) {
+	case *Skip:
+		ninsn = &Skip{Skip: skip}
+	case *SkipIf:
+		ninsn = &SkipIf{Cond: insn.Cond, Left: insn.Left, Right: insn.Right, Skip: skip}
+	default:
+		panic("unreachable")
+	}
+	// unsafe cast
+	return ninsn.(I)
+}
+
 // String implementation for Instruction interface
-func (p *Vector[W]) String(mapping SystemMap) string {
+func (p *Vector[I]) String(mapping SystemMap) string {
 	var builder strings.Builder
 	//
 	for i, code := range p.Codes {
@@ -159,7 +287,7 @@ func (p *Vector[W]) String(mapping SystemMap) string {
 // arises when a register has _definitely_ been written by an earlier
 // instruction in the vector and, hence, subsequent reads use the new value
 // (rather than the previous value).
-func (p *Vector[W]) WriteMap() dfa.Result[dfa.Writes] {
+func (p *Vector[I]) WriteMap() dfa.Result[dfa.Writes] {
 	return dfa.Construct(dfa.Writes{}, p.Codes, writeDfaTransfer)
 }
 
@@ -187,11 +315,11 @@ func (p *Vector[W]) WriteMap() dfa.Result[dfa.Writes] {
 //
 // Observe that the optimiser automatically reduces "x!=0 && x==1" to just x==1
 // (this is why it is sometimes called _branch table optimisation_).
-func (p *Vector[W]) BranchTable() (dfa.Result[dfa.Writes], dfa.Result[dfa.Branch]) {
+func (p *Vector[I]) BranchTable() (dfa.Result[dfa.Writes], dfa.Result[dfa.Branch]) {
 	// Construct suitable branch table for this instruction vector.
 	var (
 		writeMap = p.WriteMap()
-		btf      = branchTableTransfer[W](writeMap)
+		btf      = branchTableTransfer[I](writeMap)
 	)
 	//
 	return writeMap, dfa.Construct(dfa.Branch{Condition: dfa.TRUE}, p.Codes, btf)

--- a/pkg/zkc/vm/instruction/word/destruct.go
+++ b/pkg/zkc/vm/instruction/word/destruct.go
@@ -65,7 +65,7 @@ func (p *Destruct) String(mapping base.SystemMap) string {
 			builder.WriteString("::")
 		}
 		//
-		builder.WriteString(mapping.Register(rid).Name())
+		builder.WriteString(base.RegistersToString(mapping, rid))
 	}
 	//
 	builder.WriteString(" = ")

--- a/pkg/zkc/vm/instruction/word/op_arith.go
+++ b/pkg/zkc/vm/instruction/word/op_arith.go
@@ -83,7 +83,7 @@ func (p *OpArith[W]) String(mapping base.SystemMap) string {
 	builder.WriteString(base.RegistersToString(mapping, p.Target))
 	builder.WriteString(" = ")
 	//
-	if p.Constant.Cmp(zero) == 0 &&
+	if p.Constant.Cmp(zero) == 0 && len(p.Sources) > 0 &&
 		(p.Op == opcode.INT_ADD || p.Op == opcode.INT_SUB ||
 			p.Op == opcode.INT_ADDMOD_P || p.Op == opcode.INT_SUBMOD_P ||
 			p.Op == opcode.BIT_CONCAT) {

--- a/pkg/zkc/vm/internal/function/function.go
+++ b/pkg/zkc/vm/internal/function/function.go
@@ -17,6 +17,7 @@ import (
 	"encoding/gob"
 
 	"github.com/consensys/go-corset/pkg/schema/register"
+	"github.com/consensys/go-corset/pkg/trace"
 	"github.com/consensys/go-corset/pkg/util/collection/array"
 	"github.com/consensys/go-corset/pkg/util/collection/set"
 	"github.com/consensys/go-corset/pkg/zkc/vm/instruction"
@@ -129,6 +130,13 @@ func (p *Function[I]) Register(id register.Id) register.Register {
 // function.
 func (p *Function[I]) Registers() []register.Register {
 	return p.registers
+}
+
+// RegisterMap returns a register map view of the registers declared by this
+// function.
+func (p *Function[I]) RegisterMap() register.Map {
+	name := trace.ModuleName{Name: p.Name(), Multiplier: 1}
+	return register.ArrayMap(name, p.Registers()...)
 }
 
 // Width returns the number of registers in this module.'

--- a/testdata/zkc/unit/ifelse_08.accepts
+++ b/testdata/zkc/unit/ifelse_08.accepts
@@ -1,0 +1,1 @@
+{ "data": "0xEFFF", "casted":"0xEF" }

--- a/testdata/zkc/unit/ifelse_08.zkc
+++ b/testdata/zkc/unit/ifelse_08.zkc
@@ -1,0 +1,12 @@
+pub input data(address:u1) -> (data:u15)
+pub output casted(address:u1) -> (casted:u8)
+
+fn main() {
+    // the not followed branch would have issue at runtime if executed
+    if data[0] <= 0xEF {
+        casted[0] = data[0] as u8
+    } else {
+        casted[0] = (data[0] & 0xEF) as u8
+    }
+    return
+}

--- a/testdata/zkc/unit/ternary_06.accepts
+++ b/testdata/zkc/unit/ternary_06.accepts
@@ -1,0 +1,1 @@
+{ "data": "0xEFFF", "casted":"0xEF" }

--- a/testdata/zkc/unit/ternary_06.zkc
+++ b/testdata/zkc/unit/ternary_06.zkc
@@ -1,0 +1,10 @@
+pub input data(address:u1) -> (data:u15)
+pub output casted(address:u1) -> (casted:u8)
+
+fn main() {
+    // the not followed branch would have issue at runtime if executed
+
+    casted[0] = data[0] <= 0xEF ? (data[0] as u8):((data[0] & 0xEF) as u8)
+
+    return
+}


### PR DESCRIPTION
This fixes the short-circuiting behaviour of the ternary operator.  Whilst the fix itself was relatively straightforward, there were some downstream issues related to broken skip offsets.  Therefore, a new method `VectorInstruction.Map()` has been added to support lowering instructions safely (i.e. without breaking existing skips).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes codegen control-flow for ternaries and introduces new vector-instruction remapping logic that rewrites skip offsets; mistakes here could alter runtime semantics across multiple lowering passes.
> 
> **Overview**
> **Fixes ternary short-circuiting** by changing `StmtCompiler.compileTernary` to place each arm’s evaluation inside conditionally-skipped regions (instead of eagerly evaluating both arms), with skip lengths computed from the actual instruction counts.
> 
> **Adds `vm/instruction.Vector.Map()`** to transform/expand micro-instructions while automatically remapping *external* `Skip`/`SkipIf` offsets; lowering passes for bitwise, shifts, comparisons, and division are refactored to use this mapping plus a `register.Allocator`-backed `RegisterMap` API.
> 
> Improves IR/debug stringification resilience (nil-safe mapping/module names) and updates tooling to use `Function.RegisterMap()`. Adds new unit tests (`ifelse_08`, `ternary_06`) covering untaken-branch safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 326c1a1636cb1235613eeac77debee71fec6f3a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->