### PR TITLE
feat: support interpreter checkpointing

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(go build:*)",
+      "Bash(go test:*)",
+      "Bash(go vet:*)",
+      "Bash(gofmt:*)",
+      "Bash(grep:*)"
+    ]
+  }
+}

--- a/pkg/cmd/zkc/debug.go
+++ b/pkg/cmd/zkc/debug.go
@@ -59,6 +59,8 @@ func runDebugCmd[F field.Element[F]](cmd *cobra.Command, args []string, field fi
 	// Build artifacts (compiles source files or loads a prebuilt binary).
 	artifacts := build.Build(args[1:]...)
 	wm := artifacts.wir.Unwrap()
+	// Filter out unnecessary inputs
+	input = filterInputsOnly(&wm, input)
 	// Decode inputs against the compiled machine.
 	inputs, errs := vm.DecodeInputs(&wm, input)
 	if len(errs) == 0 {

--- a/pkg/cmd/zkc/execute.go
+++ b/pkg/cmd/zkc/execute.go
@@ -54,6 +54,9 @@ var executeCmds = []FieldAgnosticCmd{
 	{field.BLS12_377, runExecuteCmd[bls12_377.Element]},
 }
 
+// Permitted flag combinations
+var executeFlags FlagChecks
+
 func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field field.Config) {
 	var (
 		errors []error
@@ -78,33 +81,21 @@ func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 		// rather than an initial set of JSON inputs.  Execution then continues to
 		// completion via the fast bytecode interpreter.
 		resume = GetFlag(cmd, "resume")
-		// identify whether tracing required or not.
-		tracing = !resume && checkpoint == "" && (check || outputFile != "" || !fast)
+		// simple equivalence
+		tracing = !fast
 		//
 		trace   trace.Trace[F]
 		input   map[string][]byte
 		outputs map[string][]byte
 	)
-	// gogen only executes the fast-mode machine: without --fast the run would
-	// silently fall through to tracing. Reject it rather than ignore --gogen.
-	if gogen && tracing {
-		log.Error("--gogen requires --fast (and is incompatible with --check / --output)")
-		os.Exit(2)
-	}
+	// Sanity permitted flag combinations
+	checkFlags(cmd, executeFlags)
 	//
 	applyExecuteDefaults(&build, check, quiet)
 	//
-	// In resume mode the input file is a checkpoint, not JSON inputs.
-	if !resume {
-		input = ParseInputFile(args[0])
-	}
 	// Build artifacts (compiles source files or loads a prebuilt binary).
 	artifacts := build.Build(args[1:]...)
 	wm := artifacts.wir.Unwrap()
-	// Filter out things other than inputs
-	if !resume {
-		input = filterInputsOnly(&wm, input)
-	}
 	// Wrap the word machine in a binary file for execution / tracing / checking.
 	binfile := constraints.NewBinaryFile[F](nil, nil, field, wm)
 	// =====================================================
@@ -114,30 +105,34 @@ func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 		// Resume execution from the checkpoint held (in hex) in the input file,
 		// running the (unmodified) program to completion in fast mode.
 		outputs, errors = resumeFromCheckPoint(&wm, args[0])
-	} else if checkpoint != "" {
-		// Checkpoint the function named in the spec (periodically with "f:N", or
-		// once with "f@N") and execute in fast mode, writing the resulting
-		// checkpoints to the output file (with -o) or to stdout otherwise.
-		outputs, errors = executeWithCheckPoint(&wm, checkpoint, outputFile, input)
-	} else if tracing {
-		trace, errors = binfile.Trace(input, traceConfig)
-	} else if gogen {
-		// Execute via native Go generated from the word machine.
-		outputs, errors = executeWithGogen(&wm, input)
 	} else {
-		outputs, errors = binfile.Execute(input, 131072)
+		// Parse an filter input file
+		input = ParseInputFile(args[0])
+		input = filterInputsOnly(&wm, input)
+		// decide what is happening
+		if checkpoint != "" {
+			// Checkpoint the function named in the spec (periodically with "f:N", or
+			// once with "f@N") and execute in fast mode, writing the resulting
+			// checkpoints to the output file (with -o) or to stdout otherwise.
+			outputs, errors = executeWithCheckPoint(&wm, checkpoint, outputFile, input)
+		} else if tracing {
+			trace, errors = binfile.Trace(input, traceConfig)
+		} else if gogen {
+			// Execute via native Go generated from the word machine.
+			outputs, errors = executeWithGogen(&wm, input)
+		} else {
+			outputs, errors = binfile.Execute(input, 131072)
+		}
 	}
 	// =====================================================
 	// Generate output
 	// =====================================================
-	if resume || checkpoint != "" || outputFile == "" {
-		// In resume / checkpoint mode there is no trace (any checkpoints have
-		// already been written); here we simply report the program outputs on
-		// stdout.
-		for name, bytes := range outputs {
-			fmt.Printf("%s = 0x%s\n", name, hex.EncodeToString(bytes))
-		}
-	} else {
+	// Write outputs
+	for name, bytes := range outputs {
+		fmt.Printf("%s = 0x%s\n", name, hex.EncodeToString(bytes))
+	}
+	// write out trace (if requested)
+	if tracing && outputFile != "" {
 		// Construct trace file
 		ltf := lt.FromRawTrace(nil, trace)
 		// Write out trace file
@@ -146,7 +141,8 @@ func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 	// =====================================================
 	// Check Constraints
 	// =====================================================
-	if check && !resume && len(errors) == 0 {
+	if check && len(errors) == 0 {
+		// NOTE: check ==> tracing
 		checkConstraints(binfile, trace, traceConfig)
 	}
 	// =====================================================
@@ -163,10 +159,6 @@ func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 }
 
 func applyExecuteDefaults[F field.Element[F]](build *BuildConfig[F], check, quiet bool) {
-	// Constraint checking requires native ZkC operations to be lowered.
-	if check {
-		build.config = build.config.FastMode(false)
-	}
 	// Suppress printf debug instructions when quiet mode is enabled.
 	build.config = build.config.Quiet(quiet)
 	// Force compilation of the word machine, which is what we execute.
@@ -209,6 +201,18 @@ func init() {
 		"checkpoint a function: \"f:N\" on every Nth call to f, or \"f@N\" once after N calls to f")
 	executeCmd.Flags().Bool("resume", false,
 		"resume from a checkpoint: the input file is a hex checkpoint (rather than JSON inputs) to execute to completion")
+	// Checkpointing is only supported in fast mode.
+	executeFlags.Require("checkpoint", "fast")
+	// Resuming from a checkpoint (currently) is only supported in fast mode.
+	// Eventually, this restriction should be lifted.
+	executeFlags.Require("resume", "fast")
+	// Gogen only supports fast mode (for now).
+	executeFlags.Require("gogen", "fast")
+	// Gogen does not support checkpointing (for now)
+	executeFlags.Exclude("checkpoint", "gogen")
+	// Fast mode cannot be used to check constraints (i.e. because it does not
+	// generate a trace).
+	executeFlags.Exclude("check", "fast")
 }
 
 // executeWithCheckPoint executes the word machine via the fast bytecode

--- a/pkg/cmd/zkc/execute.go
+++ b/pkg/cmd/zkc/execute.go
@@ -330,7 +330,11 @@ func newCheckPointInterpreter(wm *vm.WordMachine[vm.Uint], fn string, clk util.C
 		}
 		//
 		out = f
-		closer = func() { f.Close() }
+		closer = func() {
+			if err = f.Close(); err != nil {
+				panic(err)
+			}
+		}
 	}
 	// Locate the function whose calls are to be checkpointed.
 	fid, ok := program.HasModule(fn)
@@ -349,7 +353,10 @@ func newCheckPointInterpreter(wm *vm.WordMachine[vm.Uint], fn string, clk util.C
 			return
 		}
 		//
-		fmt.Fprintf(out, "0x%s\n", hex.EncodeToString(bytes))
+		if _, err := fmt.Fprintf(out, "0x%s\n", hex.EncodeToString(bytes)); err != nil {
+			log.Errorf("encoding checkpoint: %s", err)
+			return
+		}
 	}
 	// The counter fires every interval invocations of fn (see
 	// executeEnterCheckPoint_n).

--- a/pkg/cmd/zkc/execute.go
+++ b/pkg/cmd/zkc/execute.go
@@ -15,7 +15,10 @@ package zkc
 import (
 	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/LFDT-Lineth/zkc/pkg/cmd/corset"
 	"github.com/LFDT-Lineth/zkc/pkg/cmd/zkc/gogen"
@@ -67,10 +70,19 @@ func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 		fast = GetFlag(cmd, "fast")
 		// gogen mode flag: execute via generated Go rather than the interpreter
 		gogen = GetFlag(cmd, "gogen")
+		// checkpoint spec: when set (as "FUNCTION:INTERVAL"), checkpoint every
+		// INTERVAL-th call to FUNCTION and execute in fast mode, printing
+		// checkpoints.
+		checkpoint = GetString(cmd, "checkpoint")
+		// resume mode: the input file holds a checkpoint (hex) to resume from,
+		// rather than an initial set of JSON inputs.  Execution then continues to
+		// completion via the fast bytecode interpreter.
+		resume = GetFlag(cmd, "resume")
 		// identify whether tracing required or not.
-		tracing = check || outputFile != "" || !fast
+		tracing = !resume && checkpoint == "" && (check || outputFile != "" || !fast)
 		//
 		trace   trace.Trace[F]
+		input   map[string][]byte
 		outputs map[string][]byte
 	)
 	// gogen only executes the fast-mode machine: without --fast the run would
@@ -82,18 +94,32 @@ func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 	//
 	applyExecuteDefaults(&build, check, quiet)
 	//
-	input := ParseInputFile(args[0])
+	// In resume mode the input file is a checkpoint, not JSON inputs.
+	if !resume {
+		input = ParseInputFile(args[0])
+	}
 	// Build artifacts (compiles source files or loads a prebuilt binary).
 	artifacts := build.Build(args[1:]...)
 	wm := artifacts.wir.Unwrap()
 	// Filter out things other than inputs
-	input = filterInputsOnly(&wm, input)
+	if !resume {
+		input = filterInputsOnly(&wm, input)
+	}
 	// Wrap the word machine in a binary file for execution / tracing / checking.
 	binfile := constraints.NewBinaryFile[F](nil, nil, field, wm)
 	// =====================================================
 	// Trace / Execute
 	// =====================================================
-	if tracing {
+	if resume {
+		// Resume execution from the checkpoint held (in hex) in the input file,
+		// running the (unmodified) program to completion in fast mode.
+		outputs, errors = resumeFromCheckPoint(&wm, args[0])
+	} else if checkpoint != "" {
+		// Checkpoint the function named in the spec (periodically with "f:N", or
+		// once with "f@N") and execute in fast mode, writing the resulting
+		// checkpoints to the output file (with -o) or to stdout otherwise.
+		outputs, errors = executeWithCheckPoint(&wm, checkpoint, outputFile, input)
+	} else if tracing {
 		trace, errors = binfile.Trace(input, traceConfig)
 	} else if gogen {
 		// Execute via native Go generated from the word machine.
@@ -104,11 +130,14 @@ func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 	// =====================================================
 	// Generate output
 	// =====================================================
-	if outputFile == "" {
+	if resume || checkpoint != "" || outputFile == "" {
+		// In resume / checkpoint mode there is no trace (any checkpoints have
+		// already been written); here we simply report the program outputs on
+		// stdout.
 		for name, bytes := range outputs {
 			fmt.Printf("%s = 0x%s\n", name, hex.EncodeToString(bytes))
 		}
-	} else if outputFile != "" {
+	} else {
 		// Construct trace file
 		ltf := lt.FromRawTrace(nil, trace)
 		// Write out trace file
@@ -117,7 +146,7 @@ func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 	// =====================================================
 	// Check Constraints
 	// =====================================================
-	if check && len(errors) == 0 {
+	if check && !resume && len(errors) == 0 {
 		checkConstraints(binfile, trace, traceConfig)
 	}
 	// =====================================================
@@ -176,6 +205,181 @@ func init() {
 	executeCmd.Flags().BoolP("quiet", "q", false, "suppress printf output")
 	executeCmd.Flags().BoolP("fast", "f", false, "enable fast execution")
 	executeCmd.Flags().BoolP("gogen", "g", false, "execute via generated Go instead of the interpreter")
+	executeCmd.Flags().String("checkpoint", "",
+		"checkpoint a function: \"f:N\" on every Nth call to f, or \"f@N\" once after N calls to f")
+	executeCmd.Flags().Bool("resume", false,
+		"resume from a checkpoint: the input file is a hex checkpoint (rather than JSON inputs) to execute to completion")
+}
+
+// executeWithCheckPoint executes the word machine via the fast bytecode
+// interpreter, having first switched every call to the checkpointed function
+// into a checkpointing call.  The spec is "FUNCTION:INTERVAL" or
+// "FUNCTION@INTERVAL" (see parseCheckPointSpec); checkpoints are written -- one
+// hex string per line -- to the given output file (or to stdout when outputFile
+// is empty).
+func executeWithCheckPoint(wm *vm.WordMachine[vm.Uint], spec, outputFile string,
+	input map[string][]byte) (map[string][]byte, []error) {
+	//
+	fn, clk, err := parseCheckPointSpec(spec)
+	if err != nil {
+		return nil, []error{err}
+	}
+	//
+	interp, closer, err := newCheckPointInterpreter(wm, fn, clk, outputFile)
+	if err != nil {
+		return nil, []error{err}
+	}
+	//
+	defer closer()
+	//
+	return vm.BootAndExecute(interp, input, 131072)
+}
+
+// parseCheckPointSpec parses a --checkpoint specification, returning the
+// function name, the (positive) interval, and whether the checkpoint is
+// one-shot.  Two forms are accepted:
+//
+//	FUNCTION:INTERVAL  checkpoint on every INTERVAL-th invocation of FUNCTION
+//	FUNCTION@INTERVAL  checkpoint once, after INTERVAL invocations of FUNCTION
+//
+// The interval is the suffix after the final ':' or '@' (whichever comes
+// later), so function names that themselves contain ':' are handled correctly.
+func parseCheckPointSpec(spec string) (string, util.Counter, error) {
+	var (
+		colon = strings.LastIndex(spec, ":")
+		at    = strings.LastIndex(spec, "@")
+	)
+	// The later separator delimits the interval; '@' selects the one-shot form.
+	if at > colon {
+		fn, nstr := spec[:at], spec[at+1:]
+		n, err := strconv.ParseUint(nstr, 10, 64)
+		//
+		return fn, util.NewCounterOnce(n), err
+	} else {
+		fn, istr := spec[:colon], spec[colon+1:]
+		n, err := strconv.ParseUint(istr, 10, 64)
+		//
+		return fn, util.NewCounter(n), err
+	}
+}
+
+// resumeFromCheckPoint resumes execution from the checkpoint held (as a hex
+// string) in inputFile.  The program is rebuilt in fast mode, the
+// interpreter's state is restored from the checkpoint, and execution continues
+// to completion.  Checkpointing is width-preserving (see Program.AddCheckPoint),
+// so checkpoints are written in the plain program's coordinates (see
+// executeWithCheckPoint) and resume directly against it -- no checkpointing
+// transformation is needed here.
+func resumeFromCheckPoint(wm *vm.WordMachine[vm.Uint], inputFile string) (map[string][]byte, []error) {
+	//
+	var (
+		stats = util.NewPerfStats()
+		// Lower to the fast (128-bit) word machine, then compile to bytecode --
+		// the same program the checkpoint was taken against (checkpointing leaves
+		// the bytecode layout unchanged).
+		m128    = vm.WordToWordMachine[vm.Uint, vm.Uint128](wm)
+		program = vm.WordToBytecodeProgram(m128)
+		interp  = vm.NewBytecodeInterpreter(program, m128.Executor().Modulus())
+	)
+	// Decode the checkpoint and restore the interpreter's state from it.
+	cp, err := readCheckPoint(inputFile)
+	if err != nil {
+		return nil, []error{err}
+	}
+	//
+	interp.Restore(cp)
+	// Continue execution to completion.
+	if nsteps, err := vm.ExecuteAll(interp, 131072); err != nil {
+		return nil, []error{err}
+	} else {
+		// Log stats
+		stats.Log(fmt.Sprintf("Machine execution (%d steps)", nsteps))
+	}
+	//
+	return vm.EncodeOutputs(interp), nil
+}
+
+// newCheckPointInterpreter lowers the word machine to the fast (128-bit)
+// bytecode form (mirroring BinaryFile.Execute), switches every call to fn into
+// a checkpointing call, and returns an interpreter whose checkpointer writes a
+// hex checkpoint line to the output file (or stdout) on every interval-th
+// invocation of fn -- or, when once is set, exactly once after the interval-th
+// invocation.  The returned closer must be invoked once execution has
+// completed.
+//
+// Switching a call to checkpointing only swaps its ENTER opcode (see
+// Program.AddCheckPoint), which is width-preserving; the resulting bytecode
+// layout is therefore identical to the unmodified program.  Captured
+// checkpoints thus share the original program's coordinates and resume directly
+// against it (see resumeFromCheckPoint).
+func newCheckPointInterpreter(wm *vm.WordMachine[vm.Uint], fn string, clk util.Counter, outputFile string,
+) (*vm.BytecodeInterpreter[vm.Uint128], func(), error) {
+	//
+	var (
+		m128    = vm.WordToWordMachine[vm.Uint, vm.Uint128](wm)
+		program = vm.WordToBytecodeProgram(m128)
+		// Checkpoints are written here: the output file (with -o) or stdout.
+		out    io.Writer = os.Stdout
+		closer           = func() {}
+	)
+	// When an output file is given, write checkpoints there instead of stdout.
+	if outputFile != "" {
+		f, err := os.Create(outputFile)
+		if err != nil {
+			return nil, nil, err
+		}
+		//
+		out = f
+		closer = func() { f.Close() }
+	}
+	// Locate the function whose calls are to be checkpointed.
+	fid, ok := program.HasModule(fn)
+	if !ok {
+		return nil, nil, fmt.Errorf("unknown function \"%s\"", fn)
+	}
+	// Switch every call to fn into a checkpointing call and build an
+	// interpreter for the result.
+	program = program.AddCheckPoint(fid)
+	interp := vm.NewBytecodeInterpreter(program, m128.Executor().Modulus())
+	// Write a checkpoint as a hex string, one per line.
+	emit := func(cp vm.CheckPoint[vm.Uint128]) {
+		bytes, err := cp.MarshalBinary()
+		if err != nil {
+			log.Errorf("encoding checkpoint: %s", err)
+			return
+		}
+		//
+		fmt.Fprintf(out, "0x%s\n", hex.EncodeToString(bytes))
+	}
+	// The counter fires every interval invocations of fn (see
+	// executeEnterCheckPoint_n).
+	interp.CheckPointer(clk, emit)
+	//
+	return interp, closer, nil
+}
+
+// readCheckPoint reads a single checkpoint, encoded as a hex string (optionally
+// 0x-prefixed) in the given file, and decodes it.
+func readCheckPoint(file string) (vm.CheckPoint[vm.Uint128], error) {
+	var cp vm.CheckPoint[vm.Uint128]
+	//
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return cp, err
+	}
+	// Tolerate surrounding whitespace and an optional 0x prefix.
+	text := strings.TrimPrefix(strings.TrimSpace(string(data)), "0x")
+	//
+	raw, err := hex.DecodeString(text)
+	if err != nil {
+		return cp, err
+	}
+	//
+	if err := cp.UnmarshalBinary(raw); err != nil {
+		return cp, err
+	}
+	//
+	return cp, nil
 }
 
 // executeWithGogen executes the word machine by generating native Go, compiling

--- a/pkg/cmd/zkc/flags.go
+++ b/pkg/cmd/zkc/flags.go
@@ -17,8 +17,51 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/LFDT-Lineth/zkc/pkg/util"
 	"github.com/spf13/cobra"
 )
+
+// FlagChecks provides some additional feature over the base flags package used
+// in Cobra.  Specifically, it allows to ensure certain flags are only used in
+// conjunction with others or, conversely, that certain flags cannot be used in
+// conjunction with others.
+type FlagChecks struct {
+	requires []util.Pair[string, string]
+	excludes []util.Pair[string, string]
+}
+
+// Require asserts that a given flag requires another flag to be set.
+func (p *FlagChecks) Require(flag, required string) {
+	p.requires = append(p.requires, util.Pair[string, string]{Left: flag, Right: required})
+}
+
+// Exclude asserts that two given flags cannot be used together.
+func (p *FlagChecks) Exclude(flag1, flag2 string) {
+	p.excludes = append(p.excludes, util.Pair[string, string]{Left: flag1, Right: flag2})
+}
+
+func checkFlags(cmd *cobra.Command, checks FlagChecks) {
+	// Check requires
+	for _, check := range checks.requires {
+		first := cmd.Flags().Changed(check.Left)
+
+		second := cmd.Flags().Changed(check.Right)
+		if first && !second {
+			fmt.Printf("error: \"--%s\" requires \"--%s\"\n", check.Left, check.Right)
+			os.Exit(1)
+		}
+	}
+	// Check excludes
+	for _, check := range checks.excludes {
+		first := cmd.Flags().Changed(check.Left)
+
+		second := cmd.Flags().Changed(check.Right)
+		if first && second {
+			fmt.Printf("error: \"--%s\" and \"--%s\" cannot be used together\n", check.Left, check.Right)
+			os.Exit(1)
+		}
+	}
+}
 
 // GetFlag gets an expected flag, or panic if an error arises.
 func GetFlag(cmd *cobra.Command, flag string) bool {

--- a/pkg/test/util/check_valid.go
+++ b/pkg/test/util/check_valid.go
@@ -299,9 +299,8 @@ func runCheckpointTests(t *testing.T, m *vm.WordMachine[vm.Uint], tc TestCase, f
 		// Run the test
 		switch w {
 		case vm.WORD_UINT:
-			runBytecodeExecutionTest(t, m, tc, w, cfg.bytecode)
 		case vm.WORD_UINT64:
-			runFixedWidthCheckpointTest[vm.Uint128](t, m, tc, cfg, w)
+			runFixedWidthCheckpointTest[vm.Uint64](t, m, tc, cfg, w)
 		case vm.WORD_UINT128:
 			runFixedWidthCheckpointTest[vm.Uint128](t, m, tc, cfg, w)
 		default:
@@ -319,6 +318,8 @@ func runFixedWidthCheckpointTest[W vm.Word[W]](t *testing.T, m *vm.WordMachine[v
 	if len(checkpoints) == 0 {
 		return
 	}
+	//
+	t.Logf("Generated %d checkpoints for %s", len(checkpoints), tc.filename)
 	//
 	var (
 		idx     = rand.Intn(len(checkpoints))

--- a/pkg/test/util/check_valid.go
+++ b/pkg/test/util/check_valid.go
@@ -15,8 +15,10 @@ package util
 import (
 	"encoding/hex"
 	"fmt"
+	"math/rand"
 	"testing"
 
+	"github.com/LFDT-Lineth/zkc/pkg/util"
 	"github.com/LFDT-Lineth/zkc/pkg/util/collection/array"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field/bls12_377"
@@ -63,6 +65,8 @@ type Config struct {
 	// enable quiet mode, which elides printf statements and calls to #[debug]
 	// functions during code generation.
 	quiet bool
+	// enable checkpoint testing.
+	checkpointing util.Option[util.Pair[string, util.Counter]]
 }
 
 // Fields determines which fields to test over.
@@ -93,6 +97,14 @@ func (p Config) Bytecode(flag bool) Config {
 // rather than failed (see runGogenExecutionTest).
 func (p Config) GoGen(flag bool) Config {
 	p.gogen = flag
+	//
+	return p
+}
+
+// Checkpoints enables checkpoint testing with checkpoints at every n ZkC
+// instructions.
+func (p Config) Checkpoints(fn string, n uint64) Config {
+	p.checkpointing = util.Some(util.NewPair(fn, util.NewCounter(n)))
 	//
 	return p
 }
@@ -178,6 +190,12 @@ func checkValidMachine(t *testing.T, m *vm.WordMachine[vm.Uint], cfg codegen.Con
 	for _, testcase := range tests {
 		runExecutionTests(t, m, testcase, cfg.GetField(), config)
 	}
+	// Run checkpointing tests (if requested)
+	if config.checkpointing.HasValue() {
+		for _, testcase := range tests {
+			runCheckpointTests(t, m, testcase, cfg.GetField(), config)
+		}
+	}
 	// Run constraint tests
 	if config.constraints {
 		for _, test := range tests {
@@ -201,7 +219,7 @@ func runExecutionTests(t *testing.T, m *vm.WordMachine[vm.Uint], tc TestCase, f 
 		case vm.WORD_UINT:
 			runBytecodeExecutionTest(t, m, tc, w, cfg.bytecode)
 		case vm.WORD_UINT64:
-			runFixedWidthExecutionTest[vm.Uint128](t, m, tc, cfg, w)
+			runFixedWidthExecutionTest[vm.Uint64](t, m, tc, cfg, w)
 		case vm.WORD_UINT128:
 			runFixedWidthExecutionTest[vm.Uint128](t, m, tc, cfg, w)
 		default:
@@ -262,6 +280,113 @@ func runExecutionTest[W vm.Word[W]](t *testing.T, wm vm.Core[W], test TestCase,
 	for _, err := range errs {
 		t.Errorf("[%s]%s:%d %v", cfg.Name, test.filename, test.line, err)
 	}
+}
+
+// runCheckpointTests exercises checkpoint/resume for a single test case.  The
+// program is first run, under the fast bytecode interpreter, to generate a
+// sequence of checkpoints (taken at the interval configured via
+// Config.Checkpoints).  One checkpoint is then chosen at random, a fresh
+// interpreter is resumed from it and run to completion, and the resulting
+// behaviour is checked against what the test expected.  Checkpoint testing is
+// (for now) restricted to the Uint128 word.
+func runCheckpointTests(t *testing.T, m *vm.WordMachine[vm.Uint], tc TestCase, f field.Config, cfg Config) {
+	for _, w := range cfg.words {
+		// Check for incompatible field/word combinations.  For example, we
+		// cannot emulate a 254bit field using a 64bit word.
+		if w.Bandwidth <= f.BandWidth {
+			continue
+		}
+		// Run the test
+		switch w {
+		case vm.WORD_UINT:
+			runBytecodeExecutionTest(t, m, tc, w, cfg.bytecode)
+		case vm.WORD_UINT64:
+			runFixedWidthCheckpointTest[vm.Uint128](t, m, tc, cfg, w)
+		case vm.WORD_UINT128:
+			runFixedWidthCheckpointTest[vm.Uint128](t, m, tc, cfg, w)
+		default:
+			panic(fmt.Sprintf("unknown machine word: %s", w.Name))
+		}
+	}
+}
+
+func runFixedWidthCheckpointTest[W vm.Word[W]](t *testing.T, m *vm.WordMachine[vm.Uint], tc TestCase,
+	cfg Config, w vm.WordConfig) {
+	//
+	program, checkpoints, outputs, modulus := bootAndCheckpoint[vm.Uint128](t, m, tc, w, cfg)
+	// Nothing to resume from (the checkpointed function ran fewer than the
+	// configured interval, or a reject test failed early): skip phase 2.
+	if len(checkpoints) == 0 {
+		return
+	}
+	//
+	var (
+		idx     = rand.Intn(len(checkpoints))
+		resumed = vm.NewBytecodeInterpreter(program, modulus)
+		errs    []error
+	)
+	// Phase 2: resume a fresh interpreter from a randomly-chosen checkpoint and
+	// run it to completion.  The resume runs against the *plain* program: the
+	// checkpoints share its coordinates (see Program.AddCheckPoint), and it has
+	// no checkpointing calls to re-trigger.
+	resumed.Restore(checkpoints[idx])
+	//
+	_, err := vm.ExecuteAll(resumed, 131072)
+	//
+	if err == nil && tc.expected {
+		// Resumed execution succeeded: check it produced the expected outputs.
+		errs = append(errs, checkExpectedOutputs(outputs, resumed)...)
+	} else if err == nil && !tc.expected {
+		errs = append(errs, fmt.Errorf("test accepted incorrectly"))
+	} else if tc.expected {
+		// Resumed execution failed, but the test was expected to pass.
+		errs = append(errs, err)
+	}
+	// Report any failures, noting which checkpoint was resumed from.
+	for _, err := range errs {
+		t.Errorf("[checkpoint:%s]%s:%d (checkpoint %d/%d) %v", w.Name, tc.filename, tc.line, idx, len(checkpoints), err)
+	}
+}
+
+func bootAndCheckpoint[W vm.Word[W]](t *testing.T, m *vm.WordMachine[vm.Uint], tc TestCase, w vm.WordConfig,
+	cfg Config) (vm.BytecodeProgram[W], []vm.CheckPoint[W], map[string][]W, W) {
+	//
+	var (
+		checkpoints     []vm.CheckPoint[W]
+		spec            = cfg.checkpointing.Unwrap()
+		fn              = spec.Left
+		counter         = spec.Right
+		m128            = vm.WordToWordMachine[vm.Uint, W](m)
+		program         = vm.WordToBytecodeProgram(m128)
+		modulus         = m128.Executor().Modulus()
+		inputs, outputs = decodeInputsOutputs(t, m128, tc.data)
+		err             error
+	)
+	// Locate the function whose calls are to be checkpointed.
+	fid, ok := program.HasModule(fn)
+	if !ok {
+		t.Errorf("[%s]%s:%d unknown checkpoint function %q", w.Name, tc.filename, tc.line, fn)
+		return program, nil, outputs, modulus
+	}
+	// Phase 1: run the program (with calls to fn switched into checkpointing
+	// calls) to completion, collecting the checkpoints it produces.
+	gen := vm.NewBytecodeInterpreter(program.AddCheckPoint(fid), modulus).
+		CheckPointer(counter, func(cp vm.CheckPoint[W]) {
+			checkpoints = append(checkpoints, cp)
+		})
+	//
+	if err = gen.Boot("main", inputs); err == nil {
+		_, err = vm.ExecuteAll(gen, 131072)
+	}
+	//
+	// An accepting test's generation run is the reference execution and must
+	// succeed; a rejecting test, by contrast, is expected to fail at some point.
+	if tc.expected && err != nil {
+		t.Errorf("[%s]%s:%d checkpoint generation failed: %v", w.Name, tc.filename, tc.line, err)
+		return program, nil, outputs, modulus
+	}
+	//
+	return program, checkpoints, outputs, modulus
 }
 
 func runConstraintTest(t *testing.T, wm *vm.WordMachine[vm.Uint], test TestCase, cfg codegen.Config) {

--- a/pkg/test/zkc_bench_test.go
+++ b/pkg/test/zkc_bench_test.go
@@ -45,7 +45,7 @@ func Test_ZkcBench_Fnv1aHash(t *testing.T) {
 }
 
 func Test_ZkcBench_Keccakf(t *testing.T) {
-	checkZkcBench(t, "zkc/bench/keccakf", DEFAULT_BENCH_CONFIG)
+	checkZkcBench(t, "zkc/bench/keccakf", DEFAULT_BENCH_CONFIG.Checkpoints("keccakf", 2))
 }
 
 // func Test_ZkcBench_KeccakfWithPadding(t *testing.T) {

--- a/pkg/test/zkc_bench_test.go
+++ b/pkg/test/zkc_bench_test.go
@@ -15,12 +15,12 @@ package test
 import (
 	"testing"
 
-	"github.com/LFDT-Lineth/zkc/pkg/test/util"
+	test_util "github.com/LFDT-Lineth/zkc/pkg/test/util"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm"
 )
 
 // DEFAULT_BENCH_CONFIG provides a default configuration for bench tests.
-var DEFAULT_BENCH_CONFIG = util.DEFAULT_CONFIG.
+var DEFAULT_BENCH_CONFIG = test_util.DEFAULT_CONFIG.
 	Words(vm.WORD_UINT128).
 	Bytecode(true).
 	GoGen(true)
@@ -64,7 +64,7 @@ func Test_ZkcBench_Keccakf(t *testing.T) {
 // }
 
 func Test_ZkcBench_Sort(t *testing.T) {
-	checkZkcBench(t, "zkc/bench/sort", DEFAULT_BENCH_CONFIG)
+	checkZkcBench(t, "zkc/bench/sort", DEFAULT_BENCH_CONFIG.Checkpoints("sort_slice", 5))
 }
 
 func Test_ZkcBench_LongDivision(t *testing.T) {
@@ -79,6 +79,6 @@ func Test_ZkcBench_DivRem(t *testing.T) {
 // Test Helpers
 // ===================================================================
 
-func checkZkcBench(t *testing.T, test string, config util.Config) {
-	util.CheckValid(t, test, "zkc", config)
+func checkZkcBench(t *testing.T, test string, config test_util.Config) {
+	test_util.CheckValid(t, test, "zkc", config)
 }

--- a/pkg/util/counter.go
+++ b/pkg/util/counter.go
@@ -1,0 +1,50 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package util
+
+import "math"
+
+// Counter is a simple countdown which fires (returns true from Tick) once every
+// `initial` ticks.  It begins at its initial value and, on each Tick,
+// decrements the current count; upon reaching zero it resets to the initial
+// value and reports true.  This is useful, for example, for triggering an
+// action periodically (e.g. taking a checkpoint every N instructions).
+type Counter struct {
+	// count is the number of ticks remaining until the counter next fires.
+	count uint64
+	// initial is the value to which count is reset whenever the counter fires.
+	initial uint64
+}
+
+// NewCounter constructs a counter which fires every n ticks.
+func NewCounter(n uint64) Counter {
+	return Counter{n, n}
+}
+
+// NewCounterOnce constructs a counter which fires once after n ticks.
+func NewCounterOnce(initial uint64) Counter {
+	return Counter{initial, math.MaxUint64}
+}
+
+// Tick decrements the counter, returning true if it has reached zero.  When it
+// fires, the counter is automatically reset to its initial value.
+func (p *Counter) Tick() bool {
+	p.count--
+	//
+	if p.count == 0 {
+		p.count = p.initial
+		return true
+	}
+	//
+	return false
+}

--- a/pkg/zkc/vm/bytecode.go
+++ b/pkg/zkc/vm/bytecode.go
@@ -32,3 +32,10 @@ type BytecodeProgram[W Word[W]] = bytecode.Program[W]
 func DecodeBytecodes[W word.Word[W]](program BytecodeProgram[W]) []Bytecode[W] {
 	return program.Bytecodes()
 }
+
+// NewBytecodeInterpreter constructs an interpreter for executing the given
+// bytecode program.  The modulus is the prime characteristic of the surrounding
+// field, used when executing native field instructions.
+func NewBytecodeInterpreter[W word.Word[W]](program BytecodeProgram[W], modulus W) *BytecodeInterpreter[W] {
+	return bytecode.NewInterpreter(program, modulus)
+}

--- a/pkg/zkc/vm/checkpoint.go
+++ b/pkg/zkc/vm/checkpoint.go
@@ -13,7 +13,8 @@
 package vm
 
 import (
-	"encoding"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/checkpoint"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/word"
 )
 
 // CheckPoint represents a captured state of an executing machine, such that
@@ -41,14 +42,4 @@ import (
 // steps of execution.  The purpose of this is to allow a program's execution to
 // be broken up into multiple checkpoints, such that each checkpoint only stores
 // the data it requires for executing its portion of the overall execution.
-type CheckPoint[W any] interface {
-	// Checkpoints must be convertable into bytes
-	encoding.BinaryMarshaler
-	// Checkpoints must be constructable from bytes
-	encoding.BinaryUnmarshaler
-	// ValidFor returns the number of execution steps for which this checkpoint
-	// is valid, or math.MaxUint64 if it is valid for all remaining steps.  We
-	// can expect that executing the machine beyond this number of steps will
-	// result in an execution which diverges from the original.
-	ValidFor() uint64
-}
+type CheckPoint[W word.Word[W]] = checkpoint.CheckPoint[W]

--- a/pkg/zkc/vm/internal/bytecode/arith.go
+++ b/pkg/zkc/vm/internal/bytecode/arith.go
@@ -15,6 +15,7 @@ package bytecode
 import (
 	"fmt"
 	"math/big"
+	"slices"
 	"strings"
 
 	"github.com/LFDT-Lineth/zkc/pkg/util/collection/array"
@@ -67,6 +68,11 @@ func (p *Arith[W]) String(mapping SystemMap) string {
 	}
 	//
 	return builder.String()
+}
+
+// Clone implementation for Bytecode / Patched interfaces.
+func (p *Arith[W]) Clone() Patched {
+	return &Arith[W]{p.Op, p.Constant, slices.Clone(p.Source), slices.Clone(p.Target)}
 }
 
 // Codes implementation for Bytecode interface

--- a/pkg/zkc/vm/internal/bytecode/bit.go
+++ b/pkg/zkc/vm/internal/bytecode/bit.go
@@ -38,6 +38,12 @@ func (p *Not) String(mapping SystemMap) string {
 	return fmt.Sprintf("not %s = ~%s [u%d]", target, source, p.Bitwidth)
 }
 
+// Clone implementation for Bytecode / Patched interfaces.
+func (p *Not) Clone() Patched {
+	var c = *p
+	return &c
+}
+
 // Codes implementation for Bytecode interface.
 func (p *Not) Codes(_ uint32) []uint32 {
 	return encodeNot(p.Target, p.Source, p.Bitwidth)
@@ -119,6 +125,12 @@ func (p *Bitwise) String(mapping SystemMap) string {
 	}
 	//
 	return fmt.Sprintf("%s %s = %s %s %s", prefix, target, left, bitwiseSymbol(p.Opcode), right)
+}
+
+// Clone implementation for Bytecode / Patched interfaces.
+func (p *Bitwise) Clone() Patched {
+	var c = *p
+	return &c
 }
 
 // Codes implementation for Bytecode interface.
@@ -207,6 +219,12 @@ func (p *Shift) String(mapping SystemMap) string {
 	}
 	//
 	return fmt.Sprintf("%s = %s %s %s [u%d]", target, source, symbol, amount, p.Bitwidth)
+}
+
+// Clone implementation for Bytecode / Patched interfaces.
+func (p *Shift) Clone() Patched {
+	var c = *p
+	return &c
 }
 
 // Codes implementation for Bytecode interface.

--- a/pkg/zkc/vm/internal/bytecode/bytecode.go
+++ b/pkg/zkc/vm/internal/bytecode/bytecode.go
@@ -95,6 +95,8 @@ const (
 	SGE_rr
 	// ENTER_n instruction
 	ENTER_n
+	// ENTERCP_n (enter and checkpoint) instruction
+	ENTERCP_n
 	// LEAVE_n instruction
 	LEAVE_n
 	// RET instruction
@@ -175,6 +177,8 @@ const (
 	CAT
 	// DEBUG instruction
 	DEBUG
+	// CHECKPOINT instruction (no operands)
+	CHECKPOINT
 	//
 	MAX_BYTECODE
 )
@@ -183,6 +187,10 @@ const (
 type Bytecode[W word.Word[W]] interface {
 	String(SystemMap) string
 	Codes(uint32) []uint32
+	// Clone returns a deep copy of this bytecode, sharing no mutable state (in
+	// particular, no operand slices) with the original.  See
+	// Program.AddCheckPoint.
+	Clone() Patched
 }
 
 // Patchable bytecodes contain a branch target which must be resolved during
@@ -204,6 +212,8 @@ type Patchable[W word.Word[W]] interface {
 type Patched interface {
 	String(SystemMap) string
 	Codes(uint32) []uint32
+	// Clone returns a deep copy of this bytecode (see Bytecode.Clone).
+	Clone() Patched
 }
 
 // ============================================================================
@@ -241,8 +251,8 @@ func AddVecConst[W word.Word[W]](targets []register.Id, sources []register.Id, c
 }
 
 // CallFun constructs a function-call bytecode.
-func CallFun(target Address, width uint16, args []register.Id, returns []register.Id) *Call {
-	return &Call{target, width, asRegs(args...), asRegs(returns...)}
+func CallFun(target Address, checkpoint bool, width uint16, args []register.Id, returns []register.Id) *Call {
+	return &Call{target, checkpoint, width, asRegs(args...), asRegs(returns...)}
 }
 
 // Jump creates an unconditional jump instruction transferring control to the

--- a/pkg/zkc/vm/internal/bytecode/call.go
+++ b/pkg/zkc/vm/internal/bytecode/call.go
@@ -15,6 +15,7 @@ package bytecode
 import (
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/word"
@@ -24,6 +25,8 @@ import (
 type Call struct {
 	// address of target function
 	Target Address
+	// CheckPoint indicates whether this is a checkpointing call (or not).
+	CheckPoint bool
 	// FrameWidth of target function
 	FrameWidth uint16
 	// Arguments are caller-frame registers copied into callee inputs.
@@ -47,30 +50,36 @@ func (p *Call) String(mapping SystemMap) string {
 	return builder.String()
 }
 
+// Clone implementation for Bytecode / Patched interfaces.
+func (p *Call) Clone() Patched {
+	return &Call{p.Target, p.CheckPoint, p.FrameWidth, slices.Clone(p.Arguments), slices.Clone(p.Returns)}
+}
+
 // Codes implementation for Bytecode interface.
 func (p *Call) Codes(pc uint32) (codes []uint32) {
 	// Encode enter
-	codes = append(codes, encodeEnter_n(pc, p.Target, p.FrameWidth, p.Arguments)...)
+	codes = append(codes, encodeEnter_n(pc, p.Target, p.CheckPoint, p.FrameWidth, p.Arguments)...)
 	// Encode leave
 	return append(codes, encodeLeave_n(p.Returns)...)
 }
 
 // Patch implementation for Patchable interface
 func (p *Call) Patch(labels []Address) Patched {
-	return &Call{labels[p.Target], p.FrameWidth, p.Arguments, p.Returns}
+	return &Call{labels[p.Target], p.CheckPoint, p.FrameWidth, p.Arguments, p.Returns}
 }
 
 // MaxWidth implementation for Patchable interface: the width of a call is
 // independent of where its target resolves (the relative offset always
 // occupies the same field), so it is computed against a dummy nearby target.
 func (p *Call) MaxWidth() uint32 {
-	var enter = encodeEnter_n(0, 1, p.FrameWidth, p.Arguments)
+	var enter = encodeEnter_n(0, 1, p.CheckPoint, p.FrameWidth, p.Arguments)
 	//
 	return uint32(len(enter) + len(encodeLeave_n(p.Returns)))
 }
 
 func decodeCall[W word.Word[W]](pc uint32, codes []uint32) (Bytecode[W], uint32) {
 	var (
+		checkpoint = (codes[pc] & OPCODE_MASK) == ENTERCP_n
 		// Decode ENTER
 		width, target, argsIter, n = decodeEnter_n(pc, codes)
 		// Decode LEAVE
@@ -80,7 +89,7 @@ func decodeCall[W word.Word[W]](pc uint32, codes []uint32) (Bytecode[W], uint32)
 		rets []Reg = OpIterToArray[uint16](retsIter)
 	)
 	// //
-	return &Call{target, width, args, rets}, n + m
+	return &Call{target, checkpoint, width, args, rets}, n + m
 }
 
 // NOTE: a call bytecode compiles down into a pair of instructions, ENTER/LEAVE.
@@ -106,7 +115,7 @@ func decodeCall[W word.Word[W]](pc uint32, codes []uint32) (Bytecode[W], uint32)
 // offset to the target.
 // ============================================================================
 
-func encodeEnter_n(pc, target uint32, width uint16, args []Reg) []uint32 {
+func encodeEnter_n(pc, target uint32, checkpoint bool, width uint16, args []Reg) []uint32 {
 	if width > math.MaxUint8 || len(args) > math.MaxUint8 {
 		panic("wide call instructions not supported")
 	}
@@ -114,14 +123,18 @@ func encodeEnter_n(pc, target uint32, width uint16, args []Reg) []uint32 {
 	var (
 		roff, ok = getRelativeOffset(pc, target, 16)
 		_width   = uint32(width) << 8
-		codes    = []uint32{roff<<16 | _width | ENTER_n}
 		bytes    = []uint8{uint8(len(args))}
+		opcode   = ENTER_n
 	)
 	// sanity check
 	if !ok {
 		panic("branch target overflow")
+	} else if checkpoint {
+		opcode = ENTERCP_n
 	}
-	//
+	// Determine full opcode
+	codes := []uint32{roff<<16 | _width | opcode}
+	// Generate register bytes
 	bytes = append(bytes, regsAsBytes(args)...)
 	//
 	return append(codes, packRegsIntoCodes(bytes)...)

--- a/pkg/zkc/vm/internal/bytecode/cat.go
+++ b/pkg/zkc/vm/internal/bytecode/cat.go
@@ -13,6 +13,7 @@
 package bytecode
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/LFDT-Lineth/zkc/pkg/schema/register"
@@ -42,6 +43,11 @@ func (p *Cat) String(mapping SystemMap) string {
 // Codes implementation for Bytecode interface.
 func (p *Cat) Codes(_ uint32) []uint32 {
 	return encodeCat(p.Targets, p.Sources)
+}
+
+// Clone implementation for Bytecode / Patched interfaces.
+func (p *Cat) Clone() Patched {
+	return &Cat{slices.Clone(p.Targets), slices.Clone(p.Sources)}
 }
 
 func decodeCat[W word.Word[W]](pc uint32, codes []uint32) (Bytecode[W], uint32) {

--- a/pkg/zkc/vm/internal/bytecode/checkcast.go
+++ b/pkg/zkc/vm/internal/bytecode/checkcast.go
@@ -42,6 +42,12 @@ func (p *CheckCast) String(mapping SystemMap) string {
 	return fmt.Sprintf("check %s:u%d", registerToString(p.Target, mapping), p.Bitwidth)
 }
 
+// Clone implementation for Bytecode / Patched interfaces.
+func (p *CheckCast) Clone() Patched {
+	var c = *p
+	return &c
+}
+
 // Codes implementation for Bytecode interface
 func (p *CheckCast) Codes(_ uint32) []uint32 {
 	var (

--- a/pkg/zkc/vm/internal/bytecode/debug.go
+++ b/pkg/zkc/vm/internal/bytecode/debug.go
@@ -13,6 +13,8 @@
 package bytecode
 
 import (
+	"slices"
+
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/instruction/base"
 )
 
@@ -41,6 +43,11 @@ func (p *Debug) String(mapping SystemMap) string {
 // side-table.
 func (p *Debug) Codes(_ uint32) []uint32 {
 	return []uint32{(p.Index << 8) | DEBUG}
+}
+
+// Clone implementation for Bytecode / Patched interfaces.
+func (p *Debug) Clone() Patched {
+	return &Debug{slices.Clone(p.Chunks), p.Index}
 }
 
 // NewDebug constructs a debug bytecode carrying the given formatted-print

--- a/pkg/zkc/vm/internal/bytecode/div.go
+++ b/pkg/zkc/vm/internal/bytecode/div.go
@@ -46,6 +46,12 @@ func (p *DivRem) String(mapping SystemMap) string {
 	return fmt.Sprintf("%s = %s %s %s", target, dividend, symbol, divisor)
 }
 
+// Clone implementation for Bytecode / Patched interfaces.
+func (p *DivRem) Clone() Patched {
+	var c = *p
+	return &c
+}
+
 // Codes implementation for Bytecode interface.
 func (p *DivRem) Codes(_ uint32) []uint32 {
 	return encodeDivRem(p.Opcode, p.Target, p.Dividend, p.Divisor)
@@ -115,6 +121,12 @@ func (p *DivHint) String(mapping SystemMap) string {
 	)
 	//
 	return fmt.Sprintf("%s::%s::%s = hint(%s, %s)", quotient, remainder, witness, dividend, divisor)
+}
+
+// Clone implementation for Bytecode / Patched interfaces.
+func (p *DivHint) Clone() Patched {
+	var c = *p
+	return &c
 }
 
 // Codes implementation for Bytecode interface.

--- a/pkg/zkc/vm/internal/bytecode/encoder.go
+++ b/pkg/zkc/vm/internal/bytecode/encoder.go
@@ -167,7 +167,7 @@ func (p *Encoder[W, T]) compile() (codes []uint32, symbols map[uint32]uint, chun
 		offset += uint32(len(cs))
 	}
 	// Sanity check the emitted codes decode consistently with the mapping.
-	verifyAlignment[W](codes, mapping, p.modules)
+	verifyAlignment[W](codes, mapping, p.modules, chunks)
 	//
 	return codes, symbols, chunks
 }
@@ -200,7 +200,8 @@ func indexFormattedBytecodes[W word.Word[W]](bytecodes []Bytecode[W]) [][]base.F
 // at execution time.  Note that a single bytecode may legitimately decode as
 // several instructions (e.g. an Arith with two sources and a constant), hence
 // boundaries are checked by inclusion rather than index-by-index.
-func verifyAlignment[W word.Word[W]](codes []uint32, mapping []uint32, modules []Module) {
+func verifyAlignment[W word.Word[W]](codes []uint32, mapping []uint32, modules []Module,
+	chunks [][]base.FormattedChunk) {
 	var (
 		rmap       = buildReverseMemoryMap[W](modules...)
 		offset     uint32
@@ -211,7 +212,7 @@ func verifyAlignment[W word.Word[W]](codes []uint32, mapping []uint32, modules [
 	for offset < uint32(len(codes)) {
 		boundaries[offset] = true
 		//
-		bc, n := decodeBytecode[W](offset, codes, rmap)
+		bc, n := decodeBytecode[W](offset, codes, rmap, chunks)
 		//
 		switch bc := bc.(type) {
 		case *Jmp:

--- a/pkg/zkc/vm/internal/bytecode/fail.go
+++ b/pkg/zkc/vm/internal/bytecode/fail.go
@@ -13,6 +13,8 @@
 package bytecode
 
 import (
+	"slices"
+
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/instruction/base"
 )
 
@@ -42,6 +44,11 @@ func (p *Fail) String(_ SystemMap) string {
 // above it, mirroring Debug.Codes' "(Index << 8) | DEBUG").
 func (p *Fail) Codes(_ uint32) []uint32 {
 	return []uint32{p.Index << 8}
+}
+
+// Clone implementation for Bytecode / Patched interfaces.
+func (p *Fail) Clone() Patched {
+	return &Fail{slices.Clone(p.Chunks), p.Index}
 }
 
 // NewFail constructs a fail bytecode carrying the given (possibly empty)

--- a/pkg/zkc/vm/internal/bytecode/field.go
+++ b/pkg/zkc/vm/internal/bytecode/field.go
@@ -14,6 +14,7 @@ package bytecode
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/LFDT-Lineth/zkc/pkg/schema/register"
@@ -65,6 +66,11 @@ func (p *FieldArith[W]) String(mapping SystemMap) string {
 // Codes implementation for Bytecode interface.
 func (p *FieldArith[W]) Codes(_ uint32) []uint32 {
 	return encodeFieldArith(p.Op, p.Target, p.Sources, p.Constant)
+}
+
+// Clone implementation for Bytecode / Patched interfaces.
+func (p *FieldArith[W]) Clone() Patched {
+	return &FieldArith[W]{p.Op, p.Target, slices.Clone(p.Sources), p.Constant}
 }
 
 func decodeFieldArith[W word.Word[W]](pc uint32, codes []uint32) (Bytecode[W], uint32) {

--- a/pkg/zkc/vm/internal/bytecode/interpreter.go
+++ b/pkg/zkc/vm/internal/bytecode/interpreter.go
@@ -238,8 +238,9 @@ func (p *Interpreter[W]) Outputs() iter.Iterator[memory.InputOutput[W]] {
 //     pushed on top so that the full active call chain is self-contained;
 //   - the data stack holding the activation records (registers) of all active
 //     frames;
-//   - a snapshot of every mutable memory.  Static and (non-static) read-only
-//     memories form the program's fixed inputs and so need not be captured.
+//   - a snapshot of every read-only input memory and every mutable memory.
+//     Static read-only memories form part of the fixed program and are not
+//     captured.
 //
 // The data and call stacks are copied so that the checkpoint is unaffected by
 // any subsequent execution of the interpreter.
@@ -252,7 +253,11 @@ func (p *Interpreter[W]) CheckPoint() checkpoint.CheckPoint[W] {
 	// Record the currently executing frame as the top of the call stack, so the
 	// checkpoint fully describes the active call chain.
 	callStack = append(callStack, checkpoint.NewStackFrame(p.fid, p.fp, p.pc))
-	// Snapshot mutable (write-once and random-access) memories.
+	// Snapshot read-only input memories and mutable memories.
+	for i := range p.roms {
+		memory = append(memory, p.snapshotMemory(&p.roms[i]))
+	}
+	//
 	for i := range p.woms {
 		memory = append(memory, p.snapshotMemory(&p.woms[i]))
 	}
@@ -268,9 +273,9 @@ func (p *Interpreter[W]) CheckPoint() checkpoint.CheckPoint[W] {
 	return checkpoint.NewCheckPoint(callStack, dataStack, memory)
 }
 
-// snapshotMemory captures the full contents of a (flat) mutable memory as a
-// single checkpoint page beginning at address zero.  The memory's module
-// identifier is recovered from the program by name.
+// snapshotMemory captures the full contents of a flat memory as a single
+// checkpoint page beginning at address zero.  The memory's module identifier is
+// recovered from the program by name.
 func (p *Interpreter[W]) snapshotMemory(mem memory.Memory[W]) checkpoint.Memory[W] {
 	var (
 		moduleId, _ = p.program.HasModule(mem.Name())
@@ -301,7 +306,7 @@ func (p *Interpreter[W]) snapshotPagedMemory(mem *memory.PagedRandomAccess[W]) c
 
 // Restore resets this interpreter to the state captured by the given checkpoint
 // (see CheckPoint), such that execution can resume from that point.  The call
-// stack, data stack and all mutable memories are overwritten; the currently
+// stack, data stack and all captured memories are overwritten; the currently
 // executing frame (the top of the checkpoint's call stack) is unpacked into the
 // active fid/fp/pc.  The checkpoint's slices are copied into the interpreter, so
 // the checkpoint remains valid for subsequent restores.
@@ -332,18 +337,26 @@ func (p *Interpreter[W]) Restore(cp checkpoint.CheckPoint[W]) {
 	p.dataStack.Clear()
 	p.dataStack.Alloc(uint(len(data)))
 	copy(p.dataStack.SliceEnd(0), data)
-	// Restore mutable memories.
+	// Restore captured memories.
 	for _, m := range cp.Memories() {
 		p.restoreMemory(m)
 	}
 }
 
 // restoreMemory overwrites the contents of the live memory identified by the
-// snapshot's module identifier.  The memory is first cleared, then each captured
-// page is written back at its recorded address.  Writing page-by-page preserves
-// the sparse layout of paged memories (only captured pages are materialised).
+// snapshot's module identifier.  Read-only input memories are restored by
+// replacing their flat contents directly, whilst mutable memories are first
+// cleared and then each captured page is written back at its recorded address.
+// Writing page-by-page preserves the sparse layout of paged memories (only
+// captured pages are materialised).
 func (p *Interpreter[W]) restoreMemory(m checkpoint.Memory[W]) {
 	var mem = p.findMemory(p.program.Module(m.ModuleId()).Name())
+	// Read-only memories cannot be written cell-by-cell; checkpoint snapshots
+	// for ROMs are flat pages, so restore them by replacing the contents.
+	if mem.IsReadOnly() {
+		mem.Initialise(flattenMemory(m.Pages()))
+		return
+	}
 	// Clear any existing contents.
 	mem.Initialise(nil)
 	// Write back each captured page.
@@ -359,11 +372,35 @@ func (p *Interpreter[W]) restoreMemory(m checkpoint.Memory[W]) {
 	}
 }
 
-// findMemory locates the live mutable memory with the given module name amongst
-// the write-once, random-access and paged random-access memories.  It panics if
-// no such memory exists, as a checkpoint should only ever reference memories
-// belonging to the program being executed.
+// flattenMemory converts a page-based checkpoint snapshot into flat contents.
+// This is used for ROMs, whose checkpoint snapshots are full flat pages.
+func flattenMemory[W word.Word[W]](pages []checkpoint.Page[W]) []W {
+	var size uint64
+	//
+	for _, page := range pages {
+		size = max(size, page.Address()+uint64(len(page.Data())))
+	}
+	//
+	contents := make([]W, size)
+	//
+	for _, page := range pages {
+		copy(contents[page.Address():], page.Data())
+	}
+	//
+	return contents
+}
+
+// findMemory locates the live checkpointable memory with the given module name
+// amongst the read-only input, write-once, random-access and paged random-access
+// memories.  It panics if no such memory exists, as a checkpoint should only
+// ever reference memories belonging to the program being executed.
 func (p *Interpreter[W]) findMemory(name string) memory.Memory[W] {
+	for i := range p.roms {
+		if p.roms[i].Name() == name {
+			return &p.roms[i]
+		}
+	}
+	//
 	for i := range p.woms {
 		if p.woms[i].Name() == name {
 			return &p.woms[i]

--- a/pkg/zkc/vm/internal/bytecode/interpreter.go
+++ b/pkg/zkc/vm/internal/bytecode/interpreter.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"slices"
 	"strings"
 
 	"github.com/LFDT-Lineth/zkc/pkg/schema/register"
@@ -25,6 +26,7 @@ import (
 	"github.com/LFDT-Lineth/zkc/pkg/util/collection/iter"
 	zkc_util "github.com/LFDT-Lineth/zkc/pkg/zkc/util"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/instruction/base"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/checkpoint"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/memory"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/word"
 )
@@ -88,6 +90,13 @@ type Interpreter[W word.Word[W]] struct {
 	// (Large) paged random-access memories which may be freely read and
 	// written.
 	prams []memory.PagedRandomAccess[W]
+	// Optional callback invoked when a CHECKPOINT bytecode is executed, passed a
+	// snapshot of the current machine state (see CheckPoint).  Configured via
+	// the CheckPointer builder method; nil if no checkpointer has been set.
+	checkpointer func(checkpoint.CheckPoint[W])
+	// Counter governing how frequently the checkpointer fires.  Configured
+	// alongside the checkpointer via the CheckPointer builder method.
+	counter util.Counter
 }
 
 // StackFrame captures relevant information about all functions currently
@@ -95,14 +104,7 @@ type Interpreter[W word.Word[W]] struct {
 // being executed.  The purpose of a stack frame is to record the Frame Pointer
 // (FP) and Program Counter (PC) of the relevant function so that these can be
 // restored when it becomes the active function.
-type StackFrame struct {
-	// DEPRECATED
-	fid uint
-	// frame pointer of the executing function.
-	fp uint32
-	// program counter identifies next bytecode to execute.
-	pc uint32
-}
+type StackFrame = checkpoint.StackFrame
 
 // NewInterpreter constructs a new bytecode interpreter for the given program.
 // The program's memory modules are partitioned by access discipline (static
@@ -149,7 +151,29 @@ func NewInterpreter[W word.Word[W]](program Program[W], modulus W) *Interpreter[
 		woms:    woms,
 		rams:    rams,
 		prams:   prams,
+		// Default checkpointer: panics until a real one is configured via
+		// CheckPointer, since a CHECKPOINT bytecode is meaningless without one.
+		checkpointer: func(checkpoint.CheckPoint[W]) {
+			panic("no checkpointer configured")
+		},
+		// Default counter fires on every CHECKPOINT, so an unconfigured
+		// interpreter reaches the panicking default checkpointer above.
+		counter: util.NewCounter(1),
 	}
+}
+
+// CheckPointer configures the callback invoked whenever a CHECKPOINT bytecode
+// is executed, passing it a snapshot of the current machine state (see
+// CheckPoint).  The given counter initialises the interpreter's checkpoint
+// counter, governing how frequently the checkpointer fires.  It returns the
+// interpreter to allow method chaining.
+func (p *Interpreter[W]) CheckPointer(counter util.Counter,
+	checkpointer func(checkpoint.CheckPoint[W])) *Interpreter[W] {
+	//
+	p.counter = counter
+	p.checkpointer = checkpointer
+	//
+	return p
 }
 
 // Boot implementation of Core interface.  This locates the named function,
@@ -206,6 +230,161 @@ func (p *Interpreter[W]) Outputs() iter.Iterator[memory.InputOutput[W]] {
 	return iter.NewArrayIterator(outputs)
 }
 
+// CheckPoint captures the current state of this interpreter as a checkpoint,
+// from which execution can later be resumed (see checkpoint.CheckPoint).  The
+// returned checkpoint records:
+//
+//   - the call stack of paused callers, with the currently executing frame
+//     pushed on top so that the full active call chain is self-contained;
+//   - the data stack holding the activation records (registers) of all active
+//     frames;
+//   - a snapshot of every mutable memory.  Static and (non-static) read-only
+//     memories form the program's fixed inputs and so need not be captured.
+//
+// The data and call stacks are copied so that the checkpoint is unaffected by
+// any subsequent execution of the interpreter.
+func (p *Interpreter[W]) CheckPoint() checkpoint.CheckPoint[W] {
+	var (
+		callStack = slices.Clone(p.callStack.SliceEnd(0))
+		dataStack = slices.Clone(p.dataStack.SliceEnd(0))
+		memory    []checkpoint.Memory[W]
+	)
+	// Record the currently executing frame as the top of the call stack, so the
+	// checkpoint fully describes the active call chain.
+	callStack = append(callStack, checkpoint.NewStackFrame(p.fid, p.fp, p.pc))
+	// Snapshot mutable (write-once and random-access) memories.
+	for i := range p.woms {
+		memory = append(memory, p.snapshotMemory(&p.woms[i]))
+	}
+	//
+	for i := range p.rams {
+		memory = append(memory, p.snapshotMemory(&p.rams[i]))
+	}
+	//
+	for i := range p.prams {
+		memory = append(memory, p.snapshotPagedMemory(&p.prams[i]))
+	}
+	//
+	return checkpoint.NewCheckPoint(callStack, dataStack, memory)
+}
+
+// snapshotMemory captures the full contents of a (flat) mutable memory as a
+// single checkpoint page beginning at address zero.  The memory's module
+// identifier is recovered from the program by name.
+func (p *Interpreter[W]) snapshotMemory(mem memory.Memory[W]) checkpoint.Memory[W] {
+	var (
+		moduleId, _ = p.program.HasModule(mem.Name())
+		page        = checkpoint.NewPage(0, slices.Clone(mem.Contents()))
+	)
+	//
+	return checkpoint.NewMemory(moduleId, []checkpoint.Page[W]{page})
+}
+
+// snapshotPagedMemory captures a paged random-access memory as one checkpoint
+// page per allocated memory page, preserving the sparse layout: page i in the
+// backing table begins at physical address i*PAGE_SIZE.  Pages which have never
+// been written (nil) are omitted.  The memory's module identifier is recovered
+// from the program by name.
+func (p *Interpreter[W]) snapshotPagedMemory(mem *memory.PagedRandomAccess[W]) checkpoint.Memory[W] {
+	var (
+		moduleId, _ = p.program.HasModule(mem.Name())
+		pages       []checkpoint.Page[W]
+	)
+	//
+	for it := mem.Pages(); it.HasNext(); {
+		// Clone each page, as Pages references the live backing slices.
+		pages = append(pages, it.Next().Clone())
+	}
+	//
+	return checkpoint.NewMemory(moduleId, pages)
+}
+
+// Restore resets this interpreter to the state captured by the given checkpoint
+// (see CheckPoint), such that execution can resume from that point.  The call
+// stack, data stack and all mutable memories are overwritten; the currently
+// executing frame (the top of the checkpoint's call stack) is unpacked into the
+// active fid/fp/pc.  The checkpoint's slices are copied into the interpreter, so
+// the checkpoint remains valid for subsequent restores.
+func (p *Interpreter[W]) Restore(cp checkpoint.CheckPoint[W]) {
+	var (
+		frames = cp.CallStack()
+		// The topmost frame records the currently executing function (see
+		// CheckPoint); the remainder are the paused callers.
+		active = frames[len(frames)-1]
+	)
+	// Restore the active frame.
+	p.fid = active.FunctionId
+	p.fp = active.FramePointer
+	p.pc = active.ProgramCounter
+	// Reset the return pointer/width: these are transient and meaningful only
+	// mid-return, so a checkpoint never captures an in-flight value.
+	p.rp = 0
+	p.rw = 0
+	// Restore the paused callers.
+	p.callStack.Clear()
+	//
+	for _, f := range frames[:len(frames)-1] {
+		p.callStack.Push(f)
+	}
+	// Restore the data stack.
+	var data = cp.DataStack()
+
+	p.dataStack.Clear()
+	p.dataStack.Alloc(uint(len(data)))
+	copy(p.dataStack.SliceEnd(0), data)
+	// Restore mutable memories.
+	for _, m := range cp.Memories() {
+		p.restoreMemory(m)
+	}
+}
+
+// restoreMemory overwrites the contents of the live memory identified by the
+// snapshot's module identifier.  The memory is first cleared, then each captured
+// page is written back at its recorded address.  Writing page-by-page preserves
+// the sparse layout of paged memories (only captured pages are materialised).
+func (p *Interpreter[W]) restoreMemory(m checkpoint.Memory[W]) {
+	var mem = p.findMemory(p.program.Module(m.ModuleId()).Name())
+	// Clear any existing contents.
+	mem.Initialise(nil)
+	// Write back each captured page.
+	for _, page := range m.Pages() {
+		var address = page.Address()
+		//
+		for _, w := range page.Data() {
+			//nolint
+			mem.Write(address, w)
+			//
+			address++
+		}
+	}
+}
+
+// findMemory locates the live mutable memory with the given module name amongst
+// the write-once, random-access and paged random-access memories.  It panics if
+// no such memory exists, as a checkpoint should only ever reference memories
+// belonging to the program being executed.
+func (p *Interpreter[W]) findMemory(name string) memory.Memory[W] {
+	for i := range p.woms {
+		if p.woms[i].Name() == name {
+			return &p.woms[i]
+		}
+	}
+	//
+	for i := range p.rams {
+		if p.rams[i].Name() == name {
+			return &p.rams[i]
+		}
+	}
+	//
+	for i := range p.prams {
+		if p.prams[i].Name() == name {
+			return &p.prams[i]
+		}
+	}
+	//
+	panic(fmt.Sprintf("unknown memory \"%s\"", name))
+}
+
 // Execute implementation of Core interface.  This runs the central fetch-decode-
 // dispatch loop: each iteration reads the bytecode at the current program
 // counter, extracts its opcode, and dispatches to the corresponding executor
@@ -236,6 +415,14 @@ func (p *Interpreter[W]) Execute(steps uint) (uint, error) {
 		case DEBUG:
 			p.executeDebug(bytecodes[p.pc], frame)
 			p.pc++
+		case CHECKPOINT:
+			// Advance past CHECKPOINT before snapshotting, so any captured state
+			// resumes at the following instruction rather than re-checkpointing.
+			p.pc++
+			// Only fire the checkpointer once every counter period.
+			if p.counter.Tick() {
+				p.checkpointer(p.CheckPoint())
+			}
 		case LDC:
 			p.pc = executeLdc_1(p.pc, bytecodes, frame)
 		case LDC_w:
@@ -244,6 +431,10 @@ func (p *Interpreter[W]) Execute(steps uint) (uint, error) {
 			p.pc = executeMove_1s1(p.pc, bytecodes, frame)
 		case ENTER_n:
 			err = p.executeEnter_n(p.pc, bytecodes, frame)
+			// refresh the register window.
+			frame = p.dataStack.SliceEnd(uint(p.fp))
+		case ENTERCP_n:
+			err = p.executeEnterCheckPoint_n(p.pc, bytecodes, frame)
 			// refresh the register window.
 			frame = p.dataStack.SliceEnd(uint(p.fp))
 		case LEAVE_n:
@@ -417,7 +608,7 @@ func (p *Interpreter[W]) executeEnter_n(pc uint32, codes []uint32, stack []W) er
 	// allocate callee frame
 	p.dataStack.Alloc(uint(width))
 	// save function pointer and return address
-	p.callStack.Push(StackFrame{p.fid, p.fp, p.pc + n})
+	p.callStack.Push(checkpoint.NewStackFrame(p.fid, p.fp, p.pc+n))
 	// copy arguments into callee frame
 	for i := uint(calleeFp); args.HasNext(); i++ {
 		p.dataStack.Set(i, stack[args.Next()])
@@ -428,6 +619,17 @@ func (p *Interpreter[W]) executeEnter_n(pc uint32, codes []uint32, stack []W) er
 	p.pc = target
 	//
 	return nil
+}
+
+func (p *Interpreter[W]) executeEnterCheckPoint_n(pc uint32, codes []uint32, stack []W) error {
+	// Enter checkpoint function
+	err := p.executeEnter_n(pc, codes, stack)
+	// Only fire the checkpointer once every counter period.
+	if p.counter.Tick() {
+		p.checkpointer(p.CheckPoint())
+	}
+	//
+	return err
 }
 
 func (p *Interpreter[W]) executeLeave_n(pc uint32, codes []uint32, stack []W) uint32 {
@@ -450,12 +652,12 @@ func (p *Interpreter[W]) executeReturn(pc uint32, codes []uint32) (uint32, error
 		width, roffset, _ = decodeRet1(pc, codes)
 	)
 	//
-	p.fid = frame.fid // FIXME: remove
+	p.fid = frame.FunctionId // FIXME: remove
 	p.rp = p.fp + uint32(roffset)
 	p.rw = uint32(width)
-	p.fp = frame.fp
+	p.fp = frame.FramePointer
 	//
-	return frame.pc, nil
+	return frame.ProgramCounter, nil
 }
 
 // executeAdd_nm implements ADD_nm: it sums the constant and all sources and

--- a/pkg/zkc/vm/internal/bytecode/jif.go
+++ b/pkg/zkc/vm/internal/bytecode/jif.go
@@ -54,6 +54,12 @@ func (p *Jif) String(mapping SystemMap) string {
 	return fmt.Sprintf("jif %s %s %s 0x%08x", src0, ops, src1, p.Target)
 }
 
+// Clone implementation for Bytecode / Patched interfaces.
+func (p *Jif) Clone() Patched {
+	var c = *p
+	return &c
+}
+
 // Codes implementation for Bytecode interface
 func (p *Jif) Codes(offset uint32) []uint32 {
 	var (

--- a/pkg/zkc/vm/internal/bytecode/jmp.go
+++ b/pkg/zkc/vm/internal/bytecode/jmp.go
@@ -21,6 +21,12 @@ func (p *Jmp) String(_ SystemMap) string {
 	return fmt.Sprintf("jmp 0x%08x", p.Target)
 }
 
+// Clone implementation for Bytecode / Patched interfaces.
+func (p *Jmp) Clone() Patched {
+	var c = *p
+	return &c
+}
+
 // Codes implementation for Bytecode interface
 func (p *Jmp) Codes(pc uint32) []uint32 {
 	// Forward branches are preferred as SKIP instructions, whose offset is

--- a/pkg/zkc/vm/internal/bytecode/program.go
+++ b/pkg/zkc/vm/internal/bytecode/program.go
@@ -14,6 +14,7 @@ package bytecode
 
 import (
 	"math"
+	"slices"
 
 	"github.com/LFDT-Lineth/zkc/pkg/util"
 	"github.com/LFDT-Lineth/zkc/pkg/util/collection/array"
@@ -67,9 +68,12 @@ func (p Program[W]) Chunks(index uint32) []base.FormattedChunk {
 }
 
 // Bytecodes decodes this program into a more human-friendly representation.
-// Observe that this decoding procedure is non-trivial, and may allocate memory.
-// As such, it should not be used when performance is critical.  In such
-// situations, direct decoding should be preferred.
+// The decoding is faithful: re-encoding the result (via each bytecode's Codes
+// method) reproduces this program's words exactly, including the side-table
+// indices and formatted-message chunks of any DEBUG / FAIL sites.  Observe that
+// this decoding procedure is non-trivial, and may allocate memory.  As such, it
+// should not be used when performance is critical.  In such situations, direct
+// decoding should be preferred.
 func (p Program[W]) Bytecodes() (bytecodes []Bytecode[W]) {
 	var (
 		rmap   = buildReverseMemoryMap[W](p.modules...)
@@ -78,7 +82,7 @@ func (p Program[W]) Bytecodes() (bytecodes []Bytecode[W]) {
 	)
 	//
 	for offset < ncodes {
-		bc, n := decodeBytecode[W](offset, p.bytecodes, rmap)
+		bc, n := decodeBytecode[W](offset, p.bytecodes, rmap, p.chunks)
 		bytecodes = append(bytecodes, bc)
 		offset += n
 	}
@@ -129,7 +133,55 @@ func (p Program[W]) Modules() []Module {
 	return p.modules
 }
 
-func decodeBytecode[W word.Word[W]](pc uint32, codes []uint32, rmap map[MemoryId]uint16) (Bytecode[W], uint32) {
+// AddCheckPoint returns a copy of this program in which all calls to the target
+// function are "checkpointing calls" (i.e. have their CheckPoint field set).
+// Switching a call to checkpointing only swaps its ENTER opcode (ENTER_n =>
+// ENTERCP_n), which is width-preserving; hence every instruction offset --
+// along with the symbol and chunk side-tables -- is unaffected, and the
+// returned program shares those tables with the original.
+func (p Program[W]) AddCheckPoint(fid uint) Program[W] {
+	var (
+		// Clone of the raw words: only matching ENTER words are rewritten, and
+		// always in place (see above), so the remaining words are untouched.
+		bytecodes = slices.Clone(p.bytecodes)
+		rmap      = buildReverseMemoryMap[W](p.modules...)
+		offset    uint32
+	)
+	// Determine the entry address of the target function.  If it has none (e.g.
+	// it is never marked, or fid does not name a function), there are no calls
+	// to rewrite and the clone is returned unchanged.
+	target, ok := p.AddressOf(fid)
+	//
+	for ok && offset < uint32(len(bytecodes)) {
+		bc, n := decodeBytecode[W](offset, bytecodes, rmap, p.chunks)
+		// Switch on checkpointing for any call to the target function, then
+		// re-encode it in place over its original words.
+		if call, isCall := bc.(*Call); isCall && call.Target == target {
+			call.CheckPoint = true
+			cs := call.Codes(offset)
+			// Sanity check: switching on checkpointing must not resize the call.
+			if uint32(len(cs)) != n {
+				panic("checkpointing call changed its encoded width")
+			}
+			//
+			copy(bytecodes[offset:], cs)
+		}
+		//
+		offset += n
+	}
+	//
+	return NewProgram[W](p.modules, bytecodes, p.constants, p.symbols, p.chunks)
+}
+
+// decodeBytecode decodes the single bytecode beginning at pc into its
+// higher-level representation, returning it together with the number of words
+// consumed.  Decoding is faithful: re-encoding the result via its Codes method
+// reproduces the original words exactly.  In particular, DEBUG and FAIL recover
+// both their side-table index (packed into the word) and the formatted-message
+// chunks it points at, so they round-trip without loss; chunks is the program's
+// chunk side-table (see Program.chunks).
+func decodeBytecode[W word.Word[W]](pc uint32, codes []uint32, rmap map[MemoryId]uint16,
+	chunks [][]base.FormattedChunk) (Bytecode[W], uint32) {
 	var (
 		code = codes[pc]
 	)
@@ -145,9 +197,11 @@ func decodeBytecode[W word.Word[W]](pc uint32, codes []uint32, rmap map[MemoryId
 		rd, width, n := decodeCheckCast(pc, codes)
 		return &CheckCast{width, rd}, n
 	case DEBUG:
-		return &Debug{}, 1
+		index := code >> 8
+		return &Debug{Chunks: chunks[index], Index: index}, 1
 	case FAIL:
-		return &Fail{}, 1
+		index := code >> 8
+		return &Fail{Chunks: chunks[index], Index: index}, 1
 	case JMP:
 		target, n := decodeJmp1(pc, codes)
 		return &Jmp{Target: target}, n

--- a/pkg/zkc/vm/internal/bytecode/readwrite.go
+++ b/pkg/zkc/vm/internal/bytecode/readwrite.go
@@ -15,6 +15,7 @@ package bytecode
 import (
 	"fmt"
 	"math"
+	"slices"
 
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/word"
 )
@@ -120,6 +121,11 @@ func (p *ReadWrite) String(mapping SystemMap) string {
 func (p *ReadWrite) Codes(_ uint32) []uint32 {
 	//
 	return encodeReadWrite_sn(p.Mode, p.Id, p.Address, p.Data)
+}
+
+// Clone implementation for Bytecode / Patched interfaces.
+func (p *ReadWrite) Clone() Patched {
+	return &ReadWrite{p.Mode, p.Id, slices.Clone(p.Address), slices.Clone(p.Data)}
 }
 
 func decodeReadWrite[W word.Word[W]](pc uint32, codes []uint32, rmap map[MemoryId]uint16) (Bytecode[W], uint32) {

--- a/pkg/zkc/vm/internal/bytecode/ret.go
+++ b/pkg/zkc/vm/internal/bytecode/ret.go
@@ -45,6 +45,12 @@ func (p *Ret) String(_ SystemMap) string {
 	return fmt.Sprintf("ret %d/%d", p.ReturnOffset, p.FrameWidth)
 }
 
+// Clone implementation for Bytecode / Patched interfaces.
+func (p *Ret) Clone() Patched {
+	var c = *p
+	return &c
+}
+
 // Codes implementation for Bytecode interface
 func (p *Ret) Codes(_ uint32) []uint32 {
 	return encodeRet1(p.FrameWidth, p.ReturnOffset)

--- a/pkg/zkc/vm/internal/bytecode/switch.go
+++ b/pkg/zkc/vm/internal/bytecode/switch.go
@@ -14,6 +14,7 @@ package bytecode
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/word"
@@ -68,6 +69,11 @@ func (p *Switch) String(_ SystemMap) string {
 	b.WriteString("]")
 	//
 	return b.String()
+}
+
+// Clone implementation for Bytecode / Patched interfaces.
+func (p *Switch) Clone() Patched {
+	return &Switch{p.Source, slices.Clone(p.Cases)}
 }
 
 // Codes implementation for Bytecode interface.

--- a/pkg/zkc/vm/internal/checkpoint/checkpoint.go
+++ b/pkg/zkc/vm/internal/checkpoint/checkpoint.go
@@ -5,6 +5,7 @@
 package checkpoint
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -44,12 +45,12 @@ type CheckPoint[W word.Word[W]] struct {
 	// Data stack holding the activation records (registers) of active function
 	// calls.  The current frame begins at fp.
 	dataStack []W
-	// Snapshot of all mutable Memory.
+	// Snapshot of all checkpointed memories.
 	memory []Memory[W]
 }
 
 // NewCheckPoint constructs a checkpoint from a snapshot of the call stack, data
-// stack and mutable memories of an executing machine.  The provided slices are
+// stack and memories of an executing machine.  The provided slices are
 // retained by reference, so callers which intend to continue mutating the
 // underlying storage (e.g. an interpreter's live stacks) should pass copies.
 func NewCheckPoint[W word.Word[W]](callStack []StackFrame, dataStack []W, memory []Memory[W]) CheckPoint[W] {
@@ -67,7 +68,7 @@ func (p CheckPoint[W]) DataStack() []W {
 	return p.dataStack
 }
 
-// Memories returns the captured snapshots of all mutable memories.
+// Memories returns the captured memory snapshots.
 func (p CheckPoint[W]) Memories() []Memory[W] {
 	return p.memory
 }
@@ -96,23 +97,17 @@ func NewStackFrame(fid uint, fp uint32, pc uint32) StackFrame {
 // Encoding / Decoding
 // ============================================================================
 //
-// A checkpoint is serialised into a flat byte sequence using a big-endian
-// layout.  Counts, identifiers and addresses are written as fixed-width
-// integers, whilst each word is written using exactly bytesPerWord(W) bytes
-// (derived from the word type's Bandwidth).  The bytes-per-word is itself
-// written as the first field, so that unmarshalling can sanity check that the
-// data was produced for a word type of the expected width.
+// A checkpoint is serialised into a flat byte sequence beginning with
+// checkpointHeader.  Counts, identifiers and addresses are written as fixed-
+// width big-endian integers, whilst each word is written as an unsigned
+// LEB128-style variable-length integer.
+
+var checkpointHeader = []byte{'Z', 'K', 'C', 'P', 1}
 
 // MarshalBinary implements encoding.BinaryMarshaler, serialising this checkpoint
-// into a flat big-endian byte sequence (see above).
+// into the checkpoint format (see above).
 func (p CheckPoint[W]) MarshalBinary() ([]byte, error) {
-	var (
-		buf   []byte
-		nbits = bytesPerWord[W]()
-		tmp   = make([]byte, nbits)
-	)
-	// Bytes-per-word: written first so it can be validated on unmarshalling.
-	buf = binary.BigEndian.AppendUint32(buf, uint32(nbits))
+	buf := append([]byte{}, checkpointHeader...)
 	// Call stack: count followed by each frame.
 	buf = binary.BigEndian.AppendUint32(buf, uint32(len(p.callStack)))
 	//
@@ -125,7 +120,11 @@ func (p CheckPoint[W]) MarshalBinary() ([]byte, error) {
 	buf = binary.BigEndian.AppendUint32(buf, uint32(len(p.dataStack)))
 	//
 	for _, w := range p.dataStack {
-		buf = append(buf, w.BigInt().FillBytes(tmp)...)
+		var err error
+		//
+		if buf, err = appendUvarWord(buf, w); err != nil {
+			return nil, err
+		}
 	}
 	// Memories: count followed by each memory.
 	buf = binary.BigEndian.AppendUint32(buf, uint32(len(p.memory)))
@@ -139,7 +138,11 @@ func (p CheckPoint[W]) MarshalBinary() ([]byte, error) {
 			buf = binary.BigEndian.AppendUint32(buf, uint32(len(pg.data)))
 			//
 			for _, w := range pg.data {
-				buf = append(buf, w.BigInt().FillBytes(tmp)...)
+				var err error
+				//
+				if buf, err = appendUvarWord(buf, w); err != nil {
+					return nil, err
+				}
 			}
 		}
 	}
@@ -150,19 +153,22 @@ func (p CheckPoint[W]) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary implements encoding.BinaryUnmarshaler, reconstructing a
 // checkpoint previously serialised by MarshalBinary.
 func (p *CheckPoint[W]) UnmarshalBinary(data []byte) error {
-	var (
-		r     = &reader{data: data}
-		nbits = bytesPerWord[W]()
-		err   error
-		n     uint32
-	)
-	// Bytes-per-word: validate the data was produced for a word type of the
-	// expected width before decoding anything else.
-	if n, err = r.uint32(); err != nil {
-		return err
-	} else if n != uint32(nbits) {
-		return fmt.Errorf("invalid checkpoint: expected %d bytes-per-word, got %d", nbits, n)
+	if !bytes.HasPrefix(data, checkpointHeader) {
+		return fmt.Errorf("invalid checkpoint: missing header")
 	}
+	//
+	data = data[len(checkpointHeader):]
+	//
+	return p.unmarshalFromReader(&reader{data: data}, readUvarWord[W])
+}
+
+// unmarshalFromReader decodes the checkpoint payload.  The supplied readWord
+// function handles the word representation.
+func (p *CheckPoint[W]) unmarshalFromReader(r *reader, readWord func(*reader) (W, error)) error {
+	var (
+		err error
+		n   uint32
+	)
 	// Call stack.
 	if n, err = r.uint32(); err != nil {
 		return err
@@ -196,7 +202,7 @@ func (p *CheckPoint[W]) UnmarshalBinary(data []byte) error {
 	dataStack := make([]W, n)
 	//
 	for i := range dataStack {
-		if dataStack[i], err = readWord[W](r, nbits); err != nil {
+		if dataStack[i], err = readWord(r); err != nil {
 			return err
 		}
 	}
@@ -208,7 +214,7 @@ func (p *CheckPoint[W]) UnmarshalBinary(data []byte) error {
 	memory := make([]Memory[W], n)
 	//
 	for i := range memory {
-		if memory[i], err = readMemory[W](r, nbits); err != nil {
+		if memory[i], err = readMemory(r, readWord); err != nil {
 			return err
 		}
 	}
@@ -221,7 +227,7 @@ func (p *CheckPoint[W]) UnmarshalBinary(data []byte) error {
 }
 
 // readMemory decodes a single memory snapshot (module identifier plus pages).
-func readMemory[W word.Word[W]](r *reader, nbits int) (Memory[W], error) {
+func readMemory[W word.Word[W]](r *reader, readWord func(*reader) (W, error)) (Memory[W], error) {
 	var (
 		mid, err = r.uint64()
 		np       uint32
@@ -238,7 +244,7 @@ func readMemory[W word.Word[W]](r *reader, nbits int) (Memory[W], error) {
 	pages := make([]Page[W], np)
 	//
 	for j := range pages {
-		if pages[j], err = readPage[W](r, nbits); err != nil {
+		if pages[j], err = readPage[W](r, readWord); err != nil {
 			return Memory[W]{}, err
 		}
 	}
@@ -247,7 +253,7 @@ func readMemory[W word.Word[W]](r *reader, nbits int) (Memory[W], error) {
 }
 
 // readPage decodes a single page (address plus data words).
-func readPage[W word.Word[W]](r *reader, nbits int) (Page[W], error) {
+func readPage[W word.Word[W]](r *reader, readWord func(*reader) (W, error)) (Page[W], error) {
 	var (
 		address, err = r.uint64()
 		nd           uint32
@@ -264,7 +270,7 @@ func readPage[W word.Word[W]](r *reader, nbits int) (Page[W], error) {
 	data := make([]W, nd)
 	//
 	for k := range data {
-		if data[k], err = readWord[W](r, nbits); err != nil {
+		if data[k], err = readWord(r); err != nil {
 			return Page[W]{}, err
 		}
 	}
@@ -272,28 +278,103 @@ func readPage[W word.Word[W]](r *reader, nbits int) (Page[W], error) {
 	return Page[W]{address, data}, nil
 }
 
-// readWord decodes a single word from the next nbits bytes (big-endian).
-func readWord[W word.Word[W]](r *reader, nbits int) (W, error) {
-	var (
-		zero    W
-		bs, err = r.bytes(nbits)
-	)
+// appendUvarWord appends w using unsigned LEB128-style variable-length
+// encoding.
+func appendUvarWord[W word.Word[W]](buf []byte, w W) ([]byte, error) {
+	value := w.BigInt()
 	//
-	if err != nil {
-		return zero, err
+	if value.Sign() < 0 {
+		return nil, fmt.Errorf("invalid checkpoint word: negative value 0x%s", value.Text(16))
 	}
 	//
-	var value big.Int
-	value.SetBytes(bs)
+	return appendUvarBig(buf, value), nil
+}
+
+// appendUvarBig appends value using unsigned LEB128-style variable-length
+// encoding.  The input is copied before shifting, so callers retain ownership of
+// value.
+func appendUvarBig(buf []byte, value *big.Int) []byte {
+	if value.Sign() == 0 {
+		return append(buf, 0)
+	}
+	//
+	var v big.Int
+	v.Set(value)
+	//
+	for v.Sign() > 0 {
+		b := byte(v.Uint64() & 0x7f)
+		v.Rsh(&v, 7)
+		//
+		if v.Sign() != 0 {
+			b |= 0x80
+		}
+		//
+		buf = append(buf, b)
+	}
+	//
+	return buf
+}
+
+// readUvarWord decodes a single unsigned LEB128-style word.
+func readUvarWord[W word.Word[W]](r *reader) (W, error) {
+	var (
+		zero      W
+		value     big.Int
+		shift     uint
+		bandwidth = zero.Bandwidth()
+		maxBytes  = maxUvarWordBytes(bandwidth)
+	)
+	//
+	for nbytes := uint(1); ; nbytes++ {
+		if maxBytes != 0 && nbytes > maxBytes {
+			return zero, fmt.Errorf("invalid checkpoint: variable-length word exceeds %d-bit bandwidth", bandwidth)
+		}
+		//
+		b, err := r.byte()
+		if err != nil {
+			return zero, err
+		}
+		//
+		if payload := b & 0x7f; payload != 0 {
+			var part big.Int
+			part.SetUint64(uint64(payload))
+			part.Lsh(&part, shift)
+			value.Or(&value, &part)
+		}
+		//
+		if b&0x80 == 0 {
+			break
+		}
+		//
+		shift += 7
+	}
+	//
+	if err := validateWordBandwidth[W](&value); err != nil {
+		return zero, err
+	}
 	//
 	return zero.SetBigInt(&value), nil
 }
 
-// bytesPerWord returns the number of bytes required to hold a single word of
-// type W, derived from the word type's Bandwidth (rounded up to whole bytes).
-func bytesPerWord[W word.Word[W]]() int {
+// validateWordBandwidth reports an error when value does not fit into W.
+func validateWordBandwidth[W word.Word[W]](value *big.Int) error {
 	var zero W
-	return int((zero.Bandwidth() + 7) / 8)
+	//
+	if bandwidth := zero.Bandwidth(); bandwidth != ^uint(0) && uint(value.BitLen()) > bandwidth {
+		return fmt.Errorf("invalid checkpoint: word value 0x%s exceeds %d-bit bandwidth", value.Text(16), bandwidth)
+	}
+	//
+	return nil
+}
+
+// maxUvarWordBytes returns the maximum canonical byte length for a word with a
+// finite bit bandwidth.  A zero result means unbounded.
+func maxUvarWordBytes(bandwidth uint) uint {
+	if bandwidth == ^uint(0) {
+		return 0
+	}
+	//
+	return (bandwidth + 6) / 7
 }
 
 // reader is a minimal cursor over a byte slice used during decoding.  Each read
@@ -314,6 +395,16 @@ func (r *reader) bytes(n int) ([]byte, error) {
 	r.pos += n
 	//
 	return bs, nil
+}
+
+// byte returns the next byte.
+func (r *reader) byte() (byte, error) {
+	bs, err := r.bytes(1)
+	if err != nil {
+		return 0, err
+	}
+	//
+	return bs[0], nil
 }
 
 // uint32 reads the next big-endian uint32.

--- a/pkg/zkc/vm/internal/checkpoint/checkpoint.go
+++ b/pkg/zkc/vm/internal/checkpoint/checkpoint.go
@@ -1,0 +1,337 @@
+// Package checkpoint provides the data structures used to capture (a snapshot
+// of) the state of an executing machine, so that execution can later be resumed
+// from that point.  See CheckPoint for the central type and a discussion of how
+// such snapshots may be optimised.
+package checkpoint
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math/big"
+
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/word"
+)
+
+// CheckPoint represents a captured state of an executing machine, such that
+// execution can be continued later from this position (sometimes also known as
+// a "continuation").  As such, the checkpoint must include all information
+// necessary to allow execution to continue.  However, to reduce the size of a
+// checkpoint, certain optimsiations of this information are permitted.  As
+// such, implementations can manage this information in different ways (e.g.
+// using compression, read-access lists, page-access lists, etc).
+//
+// For example suppose that a machine, upon reaching the checkpoint, has 1GB of
+// some RAM allocated.  A full checkpoint would include all of this data and,
+// therefore, be at least 1GB in size.  Suppose, however, that executing the
+// machine from this point onwards only requires accessing 1MB of data from that
+// RAM.  Then, in fact, a valid implementation might only store that 1MB of
+// information (e.g. to reduce network transport costs, or proof size, etc).
+//
+// Finally, to support more aggressive optimisation, checkpoints have a notion
+// of their "validity window".   To understand this, consider a refinement of
+// the example above.  Suppose there are M execution steps remaining from the
+// checkpoint until the machine terminates, but that executing these M steps now
+// requires the full 1GB of RAM.  However, we now suppose that executing the
+// next N steps requires accessing only 1MB of that RAM. Then, the checkpoint
+// may only store that 1MB of data if it is marked as being valid for (upto) N
+// steps of execution.  The purpose of this is to allow a program's execution to
+// be broken up into multiple checkpoints, such that each checkpoint only stores
+// the data it requires for executing its portion of the overall execution.
+type CheckPoint[W word.Word[W]] struct {
+	// Call stack holding caller state for nested calls.
+	callStack []StackFrame
+	// Data stack holding the activation records (registers) of active function
+	// calls.  The current frame begins at fp.
+	dataStack []W
+	// Snapshot of all mutable Memory.
+	memory []Memory[W]
+}
+
+// NewCheckPoint constructs a checkpoint from a snapshot of the call stack, data
+// stack and mutable memories of an executing machine.  The provided slices are
+// retained by reference, so callers which intend to continue mutating the
+// underlying storage (e.g. an interpreter's live stacks) should pass copies.
+func NewCheckPoint[W word.Word[W]](callStack []StackFrame, dataStack []W, memory []Memory[W]) CheckPoint[W] {
+	return CheckPoint[W]{callStack, dataStack, memory}
+}
+
+// CallStack returns the captured call stack of paused callers.
+func (p CheckPoint[W]) CallStack() []StackFrame {
+	return p.callStack
+}
+
+// DataStack returns the captured data stack holding the activation records
+// (registers) of all active function calls.
+func (p CheckPoint[W]) DataStack() []W {
+	return p.dataStack
+}
+
+// Memories returns the captured snapshots of all mutable memories.
+func (p CheckPoint[W]) Memories() []Memory[W] {
+	return p.memory
+}
+
+// StackFrame captures relevant information about all functions currently
+// executing a CALL.  Such functions are "paused" whilst the active function is
+// being executed.  The purpose of a stack frame is to record the Frame Pointer
+// (FP) and Program Counter (PC) of the relevant function so that these can be
+// restored when it becomes the active function.
+type StackFrame struct {
+	// module identifier of the executing function.
+	FunctionId uint
+	// frame pointer of the executing function.
+	FramePointer uint32
+	// program counter identifies next bytecode to execute.
+	ProgramCounter uint32
+}
+
+// NewStackFrame constructs a stack frame recording the function identifier,
+// frame pointer and program counter of a paused function.
+func NewStackFrame(fid uint, fp uint32, pc uint32) StackFrame {
+	return StackFrame{fid, fp, pc}
+}
+
+// ============================================================================
+// Encoding / Decoding
+// ============================================================================
+//
+// A checkpoint is serialised into a flat byte sequence using a big-endian
+// layout.  Counts, identifiers and addresses are written as fixed-width
+// integers, whilst each word is written using exactly bytesPerWord(W) bytes
+// (derived from the word type's Bandwidth).  The bytes-per-word is itself
+// written as the first field, so that unmarshalling can sanity check that the
+// data was produced for a word type of the expected width.
+
+// MarshalBinary implements encoding.BinaryMarshaler, serialising this checkpoint
+// into a flat big-endian byte sequence (see above).
+func (p CheckPoint[W]) MarshalBinary() ([]byte, error) {
+	var (
+		buf   []byte
+		nbits = bytesPerWord[W]()
+		tmp   = make([]byte, nbits)
+	)
+	// Bytes-per-word: written first so it can be validated on unmarshalling.
+	buf = binary.BigEndian.AppendUint32(buf, uint32(nbits))
+	// Call stack: count followed by each frame.
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(p.callStack)))
+	//
+	for _, f := range p.callStack {
+		buf = binary.BigEndian.AppendUint64(buf, uint64(f.FunctionId))
+		buf = binary.BigEndian.AppendUint32(buf, f.FramePointer)
+		buf = binary.BigEndian.AppendUint32(buf, f.ProgramCounter)
+	}
+	// Data stack: count followed by each word.
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(p.dataStack)))
+	//
+	for _, w := range p.dataStack {
+		buf = append(buf, w.BigInt().FillBytes(tmp)...)
+	}
+	// Memories: count followed by each memory.
+	buf = binary.BigEndian.AppendUint32(buf, uint32(len(p.memory)))
+	//
+	for _, m := range p.memory {
+		buf = binary.BigEndian.AppendUint64(buf, uint64(m.moduleId))
+		buf = binary.BigEndian.AppendUint32(buf, uint32(len(m.pages)))
+		//
+		for _, pg := range m.pages {
+			buf = binary.BigEndian.AppendUint64(buf, pg.address)
+			buf = binary.BigEndian.AppendUint32(buf, uint32(len(pg.data)))
+			//
+			for _, w := range pg.data {
+				buf = append(buf, w.BigInt().FillBytes(tmp)...)
+			}
+		}
+	}
+	//
+	return buf, nil
+}
+
+// UnmarshalBinary implements encoding.BinaryUnmarshaler, reconstructing a
+// checkpoint previously serialised by MarshalBinary.
+func (p *CheckPoint[W]) UnmarshalBinary(data []byte) error {
+	var (
+		r     = &reader{data: data}
+		nbits = bytesPerWord[W]()
+		err   error
+		n     uint32
+	)
+	// Bytes-per-word: validate the data was produced for a word type of the
+	// expected width before decoding anything else.
+	if n, err = r.uint32(); err != nil {
+		return err
+	} else if n != uint32(nbits) {
+		return fmt.Errorf("invalid checkpoint: expected %d bytes-per-word, got %d", nbits, n)
+	}
+	// Call stack.
+	if n, err = r.uint32(); err != nil {
+		return err
+	}
+	//
+	callStack := make([]StackFrame, n)
+	//
+	for i := range callStack {
+		fid, err := r.uint64()
+		if err != nil {
+			return err
+		}
+		//
+		fp, err := r.uint32()
+		if err != nil {
+			return err
+		}
+		//
+		pc, err := r.uint32()
+		if err != nil {
+			return err
+		}
+		//
+		callStack[i] = NewStackFrame(uint(fid), fp, pc)
+	}
+	// Data stack.
+	if n, err = r.uint32(); err != nil {
+		return err
+	}
+	//
+	dataStack := make([]W, n)
+	//
+	for i := range dataStack {
+		if dataStack[i], err = readWord[W](r, nbits); err != nil {
+			return err
+		}
+	}
+	// Memories.
+	if n, err = r.uint32(); err != nil {
+		return err
+	}
+	//
+	memory := make([]Memory[W], n)
+	//
+	for i := range memory {
+		if memory[i], err = readMemory[W](r, nbits); err != nil {
+			return err
+		}
+	}
+	//
+	p.callStack = callStack
+	p.dataStack = dataStack
+	p.memory = memory
+	//
+	return nil
+}
+
+// readMemory decodes a single memory snapshot (module identifier plus pages).
+func readMemory[W word.Word[W]](r *reader, nbits int) (Memory[W], error) {
+	var (
+		mid, err = r.uint64()
+		np       uint32
+	)
+	//
+	if err != nil {
+		return Memory[W]{}, err
+	}
+	//
+	if np, err = r.uint32(); err != nil {
+		return Memory[W]{}, err
+	}
+	//
+	pages := make([]Page[W], np)
+	//
+	for j := range pages {
+		if pages[j], err = readPage[W](r, nbits); err != nil {
+			return Memory[W]{}, err
+		}
+	}
+	//
+	return Memory[W]{uint(mid), pages}, nil
+}
+
+// readPage decodes a single page (address plus data words).
+func readPage[W word.Word[W]](r *reader, nbits int) (Page[W], error) {
+	var (
+		address, err = r.uint64()
+		nd           uint32
+	)
+	//
+	if err != nil {
+		return Page[W]{}, err
+	}
+	//
+	if nd, err = r.uint32(); err != nil {
+		return Page[W]{}, err
+	}
+	//
+	data := make([]W, nd)
+	//
+	for k := range data {
+		if data[k], err = readWord[W](r, nbits); err != nil {
+			return Page[W]{}, err
+		}
+	}
+	//
+	return Page[W]{address, data}, nil
+}
+
+// readWord decodes a single word from the next nbits bytes (big-endian).
+func readWord[W word.Word[W]](r *reader, nbits int) (W, error) {
+	var (
+		zero    W
+		bs, err = r.bytes(nbits)
+	)
+	//
+	if err != nil {
+		return zero, err
+	}
+	//
+	var value big.Int
+	value.SetBytes(bs)
+	//
+	return zero.SetBigInt(&value), nil
+}
+
+// bytesPerWord returns the number of bytes required to hold a single word of
+// type W, derived from the word type's Bandwidth (rounded up to whole bytes).
+func bytesPerWord[W word.Word[W]]() int {
+	var zero W
+	return int((zero.Bandwidth() + 7) / 8)
+}
+
+// reader is a minimal cursor over a byte slice used during decoding.  Each read
+// advances the cursor, returning io.ErrUnexpectedEOF if insufficient bytes
+// remain.
+type reader struct {
+	data []byte
+	pos  int
+}
+
+// bytes returns the next n bytes (a sub-slice of the underlying data).
+func (r *reader) bytes(n int) ([]byte, error) {
+	if r.pos+n > len(r.data) {
+		return nil, io.ErrUnexpectedEOF
+	}
+	//
+	bs := r.data[r.pos : r.pos+n]
+	r.pos += n
+	//
+	return bs, nil
+}
+
+// uint32 reads the next big-endian uint32.
+func (r *reader) uint32() (uint32, error) {
+	bs, err := r.bytes(4)
+	if err != nil {
+		return 0, err
+	}
+	//
+	return binary.BigEndian.Uint32(bs), nil
+}
+
+// uint64 reads the next big-endian uint64.
+func (r *reader) uint64() (uint64, error) {
+	bs, err := r.bytes(8)
+	if err != nil {
+		return 0, err
+	}
+	//
+	return binary.BigEndian.Uint64(bs), nil
+}

--- a/pkg/zkc/vm/internal/checkpoint/memory.go
+++ b/pkg/zkc/vm/internal/checkpoint/memory.go
@@ -1,0 +1,29 @@
+package checkpoint
+
+// Memory captures a snapshot of the contents of a single (mutable) memory
+// module.  To support sparse memories, the contents are described as a sequence
+// of pages, each covering a contiguous region; regions not covered by any page
+// are implicitly zero.
+type Memory[W any] struct {
+	// Module identifier for this memory.
+	moduleId uint
+	// Pages determines the contents of the given memory in this snapshot.
+	pages []Page[W]
+}
+
+// NewMemory constructs a snapshot of a single memory module, identified by its
+// module identifier and described by the given sequence of pages.
+func NewMemory[W any](moduleId uint, pages []Page[W]) Memory[W] {
+	return Memory[W]{moduleId, pages}
+}
+
+// ModuleId returns the module identifier of the memory captured by this
+// snapshot.
+func (p Memory[W]) ModuleId() uint {
+	return p.moduleId
+}
+
+// Pages returns the pages describing the captured contents of this memory.
+func (p Memory[W]) Pages() []Page[W] {
+	return p.pages
+}

--- a/pkg/zkc/vm/internal/checkpoint/page.go
+++ b/pkg/zkc/vm/internal/checkpoint/page.go
@@ -1,0 +1,34 @@
+package checkpoint
+
+import "slices"
+
+// Page represents a variable-length chunk of data within a given memory.
+type Page[W any] struct {
+	// Address specifies the physical address in memory where this page begins.
+	address uint64
+	// Data holds the words stored in this page, beginning at address.
+	data []W
+}
+
+// NewPage constructs a single page of memory beginning at the given physical
+// address and holding the given data.
+func NewPage[W any](address uint64, data []W) Page[W] {
+	return Page[W]{address, data}
+}
+
+// Clone returns a deep copy of this page, with its own copy of the underlying
+// data.  This is useful when the page references storage (e.g. live memory)
+// which may subsequently be mutated.
+func (p Page[W]) Clone() Page[W] {
+	return Page[W]{p.address, slices.Clone(p.data)}
+}
+
+// Address returns the physical address in memory where this page begins.
+func (p Page[W]) Address() uint64 {
+	return p.address
+}
+
+// Data returns the words stored in this page, beginning at Address.
+func (p Page[W]) Data() []W {
+	return p.data
+}

--- a/pkg/zkc/vm/internal/memory/paged_ram.go
+++ b/pkg/zkc/vm/internal/memory/paged_ram.go
@@ -19,6 +19,8 @@ import (
 	"github.com/LFDT-Lineth/zkc/pkg/schema/register"
 	"github.com/LFDT-Lineth/zkc/pkg/trace"
 	"github.com/LFDT-Lineth/zkc/pkg/util"
+	"github.com/LFDT-Lineth/zkc/pkg/util/collection/iter"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/checkpoint"
 )
 
 // PAGE_SIZE determines the number of words in a single page of a
@@ -156,6 +158,25 @@ func (p *PagedRandomAccess[W]) Write(address uint64, value W) error {
 // Contents implementation for Memory interface.
 func (p *PagedRandomAccess[W]) Contents() []W {
 	panic("unsupported operation")
+}
+
+// Pages returns an iterator over the allocated pages backing this memory.  Each
+// yielded page covers the PAGE_SIZE words beginning at physical address
+// i*PAGE_SIZE (where i is its page number); pages which have never been written
+// are omitted.  The backing data slices are referenced directly (not copied),
+// so callers must not mutate them.
+func (p *PagedRandomAccess[W]) Pages() iter.Iterator[checkpoint.Page[W]] {
+	var pages []checkpoint.Page[W]
+	//
+	for i, page := range p.pages {
+		if page != nil {
+			var address = uint64(i) * PAGE_SIZE
+
+			pages = append(pages, checkpoint.NewPage(address, page))
+		}
+	}
+	//
+	return iter.NewArrayIterator(pages)
 }
 
 // HasRegister implementation for vm.Module interface.

--- a/pkg/zkc/vm/internal/transform/word_to_bytecode.go
+++ b/pkg/zkc/vm/internal/transform/word_to_bytecode.go
@@ -206,7 +206,7 @@ func (p *bytecodeCompiler[W]) compileCall(insn *instruction.Call, f *WordFunctio
 	// receiving parameter registers, matching the slow machine (frameCopyTo).
 	p.addOutgoingCheckCasts(insn.Arguments, callee.Inputs(), f)
 	//
-	p.encoder.Add(bytecode.CallFun(index, uint16(frameWidth), insn.Arguments, insn.Returns))
+	p.encoder.Add(bytecode.CallFun(index, false, uint16(frameWidth), insn.Arguments, insn.Returns))
 	// Check whether cast checks are required for returns wider than their
 	// receiving target registers, matching the slow machine (frameCopyFrom).
 	p.addIncomingCheckCasts(callee.Outputs(), insn.Returns, f)


### PR DESCRIPTION
This adds support for creating checkpoints and restoring them in the bytecode interpreter.  This uses a binary format for representing a checkpoint, where memories are divided into pages (of varying length) to enable a pseudo-sparse representation.  The current implementation supports a notion of a "checkpointing call" instruction.  That is, calls to specific functions are marked as "checkpointing" and, on entry to those calls, can (potentially) generate a checkpoint.