### PR TITLE
ci: bump pinned GitHub Actions to latest

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '>=1.24'
       - name: golangci-lint

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -19,7 +19,7 @@ permissions: {} # lock everything by default (least-privilege)
 
 jobs:
   security-scan:
-    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@1cd598629833fa9fc1694f03abfce8d21b72eb5d # v2.0.6
+    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@ff5edd492dfd4a70813066fe9f1552a2ac13766f # v2.1.0
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,9 +32,9 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '>=1.24'
       - run: make ${{ matrix.test }}
@@ -48,9 +48,9 @@ jobs:
     runs-on: gha-lfdt-lineth-ss-ubuntu-24-amd64-large
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '>=1.24'
       - run: make zkc-test


### PR DESCRIPTION
## Summary

Routine maintenance of the SHA-pinned actions in our GitHub workflows. Every action stays pinned to a full commit SHA (the secure form — a mutable tag can be re-pointed, a SHA cannot), with the trailing `# vX.Y.Z` comment kept accurate.

I verified each pin against the GitHub API (`gh api repos/.../commits/<tag>`): all existing pins already matched their comments, and two actions had newer releases.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v6.0.2 | **v6.0.3** |
| `MetaMask/action-security-code-scanner` | v2.0.6 | **v2.1.0** |
| `actions/setup-go` | v6.4.0 | unchanged (latest) |
| `golangci/golangci-lint-action` | v9.2.1 | unchanged (latest) |

Both bumps stay within the same major version (patch + minor), so no input/behaviour changes are expected.

Also normalized all version comments to the `# vX.Y.Z` form (space after `#`) for consistency with the Dependabot / `pin-github-action` convention.

Files touched: `.github/workflows/{lint,test,security-code-scanner}.yml`.