### PR TITLE
feat: tweak cli for compile and execute

### DIFF
--- a/pkg/cmd/zkc/compile.go
+++ b/pkg/cmd/zkc/compile.go
@@ -58,7 +58,10 @@ func runCompileCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 	var (
 		build  = GetBuildConfig[F](cmd, field)
 		output = GetString(cmd, "output")
+		quiet  = GetFlag(cmd, "quiet")
 	)
+	// Suppress printf debug instructions when quiet mode is enabled.
+	build.config = build.config.Quiet(quiet)
 	applyCompileDefaults(&build, output)
 	// Build all artifacts
 	artifacts := build.Build(args...)
@@ -408,4 +411,5 @@ func registerType(r register.Register) string {
 func init() {
 	rootCmd.AddCommand(compileCmd)
 	compileCmd.Flags().StringP("output", "o", "", "specify output file for writing binary constraints")
+	compileCmd.Flags().BoolP("quiet", "q", false, "suppress printf output")
 }

--- a/pkg/cmd/zkc/compile.go
+++ b/pkg/cmd/zkc/compile.go
@@ -59,10 +59,7 @@ func runCompileCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 		build  = GetBuildConfig[F](cmd, field)
 		output = GetString(cmd, "output")
 	)
-	// Set default target (if non specified)
-	if !build.HasTarget() {
-		build.ast = true
-	}
+	applyCompileDefaults(&build, output)
 	// Build all artifacts
 	artifacts := build.Build(args...)
 	//
@@ -71,6 +68,17 @@ func runCompileCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 	} else {
 		// Print out requested artifacts
 		printArtifacts(artifacts)
+	}
+}
+
+func applyCompileDefaults[F field.Element[F]](build *BuildConfig[F], output string) {
+	// Writing a binary file requires a word-level machine artifact.
+	if output != "" {
+		build.wir = true
+	}
+	// Set default target (if none specified).
+	if !build.HasTarget() {
+		build.ast = true
 	}
 }
 

--- a/pkg/cmd/zkc/debug.go
+++ b/pkg/cmd/zkc/debug.go
@@ -48,7 +48,10 @@ func runDebugCmd[F field.Element[F]](cmd *cobra.Command, args []string, field fi
 	var (
 		build    = GetBuildConfig[F](cmd, field)
 		observer = debug.TraceObserver[vm.Uint]{}
+		quiet    = GetFlag(cmd, "quiet")
 	)
+	// Suppress printf debug instructions when quiet mode is enabled.
+	build.config = build.config.Quiet(quiet)
 	// Force compilation of the word machine, which is what we execute.
 	build.wir = true
 	//
@@ -84,4 +87,5 @@ func runDebugCmd[F field.Element[F]](cmd *cobra.Command, args []string, field fi
 //nolint:errcheck
 func init() {
 	rootCmd.AddCommand(debugCmd)
+	debugCmd.Flags().BoolP("quiet", "q", false, "suppress printf output")
 }

--- a/pkg/cmd/zkc/execute.go
+++ b/pkg/cmd/zkc/execute.go
@@ -58,14 +58,15 @@ func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 		outputFile = GetString(cmd, "output")
 		// check constraints
 		check = GetFlag(cmd, "check")
+		// suppress printf output
+		quiet = GetFlag(cmd, "quiet")
 		// identify whether tracing required or not.
 		tracing = check || outputFile != ""
 		//
 		trace   trace.Trace[F]
 		outputs map[string][]byte
 	)
-	// Force compilation of the word machine, which is what we execute.
-	build.wir = true
+	applyExecuteDefaults(&build, check, quiet)
 	//
 	input := ParseInputFile(args[0])
 	// Build artifacts (compiles source files or loads a prebuilt binary).
@@ -113,6 +114,17 @@ func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 	}
 }
 
