### PR TITLE
fix: binary file cannot be encoded

### DIFF
--- a/pkg/schema/register/vector.go
+++ b/pkg/schema/register/vector.go
@@ -13,6 +13,8 @@
 package register
 
 import (
+	"bytes"
+	"encoding/binary"
 	"fmt"
 	"slices"
 	"strings"
@@ -97,4 +99,65 @@ func (p Vector) String(fn Map) string {
 	}
 	//
 	return builder.String()
+}
+
+// ============================================================================
+// Encoding / Decoding
+// ============================================================================
+
+// unusedIdSentinel is written in place of a register id when serialising an
+// unused id (i.e. the null-reference produced by UnusedId).  It is the maximum
+// representable value of the uint32 wire format.
+const unusedIdSentinel uint32 = 0xFFFFFFFF
+
+// MarshalBinary converts a vector into binary data.
+func (p *Vector) MarshalBinary() (data []byte, err error) {
+	buffer := bytes.NewBuffer(data)
+	// Number of register ids
+	if err := binary.Write(buffer, binary.BigEndian, uint16(len(p.regs))); err != nil {
+		return nil, err
+	}
+	// Each register id
+	for _, id := range p.regs {
+		v := unusedIdSentinel
+		if id.IsUsed() {
+			v = uint32(id.Unwrap())
+		}
+		//
+		if err := binary.Write(buffer, binary.BigEndian, v); err != nil {
+			return nil, err
+		}
+	}
+	// Success
+	return buffer.Bytes(), nil
+}
+
+// UnmarshalBinary unmarshals a vector.
+func (p *Vector) UnmarshalBinary(data []byte) error {
+	var (
+		buffer = bytes.NewBuffer(data)
+		n      uint16
+	)
+	// Number of register ids
+	if err := binary.Read(buffer, binary.BigEndian, &n); err != nil {
+		return err
+	}
+	//
+	p.regs = make([]Id, n)
+	// Each register id
+	for i := range p.regs {
+		var v uint32
+		//
+		if err := binary.Read(buffer, binary.BigEndian, &v); err != nil {
+			return err
+		}
+		//
+		if v == unusedIdSentinel {
+			p.regs[i] = UnusedId()
+		} else {
+			p.regs[i] = NewId(uint(v))
+		}
+	}
+	// Success
+	return nil
 }

