### PR TITLE
fix: update lfdt-lineth-org runners for lint and test workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
   lint:
     permissions:
       contents: read
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           - { field: GF_8209,      test: corset-racer }
           - { field: GF_8209,      test: unit-test }
       fail-fast: false
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
@@ -45,7 +45,7 @@ jobs:
   zkc-test:
     permissions:
       contents: read
-    runs-on: gha-runner-scale-set-ubuntu-24-amd64-large
+    runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2


### PR DESCRIPTION
Updates GitHub Actions workflows to run CI jobs on the `gha-lfdt-lineth-ss-ubuntu-24-amd64-large` runner label, aligning test and lint execution with the intended LFDT Lineth runner scale set.