### PR TITLE
fix(zkc): exec --gogen requires --fast; test both gogen shapes

### DIFF
--- a/pkg/cmd/zkc/execute.go
+++ b/pkg/cmd/zkc/execute.go
@@ -73,6 +73,13 @@ func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 		trace   trace.Trace[F]
 		outputs map[string][]byte
 	)
+	// gogen only executes the fast-mode machine: without --fast the run would
+	// silently fall through to tracing. Reject it rather than ignore --gogen.
+	if gogen && tracing {
+		log.Error("--gogen requires --fast (and is incompatible with --check / --output)")
+		os.Exit(2)
+	}
+	//
 	applyExecuteDefaults(&build, check, quiet)
 	//
 	input := ParseInputFile(args[0])

--- a/pkg/zkc/vm/internal/gogen/gen_test.go
+++ b/pkg/zkc/vm/internal/gogen/gen_test.go
@@ -422,8 +422,8 @@ var shapes = []struct {
 	name     string
 	fastMode bool
 }{
-	{"plain", false},
-	{"fastMode", false},
+	{"fast", true},
+	{"lowered", false},
 }
 
 func TestGenValidGo(t *testing.T) {


### PR DESCRIPTION
Two small gogen-path fixes.

## 1. `exec --gogen` requires `--fast`

`exec --gogen` only runs gogen when `--fast` is set (`tracing = check || output || !fast`). Without `--fast` the run silently falls through to the trace path and `--gogen` is ignored — on the R5 interpreter that then panics building AIR (u32 reg vs u16 field). Reject it explicitly instead.

## 2. gogen tests actually exercise the fast path

The `shapes` table in `gen_test.go` had both entries `fastMode: false` (both lowered) since the #1882 `lowered`→`fastMode` rename. So every gogen test ran the lowered shape twice and the fast/un-lowered path — the `generate` default — was untested. Make one entry fast (`{"fast", true}, {"lowered", false}`).

Both shapes pass. gogen suite green.