+func applyExecuteDefaults[F field.Element[F]](build *BuildConfig[F], check, quiet bool) {
+	// Constraint checking requires native ZkC operations to be lowered.
+	if check {
+		build.config = build.config.LowerZkcNative(true)
+	}
+	// Suppress printf debug instructions when quiet mode is enabled.
+	build.config = build.config.Quiet(quiet)
+	// Force compilation of the word machine, which is what we execute.
+	build.wir = true
+}
+
 func checkConstraints[F field.Element[F]](binfile *constraints.BinaryFile[F], tr trace.Trace[F],
 	cfg constraints.TraceConfig) {
 	//
@@ -142,4 +154,5 @@ func init() {
 	rootCmd.AddCommand(executeCmd)
 	executeCmd.Flags().StringP("output", "o", "", "specify output file for writing trace")
 	executeCmd.Flags().BoolP("check", "c", false, "check generated trace against constraints")
+	executeCmd.Flags().BoolP("quiet", "q", false, "suppress printf output")
 }

--- a/pkg/cmd/zkc/root.go
+++ b/pkg/cmd/zkc/root.go
@@ -98,6 +98,8 @@ func runFieldAgnosticCmd(cmd *cobra.Command, args []string, cmds []FieldAgnostic
 // mechanism for compiling constraint files across the various sub-commands.
 func GetBuildConfig[F field.Element[F]](cmd *cobra.Command, field field.Config) BuildConfig[F] {
 	var build BuildConfig[F]
+
+	lowerNative := GetFlag(cmd, "lower-native") || GetFlag(cmd, "mir") || GetFlag(cmd, "air")
 	// Configure log level
 	if GetFlag(cmd, "verbose") {
 		log.SetLevel(log.DebugLevel)
@@ -106,7 +108,7 @@ func GetBuildConfig[F field.Element[F]](cmd *cobra.Command, field field.Config) 
 	build.field = field
 	// Configure compiler config
 	build.config = codegen.DEFAULT_CONFIG.
-		LowerZkcNative(GetFlag(cmd, "lower-native")).
+		LowerZkcNative(lowerNative).
 		Vectorize(GetFlag(cmd, "vectorize")).
 		SplitRegisters(GetFlag(cmd, "split")).
 		Field(field)

--- a/pkg/zkc/compiler/codegen/compile.go
+++ b/pkg/zkc/compiler/codegen/compile.go
@@ -244,7 +244,15 @@ func (p *Compiler) compileFunction(id uint, mapping []uint, program []Declaratio
 		})
 	}
 	//
-	compiler := StmtCompiler{program, fn.Variables, registers, p.env, p.config.field, p.srcmaps, nil}
+	compiler := StmtCompiler{
+		components:  program,
+		variables:   fn.Variables,
+		registers:   registers,
+		environment: p.env,
+		field:       p.config.field,
+		srcmaps:     p.srcmaps,
+		quiet:       p.config.quiet,
+	}
 	//
 	for i, stmt := range fn.Code {
 		bootCode[i] = compiler.compileStatement(uint(i), mapping, stmt)

--- a/pkg/zkc/compiler/codegen/config.go
+++ b/pkg/zkc/compiler/codegen/config.go
@@ -20,6 +20,7 @@ import "github.com/consensys/go-corset/pkg/util/field"
 var DEFAULT_CONFIG = Config{
 	field:          field.KOALABEAR_16,
 	lowerZkcNative: false,
+	quiet:          false,
 	vectorize:      true,
 	splitting:      false,
 }
@@ -36,6 +37,9 @@ type Config struct {
 	// lower ZkC native functions (such as bitwise ops) into arithmetic instructions.
 	// This is required to generate arithmetic constraints. It happens before vectorization and register splitting.
 	lowerZkcNative bool
+	// quiet controls whether printf statements are emitted as VM debug
+	// instructions or skipped during code generation.
+	quiet bool
 	// vectorize controls whether the codegen pipeline runs the
 	// instruction-vectorisation pass in pkg/zkc/compiler/codegen/vectorize.go.
 	// Vectorisation merges sequences of micro-instructions that have no
@@ -85,6 +89,16 @@ func (p Config) LowerZkcNative(flag bool) Config {
 	var q = p
 	//
 	q.lowerZkcNative = flag
+	//
+	return q
+}
+
+// Quiet returns a copy of this Config where printf statements are skipped
+// during code generation when flag=true.
+func (p Config) Quiet(flag bool) Config {
+	var q = p
+	//
+	q.quiet = flag
 	//
 	return q
 }

--- a/pkg/zkc/compiler/codegen/statement.go
+++ b/pkg/zkc/compiler/codegen/statement.go
@@ -42,6 +42,8 @@ type StmtCompiler struct {
 	field       field.Config
 	srcmaps     source.Maps[any]
 	errors      []source.SyntaxError
+	// quiet suppresses printf output
+	quiet bool
 }
 
 func (p *StmtCompiler) compileStatement(pc uint, mapping []uint, s Stmt) VectorInstruction {
@@ -62,6 +64,10 @@ func (p *StmtCompiler) compileStatement(pc uint, mapping []uint, s Stmt) VectorI
 	case *stmt.Fail[symbol.Resolved]:
 		return p.compileFail(mapping, s.Chunks, s.Arguments)
 	case *stmt.Printf[symbol.Resolved]:
+		if p.quiet {
+			return instruction.NewVector[Instruction]()
+		}
+		//
 		return p.compilePrintf(mapping, s.Chunks, s.Arguments)
 	case *stmt.Return[symbol.Resolved]:
 		return instruction.NewVector[Instruction](instruction.NewReturn())


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes CLI-driven compilation behavior (auto-enabling `wir`, auto-lowering native ops for `mir/air` and `execute --check`, and optionally dropping `printf` VM debug instructions), which can affect generated artifacts and debugging output.
> 
> **Overview**
> Adds a new `--quiet/-q` flag to `zkc compile`, `debug`, and `execute` that suppresses `printf` by skipping emission of VM debug instructions during codegen.
> 
> Refactors CLI default handling: `compile` now auto-enables `--wir` when `--output` is set, and `execute` centralizes defaults so `--check` forces native-op lowering plus `wir` generation. Also updates `GetBuildConfig` so requesting `mir/air` implicitly enables `LowerZkcNative`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec5d3aad08c6cc46008b63a19a44bbc61c3968c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->