### PR TITLE
fix(zkc): generate forces fast mode + gogen support for lowered machine

### DIFF
--- a/pkg/cmd/zkc/generate.go
+++ b/pkg/cmd/zkc/generate.go
@@ -87,6 +87,10 @@ func runGenerateCmd[F field.Element[F]](cmd *cobra.Command, args []string, field
 }
 
 func applyGenerateDefaults[F field.Element[F]](build *BuildConfig[F], quiet bool) {
+	// gogen compiles native ops straight to Go operators, so it must consume the
+	// un-lowered machine: native lowering produces wide arithmetic (e.g. 128-bit
+	// masks) that gogen cannot emit. Force fast mode regardless of the --fast flag.
+	build.config = build.config.FastMode(true)
 	// Suppress printf debug instructions when quiet mode is enabled.
 	build.config = build.config.Quiet(quiet)
 	// Generation consumes the word machine.

--- a/pkg/zkc/vm/internal/gogen/emit_arith.go
+++ b/pkg/zkc/vm/internal/gogen/emit_arith.go
@@ -50,7 +50,7 @@ func (g *generator) emitArith(c *code, fn *wordFunction, x *instruction.WordType
 		return g.emitConcat(c, fn, x, store)
 	}
 
-	konst, err := uintConst(x.Constant)
+	konst, err := constOperand(x.Constant)
 	if err != nil {
 		return err
 	}
@@ -84,10 +84,10 @@ func anyWide(ops []operand) bool {
 
 // emitAdd emits `target = const + Σ sources` (executeAdd: exact sum, then the
 // store decides).  Constant-zero terms add nothing and are dropped.
-func (g *generator) emitAdd(c *code, srcs []operand, konst uint64, store storeView) error {
+func (g *generator) emitAdd(c *code, srcs []operand, konst operand, store storeView) error {
 	terms := []operand{}
-	if konst != 0 {
-		terms = append(terms, exact(new(big.Int).SetUint64(konst)))
+	if !konst.isZero() {
+		terms = append(terms, konst)
 	}
 
 	for _, s := range srcs {
@@ -165,13 +165,13 @@ func (g *generator) emitAdd(c *code, srcs []operand, konst uint64, store storeVi
 
 // emitSub emits `target = sources[0] - sources[1] - … - const`, each step
 // checked for underflow (executeSub: a negative intermediate is an error).
-func (g *generator) emitSub(c *code, srcs []operand, konst uint64, store storeView) error {
+func (g *generator) emitSub(c *code, srcs []operand, konst operand, store storeView) error {
 	minuend := srcs[0]
 
 	subtrahends := slices0(srcs[1:])
-	if konst != 0 {
+	if !konst.isZero() {
 		// The constant is subtracted last, matching executeSub.
-		subtrahends = append(subtrahends, exact(new(big.Int).SetUint64(konst)))
+		subtrahends = append(subtrahends, konst)
 	}
 	// Subtracting a provable zero never underflows and changes nothing.
 	kept := subtrahends[:0]
@@ -249,10 +249,10 @@ func (g *generator) emitSub(c *code, srcs []operand, konst uint64, store storeVi
 // emitMul emits `target = const · Π sources` (executeMul: exact product, then
 // the store decides).  The constant leads the factor list, matching the
 // oracle's evaluation order, and is dropped when it is the identity.
-func (g *generator) emitMul(c *code, srcs []operand, konst uint64, store storeView) error {
+func (g *generator) emitMul(c *code, srcs []operand, konst operand, store storeView) error {
 	factors := []operand{}
-	if konst != 1 || len(srcs) == 0 {
-		factors = append(factors, exact(new(big.Int).SetUint64(konst)))
+	if konst.val.Cmp(big.NewInt(1)) != 0 || len(srcs) == 0 {
+		factors = append(factors, konst)
 	}
 
 	factors = append(factors, srcs...)
@@ -472,6 +472,30 @@ type storeView struct {
 	total  uint // total bit width across all target registers
 }
 
+// hasWideLimb reports whether any limb of a multi-register store is itself
+// wider than 64 bits (a lo/hi pair).  Such stores arise from destructuring a
+// runtime pair (e.g. the shr_u128 bitwise-lowering helper splitting a u128 into
+// [u1, u127]) and are distributed by storePair, which is pair-aware.
+func (s storeView) hasWideLimb() bool {
+	for _, l := range s.limbs {
+		if l.width > 64 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// noWideLimb is a defensive guard for the narrow distribution paths
+// (storeNamed/storeKnown), which cannot place a value into a wide limb.
+func (s storeView) noWideLimb() error {
+	if s.hasWideLimb() {
+		return fmt.Errorf("gogen: wide register inside a multi-register store reached a narrow distribution path")
+	}
+
+	return nil
+}
+
 // buildStore translates a target register vector into a storeView.
 func (g *generator) buildStore(fn *wordFunction, vec register.Vector) (storeView, error) {
 	regs := vec.Registers()
@@ -493,10 +517,6 @@ func (g *generator) buildStore(fn *wordFunction, vec register.Vector) (storeView
 			return storeView{}, err
 		}
 
-		if l.width > 64 {
-			return storeView{}, fmt.Errorf("gogen: wide register %q inside a multi-register store unsupported", l.reg)
-		}
-
 		limbs[i] = l
 		total += l.width
 	}
@@ -508,10 +528,10 @@ func (g *generator) buildStore(fn *wordFunction, vec register.Vector) (storeView
 // (exact / narrow expression / lo-hi pair) and the target's shape.
 func (g *generator) storeValue(c *code, store storeView, op operand) error {
 	switch {
-	case op.val != nil && !op.wide():
+	case op.val != nil && !op.wide() && !store.hasWideLimb():
 		g.storeKnown(c, store, op.val)
 		return nil
-	case !op.wide():
+	case !op.wide() && !store.hasWideLimb():
 		if store.single != nil {
 			g.assignSingle(c, *store.single, op)
 			return nil
@@ -571,6 +591,10 @@ func (g *generator) storeNamed(c *code, store storeView, op operand) error {
 		return nil
 	}
 
+	if err := store.noWideLimb(); err != nil {
+		return err
+	}
+
 	v := op.expr
 	rest := new(big.Int).Set(op.max) // bound of the not-yet-distributed bits
 
@@ -599,7 +623,9 @@ func (g *generator) storeNamed(c *code, store storeView, op operand) error {
 }
 
 // storeKnown stores a generation-time known value: limbs become literals and
-// the width check resolves statically.
+// the width check resolves statically.  A multi-register store with a wide
+// limb is not reachable for known values (such stores arise from destructuring
+// runtime pairs), so storeValue routes those through storePair instead.
 func (g *generator) storeKnown(c *code, store storeView, val *big.Int) {
 	if store.single != nil {
 		l := *store.single
@@ -688,9 +714,17 @@ func (g *generator) storePair(c *code, store storeView, bound *big.Int) error {
 	for i, l := range store.limbs {
 		last := i == len(store.limbs)-1
 
-		if l.width < 64 {
+		switch {
+		case l.width > 64:
+			// Wide limb: its low 64 bits are `lo`, its high (width-64) bits are
+			// `hi` masked to that width.  In a multi-register store total ≤ 128
+			// with at least one other limb, so width-64 ≤ 63 and the mask shift
+			// never overflows.
+			c.linef("%s = lo", l.lo())
+			c.linef("%s = hi & (1<<%d - 1)", l.hiName(), l.width-64)
+		case l.width < 64:
 			c.linef("%s = lo & (1<<%d - 1)", l.reg, l.width)
-		} else {
+		default:
 			c.linef("%s = lo", l.reg)
 		}
 
@@ -701,9 +735,15 @@ func (g *generator) storePair(c *code, store storeView, bound *big.Int) error {
 			break
 		}
 
-		if l.width == 64 {
+		switch {
+		case l.width > 64:
+			// Shift the pair right by width>64: the remaining bits are wholly in
+			// hi, so the new lo is hi>>(width-64) and hi clears.
+			c.linef("lo = hi >> %d", l.width-64)
+			c.line("hi = 0")
+		case l.width == 64:
 			c.line("lo, hi = hi, 0")
-		} else {
+		default:
 			c.linef("lo = lo>>%d | hi<<%d", l.width, 64-l.width)
 			c.linef("hi >>= %d", l.width)
 		}

--- a/pkg/zkc/vm/internal/gogen/gen.go
+++ b/pkg/zkc/vm/internal/gogen/gen.go
@@ -36,9 +36,11 @@
 //   - Functions become Go functions (the Go stack is the call stack, matching
 //     CallStack.Enter/Leave); shared memories become package-level globals.
 //
-// Registers wider than 64 bits, constants beyond 64 bits and moduli beyond 64
-// bits are rejected with descriptive errors (wide-register support is future
-// work); callers treat these programs as out of scope, not failures.
+// Registers and constants up to 128 bits are supported via the lo/hi pair
+// representation (including wide limbs inside a multi-register store, as the
+// bitwise-lowering helpers produce); registers/constants beyond 128 bits,
+// native (field-element) registers and moduli beyond 64 bits are rejected with
+// descriptive errors; callers treat these programs as out of scope, not failures.
 package gogen
 
 import (
@@ -1040,6 +1042,18 @@ func uintConst(w word.Uint) (uint64, error) {
 	}
 
 	return w.Uint64(), nil
+}
+
+// constOperand renders an instruction's immediate as an exact operand,
+// supporting up to 128 bits via the lo/hi pair representation.  The lowering
+// passes introduce wide masks (e.g. the 0xff…ff produced by bitwise lowering)
+// which then flow through the arithmetic emitters like any other wide value.
+func constOperand(w word.Uint) (operand, error) {
+	if !w.FitsWithin(128) {
+		return operand{}, fmt.Errorf("gogen: constant 0x%s wider than 128 bits unsupported", w.Text(16))
+	}
+
+	return exactWide(w.BigInt()), nil
 }
 
 // hasNativeDataLine reports whether a memory has a field-element (native) data


### PR DESCRIPTION
Two related gogen fixes.

## 1. `generate` must force fast mode

`zkc generate` regressed after #1882. The fastMode refactor inverted the default: `--fast` defaults off, so `!fastMode` is true and native lowering runs for a command that should never lower.

gogen compiles native ops straight to Go operators. Native lowering produces wide arithmetic (e.g. the 128-bit `0xffff…ffff` mask from `LowerBitwise`) that gogen can't emit:

```
gogen: constant 0xffffffffffffffffffffffffffffffff wider than 64 bits unsupported
```

Fix: force `FastMode(true)` in `applyGenerateDefaults`. gogen consumes the un-lowered, unsplit machine — same reason it already rejects `--split`.

## 2. gogen support for the lowered word machine

So the lowered path works when someone *does* want it (e.g. tracer). Two blockers, found by peeling errors empirically on the RISC-V interpreter (`main.zkc`, KOALABEAR_16):

- **Constants >64 bits** — bitwise lowering emits 128-bit masks. New `constOperand` renders an immediate as an exact ≤128-bit operand (lo/hi pair) so it flows through the arith emitters like any wide value.
- **Wide register as a limb in a multi-register store** — the `shr_u128` lowering helper destructures u128 into `[u1, u127]`. `storePair` is now pair-aware for wide limbs; the narrow distribution paths (`storeNamed`/`storeKnown`) stay explicitly guarded.

Result: the lowered machine generates, `go vet`/`go build` clean, runs. gogen suite green (both shapes).

Not covered: native field-element arithmetic (`gogen: native register unsupported`) — the distinct blocker behind #1892's mixed tests, a separate larger feature.