--- a/pkg/test/util/check_valid.go
+++ b/pkg/test/util/check_valid.go
@@ -108,18 +108,26 @@ func CheckValid(t *testing.T, test, ext string, config Config) {
 func checkValidInternal(t *testing.T, testfile string, cfg codegen.Config, config Config, testcases []TestCase) {
 	var (
 		// Compile test program
-		machine = compileTestProgram(t, testfile, cfg)
+		m1 = compileTestProgram(t, testfile, cfg)
+		m2 = marshallUnmarshallMachine(m1, cfg.GetField())
 	)
+	// check for original machine
+	checkValidMachine(t, m1, cfg, config, testcases)
+	// check for marshalled / unmarshalled machine
+	checkValidMachine(t, m2, cfg, config, testcases)
+}
+
+func checkValidMachine(t *testing.T, m *vm.WordMachine[vm.Uint], cfg codegen.Config, config Config, tests []TestCase) {
 	// Run execution tests
-	for _, testcase := range testcases {
-		runExecutionTests(t, machine, testcase, cfg.GetField(), config.words)
+	for _, testcase := range tests {
+		runExecutionTests(t, m, testcase, cfg.GetField(), config.words)
 	}
 	// Run constraint tests
 	if config.constraints {
-		for _, test := range testcases {
+		for _, test := range tests {
 			// FIXME: support reject tests
 			if test.expected {
-				runConstraintTest(t, machine, test, cfg)
+				runConstraintTest(t, m, test, cfg)
 			}
 		}
 	}

--- a/pkg/test/util/util.go
+++ b/pkg/test/util/util.go
@@ -19,10 +19,15 @@ import (
 
 	cmd_util "github.com/consensys/go-corset/pkg/cmd/zkc"
 	"github.com/consensys/go-corset/pkg/util/field"
+	"github.com/consensys/go-corset/pkg/util/field/bls12_377"
+	"github.com/consensys/go-corset/pkg/util/field/gf251"
+	"github.com/consensys/go-corset/pkg/util/field/gf8209"
+	"github.com/consensys/go-corset/pkg/util/field/koalabear"
 	"github.com/consensys/go-corset/pkg/util/file"
 	"github.com/consensys/go-corset/pkg/util/source"
 	"github.com/consensys/go-corset/pkg/zkc/compiler"
 	"github.com/consensys/go-corset/pkg/zkc/compiler/codegen"
+	"github.com/consensys/go-corset/pkg/zkc/constraints"
 	"github.com/consensys/go-corset/pkg/zkc/util"
 	"github.com/consensys/go-corset/pkg/zkc/vm"
 )
@@ -132,4 +137,44 @@ func decodeInputsOutputs[W vm.Word[W]](t *testing.T, m vm.Machine[W], data map[s
 	}
 	//
 	return inputs, outputs
+}
+
+// Marshall / Unmarshall takes a machine and constructs a suitable BinaryFile
+// for the given field configuration, and then marshalls it into a byte sequence
+// and the unmarshalls this sequence back into a fresh machine.  The purpose of
+// this is to ensure that the marshalling / unmarshalling process: (a) actually
+// works; (b) does not change the machine internals in some subtle way.
+func marshallUnmarshallMachine(m *vm.WordMachine[vm.Uint], f field.Config) *vm.WordMachine[vm.Uint] {
+	switch f {
+	case field.GF_251:
+		return roundTripMachine[gf251.Element](m, f)
+	case field.GF_8209:
+		return roundTripMachine[gf8209.Element](m, f)
+	case field.KOALABEAR_16:
+		return roundTripMachine[koalabear.Element](m, f)
+	case field.BLS12_377:
+		return roundTripMachine[bls12_377.Element](m, f)
+	default:
+		panic(fmt.Sprintf("unknown field configuration: %s", f.Name))
+	}
+}
+
+func roundTripMachine[F field.Element[F]](m *vm.WordMachine[vm.Uint], f field.Config) *vm.WordMachine[vm.Uint] {
+	var (
+		original = constraints.NewBinaryFile[F](nil, nil, f, *m)
+		decoded  constraints.BinaryFile[F]
+	)
+	//
+	data, err := original.MarshalBinary()
+	if err != nil {
+		panic(fmt.Sprintf("marshalling machine failed: %s", err))
+	}
+	//
+	if err := decoded.UnmarshalBinary(data); err != nil {
+		panic(fmt.Sprintf("unmarshalling machine failed: %s", err))
+	}
+	//
+	nm := decoded.WordMachine()
+	//
+	return &nm
 }

--- a/pkg/zkc/vm/instruction/base.go
+++ b/pkg/zkc/vm/instruction/base.go
@@ -217,6 +217,7 @@ func init() {
 	gob.Register(Instruction(&Call{}))
 	gob.Register(Instruction(&Debug{}))
 	gob.Register(Instruction(&Fail{}))
+	gob.Register(Instruction(&FieldHint{}))
 	gob.Register(Instruction(&Jump{}))
 	gob.Register(Instruction(&MemRead{}))
 	gob.Register(Instruction(&MemWrite{}))


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches serialization of register layout and gob instruction types used when persisting constraint binaries; test coverage mitigates regressions but wire format changes could affect compatibility if deployed externally.
> 
> **Overview**
> Fixes **binary constraint file** serialization by making **register vectors** round-trip on the wire and ensuring **VM instructions** used in encoded machines decode correctly.
> 
> `register.Vector` now implements **`MarshalBinary` / `UnmarshalBinary`**: a big-endian `uint16` count followed by `uint32` register ids, with **`0xFFFFFFFF`** representing unused slots via `UnusedId()`.
> 
> **`FieldHint`** is registered with **`encoding/gob`** alongside other base instructions so gob-encoded machine state that includes field hints can be marshalled and unmarshalled.
> 
> **Validation tests** compile a program once, then run the same execution and constraint checks on both the original **`WordMachine`** and a copy rebuilt through **`constraints.BinaryFile`** marshal/unmarshal (`marshallUnmarshallMachine` / `roundTripMachine`), covering all supported field types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4cf53c0e37f982d7d877d53d426a3aefe6fda8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->