### PR TITLE
feat: add trace command

### DIFF
--- a/pkg/cmd/corset/inspect.go
+++ b/pkg/cmd/corset/inspect.go
@@ -124,21 +124,30 @@ func runInspectCmd[F field.Element[F]](cmd *cobra.Command, args []string) {
 // supplied register mapping, without requiring a corset source map.  Columns are
 // shown as computed (low-level) registers.  This is intended for callers (e.g.
 // the zkc toolchain) which generate a trace but have no source map available.
+//
+// The optional "public" predicate determines which modules are publicly visible
+// (shown by default); when nil, all modules are public.  Callers use this to
+// hide synthetic modules such as range-check tables.
 func InspectTrace[F field.Element[F]](mapping module.LimbsMap, trace tr.Trace[F],
-	limbs bool, cellWidth, titleWidth uint) []error {
+	public func(tr.ModuleName) bool, limbs bool, cellWidth, titleWidth uint) []error {
 	//
 	term, err := termio.NewTerminal()
 	if err != nil {
 		return []error{err}
 	}
 	// Build the viewing window (no source map, so show computed registers).
-	window := view.NewBuilder[F](mapping).
+	builder := view.NewBuilder[F](mapping).
 		WithTitleWidth(titleWidth).
 		WithCellWidth(cellWidth).
 		WithFormatting(inspector.NewFormatter()).
 		WithLimbs(limbs).
-		WithComputed(true).
-		Build(trace)
+		WithComputed(true)
+	// Apply the visibility predicate (if any).
+	if public != nil {
+		builder = builder.WithVisibility(public)
+	}
+	//
+	window := builder.Build(trace)
 	// Construct the inspector.
 	insp := inspector.NewInspector(term, window)
 	// Render it.

--- a/pkg/cmd/corset/inspect.go
+++ b/pkg/cmd/corset/inspect.go
@@ -120,6 +120,35 @@ func runInspectCmd[F field.Element[F]](cmd *cobra.Command, args []string) {
 	}
 }
 
+// InspectTrace opens the given trace in the interactive inspector using the
+// supplied register mapping, without requiring a corset source map.  Columns are
+// shown as computed (low-level) registers.  This is intended for callers (e.g.
+// the zkc toolchain) which generate a trace but have no source map available.
+func InspectTrace[F field.Element[F]](mapping module.LimbsMap, trace tr.Trace[F],
+	limbs bool, cellWidth, titleWidth uint) []error {
+	//
+	term, err := termio.NewTerminal()
+	if err != nil {
+		return []error{err}
+	}
+	// Build the viewing window (no source map, so show computed registers).
+	window := view.NewBuilder[F](mapping).
+		WithTitleWidth(titleWidth).
+		WithCellWidth(cellWidth).
+		WithFormatting(inspector.NewFormatter()).
+		WithLimbs(limbs).
+		WithComputed(true).
+		Build(trace)
+	// Construct the inspector.
+	insp := inspector.NewInspector(term, window)
+	// Render it.
+	if err := insp.Render(); err != nil {
+		return []error{err}
+	}
+	//
+	return insp.Start()
+}
+
 // Inspect a given trace using a given schema.
 func inspect[F field.Element[F]](mapping module.LimbsMap, srcmap *corset.SourceMap, trace tr.Trace[F],
 	limbs bool, cellWidth, titleWidth uint) []error {

--- a/pkg/cmd/corset/view/builder.go
+++ b/pkg/cmd/corset/view/builder.go
@@ -49,12 +49,17 @@ type Builder[F field.Element[F]] struct {
 	formatting TraceFormatting
 	// Optional source map information.  This is primarily used to determine
 	srcmap util.Option[corset.SourceMap]
+	// Optional predicate determining whether a given module is publicly visible.
+	// When set, it overrides the public flag otherwise derived from the source
+	// map (or the default).  This is used by callers without a source map (e.g.
+	// zkc) to hide synthetic modules such as range-check tables.
+	visibility util.Option[func(tr.ModuleName) bool]
 }
 
 // NewBuilder constructs a default builder.
 func NewBuilder[F field.Element[F]](mapping module.LimbsMap) Builder[F] {
 	return Builder[F]{util.None[CellRefSet](), false, false, 16, 16, mapping,
-		DefaultFormatter(), util.None[corset.SourceMap]()}
+		DefaultFormatter(), util.None[corset.SourceMap](), util.None[func(tr.ModuleName) bool]()}
 }
 
 // WithCellWidth sets the maximum width of any cell in the view.
@@ -113,6 +118,17 @@ func (p Builder[F]) WithSourceMap(srcmap corset.SourceMap) Builder[F] {
 	return builder
 }
 
+// WithVisibility applies a predicate determining whether a given module is
+// publicly visible.  When set, it overrides the public flag otherwise derived
+// from the source map (or the default).
+func (p Builder[F]) WithVisibility(public func(tr.ModuleName) bool) Builder[F] {
+	var builder = p
+	//
+	builder.visibility = util.Some(public)
+	//
+	return builder
+}
+
 // Build the viewing window for this trace.
 func (p Builder[F]) Build(trace tr.Trace[F]) TraceView {
 	var windows []ModuleView
@@ -124,6 +140,10 @@ func (p Builder[F]) Build(trace tr.Trace[F]) TraceView {
 		scMod := p.mapping.Module(i)
 		//
 		public, columns := extractSourceMapData(trMod, p.limbs, p.computed, srcmap, scMod)
+		// Override visibility with the caller-supplied predicate (if any).
+		if p.visibility.HasValue() {
+			public = p.visibility.Unwrap()(trMod.Name())
+		}
 		//
 		data := newModuleData(i, scMod, trMod, public, enums, columns)
 		// construct initial module view

--- a/pkg/cmd/zkc/execute.go
+++ b/pkg/cmd/zkc/execute.go
@@ -108,7 +108,7 @@ func runExecuteCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 			// checkpoints to the output file (with -o) or to stdout otherwise.
 			outputs, errors = executeWithCheckPoint(program, checkpoint, outputFile, input)
 		} else if tracing {
-			outputs, trace, errors = binfile.Trace(input, traceConfig)
+			outputs, _, trace, errors = binfile.Trace(input, traceConfig)
 		} else if build.gogen {
 			// Execute via native Go generated from the word machine.
 			outputs, errors = executeWithGogen(artifacts.ir, input)

--- a/pkg/cmd/zkc/trace.go
+++ b/pkg/cmd/zkc/trace.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/LFDT-Lineth/zkc/pkg/cmd/corset"
 	"github.com/LFDT-Lineth/zkc/pkg/rtrace"
+	"github.com/LFDT-Lineth/zkc/pkg/schema/module"
 	"github.com/LFDT-Lineth/zkc/pkg/trace"
 	"github.com/LFDT-Lineth/zkc/pkg/trace/lt"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field"
@@ -127,7 +128,9 @@ func runTraceCmd[F field.Element[F]](cmd *cobra.Command, args []string, field fi
 	// Open the generated trace in the interactive inspector (if requested).  This
 	// takes over the terminal, so it runs last, after any stdout output above.
 	if inspect && len(errors) == 0 {
-		errors = corset.InspectTrace(binfile.LimbsMap(), trace, false, 32, 128)
+		// Real ZkC functions are public; synthetic modules (e.g. range-check
+		// tables) are private (hidden by default in the inspector).
+		errors = corset.InspectTrace(binfile.LimbsMap(), trace, publicModule, false, 32, 128)
 	}
 	// =====================================================
 	// Report Execution Failures
@@ -149,6 +152,17 @@ func init() {
 	traceCmd.Flags().BoolP("check", "c", false, "check generated trace against constraints")
 	traceCmd.Flags().Bool("stats", false, "show overall stats for the generated trace")
 	traceCmd.Flags().BoolP("inspect", "i", false, "open the generated trace in the interactive inspector")
+}
+
+// publicModule reports whether a module is publicly visible in the inspector.
+// Real ZkC functions and memories are public; synthetic modules generated during
+// compilation (e.g. range-check tables such as "$range_u16") are private, so the
+// inspector hides them by default.  Synthetic modules are named with a "$" sigil,
+// which cannot appear in user-written identifiers (see the ZkC lexer), making the
+// prefix a reliable marker.  Note the AIR schema does not set the IsSynthetic
+// flag for these modules, so the name is the only discriminator available.
+func publicModule(name module.Name) bool {
+	return !strings.HasPrefix(name.Name, "$")
 }
 
 // Column bit-width buckets reported by printTraceStats, matching those shown by

--- a/pkg/cmd/zkc/trace.go
+++ b/pkg/cmd/zkc/trace.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/LFDT-Lineth/zkc/pkg/cmd/corset"
 	"github.com/LFDT-Lineth/zkc/pkg/rtrace"
 	"github.com/LFDT-Lineth/zkc/pkg/trace"
 	"github.com/LFDT-Lineth/zkc/pkg/trace/lt"
@@ -67,6 +68,8 @@ func runTraceCmd[F field.Element[F]](cmd *cobra.Command, args []string, field fi
 		check = GetFlag(cmd, "check")
 		// show trace statistics
 		stats = GetFlag(cmd, "stats")
+		// open trace in the interactive inspector
+		inspect = GetFlag(cmd, "inspect")
 		//
 		trace   trace.Trace[F]
 		outputs map[string][]byte
@@ -119,6 +122,14 @@ func runTraceCmd[F field.Element[F]](cmd *cobra.Command, args []string, field fi
 		checkConstraints(binfile, trace, traceConfig)
 	}
 	// =====================================================
+	// Inspect
+	// =====================================================
+	// Open the generated trace in the interactive inspector (if requested).  This
+	// takes over the terminal, so it runs last, after any stdout output above.
+	if inspect && len(errors) == 0 {
+		errors = corset.InspectTrace(binfile.LimbsMap(), trace, false, 32, 128)
+	}
+	// =====================================================
 	// Report Execution Failures
 	// =====================================================
 	if len(errors) > 0 {
@@ -137,6 +148,7 @@ func init() {
 	traceCmd.Flags().StringP("output", "o", "", "specify output file for writing trace")
 	traceCmd.Flags().BoolP("check", "c", false, "check generated trace against constraints")
 	traceCmd.Flags().Bool("stats", false, "show overall stats for the generated trace")
+	traceCmd.Flags().BoolP("inspect", "i", false, "open the generated trace in the interactive inspector")
 }
 
 // Column bit-width buckets reported by printTraceStats, matching those shown by

--- a/pkg/cmd/zkc/trace.go
+++ b/pkg/cmd/zkc/trace.go
@@ -1,0 +1,300 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package zkc
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/LFDT-Lineth/zkc/pkg/rtrace"
+	"github.com/LFDT-Lineth/zkc/pkg/trace"
+	"github.com/LFDT-Lineth/zkc/pkg/trace/lt"
+	"github.com/LFDT-Lineth/zkc/pkg/util/field"
+	"github.com/LFDT-Lineth/zkc/pkg/util/field/bls12_377"
+	"github.com/LFDT-Lineth/zkc/pkg/util/field/gf251"
+	"github.com/LFDT-Lineth/zkc/pkg/util/field/gf8209"
+	"github.com/LFDT-Lineth/zkc/pkg/util/field/koalabear"
+	"github.com/LFDT-Lineth/zkc/pkg/util/termio"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/constraints"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var traceCmd = &cobra.Command{
+	Use:   "trace [flags] input.json file1.zkc file2.zkc ...",
+	Short: "Trace a zkc program.",
+	Long: `Trace a zkc program to produce a set of outputs from a given set of inputs.
+
+This is equivalent to "execute" but always generates a trace: it does not
+support fast mode or checkpointing.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		runFieldAgnosticCmd(cmd, args, traceCmds)
+	},
+}
+
+// Available instances
+var traceCmds = []FieldAgnosticCmd{
+	{field.GF_251, runTraceCmd[gf251.Element]},
+	{field.GF_8209, runTraceCmd[gf8209.Element]},
+	{field.KOALABEAR_16, runTraceCmd[koalabear.Element]},
+	{field.BLS12_377, runTraceCmd[bls12_377.Element]},
+}
+
+// Permitted flag combinations
+var traceFlags FlagChecks
+
+func runTraceCmd[F field.Element[F]](cmd *cobra.Command, args []string, field field.Config) {
+	var (
+		build = GetBuildConfig[F](cmd, field)
+		//
+		traceConfig = constraints.DEFAULT_TRACE_CONFIG
+		// outputFile file for trace
+		outputFile = GetString(cmd, "output")
+		// check constraints
+		check = GetFlag(cmd, "check")
+		// show trace statistics
+		stats = GetFlag(cmd, "stats")
+		//
+		trace   trace.Trace[F]
+		outputs map[string][]byte
+	)
+	// Sanity permitted flag combinations
+	checkFlags(cmd, traceFlags)
+	// Tracing always generates a trace, so fast mode is not supported.
+	if GetFlag(cmd, "fast") {
+		fmt.Println("error: \"trace\" does not support fast mode (use \"execute\" instead)")
+		os.Exit(1)
+	}
+	// Build artifacts (compiles source files or loads a prebuilt binary).
+	artifacts := Build[F](build, args[1:]...)
+	// Translate bytecode => word machine
+	program := vm.ProgramToProgram[vm.Uint, vm.Uint128](artifacts.ir)
+	// Wrap the word machine in a binary file for tracing / checking.
+	binfile := constraints.NewBinaryFile[F](nil, nil, field, build.config.GetMaxStaticDepth(), artifacts.ir)
+	// =====================================================
+	// Trace
+	// =====================================================
+	// Parse and filter input file
+	input := vm.FilterInputs(program, ParseInputFile(args[0]))
+	// Always trace (no fast mode).  The raw (row-major) trace is retained for
+	// statistics, since it carries the original register/limb structure.
+	outputs, rtr, trace, errors := binfile.Trace(input, traceConfig)
+	// =====================================================
+	// Generate output
+	// =====================================================
+	// Write outputs
+	for name, bytes := range outputs {
+		fmt.Printf("%s = 0x%s\n", name, hex.EncodeToString(bytes))
+	}
+	// print trace statistics (if requested).  Only meaningful when a trace was
+	// actually generated (i.e. no execution errors).
+	if stats && len(errors) == 0 {
+		printTraceStats(rtr)
+		printModuleStats(rtr)
+	}
+	// write out trace (if requested)
+	if outputFile != "" {
+		// Construct trace file
+		ltf := lt.FromRawTrace(nil, trace)
+		// Write out trace file
+		WriteTraceFile(outputFile, ltf)
+	}
+	// =====================================================
+	// Check Constraints
+	// =====================================================
+	if check && len(errors) == 0 {
+		checkConstraints(binfile, trace, traceConfig)
+	}
+	// =====================================================
+	// Report Execution Failures
+	// =====================================================
+	if len(errors) > 0 {
+		// Log errors
+		for _, e := range errors {
+			log.Error(fmt.Sprintf("%s", e))
+		}
+		//
+		os.Exit(4)
+	}
+}
+
+//nolint:errcheck
+func init() {
+	rootCmd.AddCommand(traceCmd)
+	traceCmd.Flags().StringP("output", "o", "", "specify output file for writing trace")
+	traceCmd.Flags().BoolP("check", "c", false, "check generated trace against constraints")
+	traceCmd.Flags().Bool("stats", false, "show overall stats for the generated trace")
+}
+
+// Column bit-width buckets reported by printTraceStats, matching those shown by
+// the corset "trace --stats" command.
+var traceStatBuckets = []struct{ lo, hi uint }{{1, 8}, {9, 16}, {17, 32}, {33, 128}, {129, 256}}
+
+const (
+	oneK = 1000
+	oneM = oneK * oneK
+	oneG = oneM * oneK
+)
+
+// printTraceStats prints overall statistics for a raw (row-major) trace, much
+// like the corset "trace --stats" command.  It reports the total number of
+// traced cells (both human-readable and raw) plus a breakdown of columns by
+// bit-width.  Columns backed by field elements (i.e. native registers, which
+// have no fixed bit-width) are reported separately.
+func printTraceStats[F field.Element[F]](rtr rtrace.Trace[F]) {
+	var (
+		cells  uint
+		counts = make([]uint, len(traceStatBuckets))
+		native uint
+	)
+	// Tally cells and per-column bit-widths across all modules.
+	for mid := range rtr.Width() {
+		mod := rtr.Module(mid)
+		cells += mod.Width() * mod.Height()
+		//
+		for _, limb := range mod.Limbs().Collect() {
+			bitwidth := limb.Bitwidth()
+			// Native (field-element) limbs have no fixed bit-width.
+			if bitwidth.IsEmpty() {
+				native++
+				continue
+			}
+			// Otherwise, place the limb in its matching bit-width bucket.
+			for i, b := range traceStatBuckets {
+				if w := bitwidth.Unwrap(); w >= b.lo && w <= b.hi {
+					counts[i]++
+					break
+				}
+			}
+		}
+	}
+	// Assemble the stats table.
+	rows := [][2]string{
+		{"Cells", humanCount(cells)},
+		{"Cells (raw)", fmt.Sprintf("%d", cells)},
+	}
+	//
+	for i, b := range traceStatBuckets {
+		rows = append(rows, [2]string{fmt.Sprintf("Columns (%d..%d bits)", b.lo, b.hi), fmt.Sprintf("%d", counts[i])})
+	}
+	//
+	if native > 0 {
+		rows = append(rows, [2]string{"Columns (native)", fmt.Sprintf("%d", native)})
+	}
+	// Render it.
+	tbl := termio.NewFormattedTable(2, uint(len(rows)))
+	//
+	for i, row := range rows {
+		tbl.SetRow(uint(i), termio.NewText(row[0]), termio.NewText(row[1]))
+	}
+	//
+	tbl.SetMaxWidths(64)
+	tbl.Print(true)
+}
+
+// humanCount formats a (potentially large) count using K/M/G suffixes, matching
+// the corset trace command's cell-count formatting.
+func humanCount(total uint) string {
+	switch {
+	case total > oneG:
+		return fmt.Sprintf("%.01fG", float64(total)/oneG)
+	case total > oneM:
+		return fmt.Sprintf("%.01fM", float64(total)/oneM)
+	case total > oneK:
+		return fmt.Sprintf("%.01fK", float64(total)/oneK)
+	default:
+		return fmt.Sprintf("%d", total)
+	}
+}
+
+// Per-module summary column titles, matching those shown by the corset "trace
+// --modules" command.
+var moduleStatTitles = []string{"columns", "lines", "bitwidth", "cells", "nonzero", "bytes"}
+
+// printModuleStats prints a per-module summary for a raw (row-major) trace, much
+// like the corset trace command's module listing.  For each module it reports
+// the column count, line (row) count, total bit-width, total cells, non-zero
+// cells and total bytes.  Native (field-element) limbs, which have no fixed
+// bit-width, are excluded from the bit-width and byte totals.
+func printModuleStats[F field.Element[F]](rtr rtrace.Trace[F]) {
+	var (
+		n   = rtr.Width()
+		tbl = termio.NewFormattedTable(uint(len(moduleStatTitles))+1, n+1)
+	)
+	// Set column titles (leaving the top-left cell blank, as corset does).
+	for i, title := range moduleStatTitles {
+		tbl.Set(uint(i)+1, 0, termio.NewText(title))
+	}
+	// Compute a summary row for each module.
+	for mid := range n {
+		var (
+			mod      = rtr.Module(mid)
+			columns  = mod.Width()
+			lines    = mod.Height()
+			bitwidth uint
+			nonzero  uint
+			bytes    uint
+		)
+		// Sum per-limb bit-widths and byte requirements.
+		for _, limb := range mod.Limbs().Collect() {
+			if bw := limb.Bitwidth(); bw.HasValue() {
+				w := bw.Unwrap()
+				bitwidth += w
+				bytes += byteWidth(w) * lines
+			}
+		}
+		// Count non-zero cells.
+		for rid := range lines {
+			row := mod.Row(rid)
+			//
+			for cid := range columns {
+				if !row.Get(cid).IsZero() {
+					nonzero++
+				}
+			}
+		}
+		//
+		tbl.SetRow(mid+1,
+			termio.NewText(mod.Name()),
+			termio.NewText(fmt.Sprintf("%d", columns)),
+			termio.NewText(fmt.Sprintf("%d", lines)),
+			termio.NewText(fmt.Sprintf("%d", bitwidth)),
+			termio.NewText(fmt.Sprintf("%d", columns*lines)),
+			termio.NewText(fmt.Sprintf("%d", nonzero)),
+			termio.NewText(fmt.Sprintf("%d", bytes)),
+		)
+	}
+	//
+	tbl.SetMaxWidths(64)
+	// Separate the summary stats (above) from the per-module stats (below) with a
+	// horizontal rule as wide as the module table.
+	fmt.Println(strings.Repeat("-", int(tbl.PrintedWidth())))
+	// Sort modules (descending) by cell count, skipping the title row.
+	tbl.Sort(1, termio.NewTableSorter().SortNumericalColumn(4).Invert())
+	tbl.Print(true)
+}
+
+// byteWidth returns the number of bytes required to hold a value of the given
+// bit-width (i.e. the bit-width rounded up to the nearest byte).
+func byteWidth(bitwidth uint) uint {
+	w := bitwidth / 8
+	//
+	if bitwidth%8 != 0 {
+		w++
+	}
+	//
+	return w
+}

--- a/pkg/ir/trace_builder.go
+++ b/pkg/ir/trace_builder.go
@@ -223,7 +223,7 @@ func (tb TraceBuilder[F]) innerBuild(schema sc.AnySchema[F], mods []lt.Module[F]
 		}
 	}
 	// Padding
-	padColumns(tr, tb.paddingStrategy)
+	padColumns(schema, tr, tb.paddingStrategy)
 	//
 	return tr, errors
 }
@@ -330,16 +330,21 @@ func checkModuleHeights[F field.Element[F]](original []uint, defensive bool, tr 
 // multiplier.  This ensures the amount of padding added is always a multiple of
 // the multiplier, as required by ArrayModule.Pad (relevant for interleaved
 // corset modules, whose multiplier can exceed one).
-func padColumns[F field.Element[F]](tr *trace.ArrayTrace[F], strategy PaddingStrategy) {
+func padColumns[F field.Element[F]](schema sc.AnySchema[F], tr *trace.ArrayTrace[F], strategy PaddingStrategy) {
 	n := tr.Modules().Count()
 	// Iterate over modules
 	for i := uint(0); i < n; i++ {
 		var (
+			scMod      = schema.Module(i)
 			height     = tr.Module(i).Height()
 			multiplier = tr.Module(i).Name().Multiplier
 			logical    = height / multiplier
 			target     uint
 		)
+		// Skip static reference tables
+		if scMod.IsStatic() {
+			continue
+		}
 		// Apply padding strategy
 		target = strategy(logical, multiplier)
 		// Only pad when the module falls short of its target.

--- a/pkg/test/util/check_valid.go
+++ b/pkg/test/util/check_valid.go
@@ -240,16 +240,16 @@ func runExecutionTests(t *testing.T, m vm.Program[vm.Uint], tc TestCase, f field
 		// Run the test
 		switch w {
 		case vm.WORD_UINT64:
-			runFixedWidthExecutionTest[vm.Uint64](t, m, tc, cfg, w)
+			runFixedWidthExecutionTest[vm.Uint64](t, m, tc, w)
 		case vm.WORD_UINT128:
-			runFixedWidthExecutionTest[vm.Uint128](t, m, tc, cfg, w)
+			runFixedWidthExecutionTest[vm.Uint128](t, m, tc, w)
 		default:
 			panic(fmt.Sprintf("unknown machine word: %s", w.Name))
 		}
 	}
 }
 
-func runFixedWidthExecutionTest[W vm.Word[W]](t *testing.T, pU vm.Program[vm.Uint], tc TestCase, cfg Config,
+func runFixedWidthExecutionTest[W vm.Word[W]](t *testing.T, pU vm.Program[vm.Uint], tc TestCase,
 	w vm.WordConfig) {
 	// Lower to fixed-width machine
 	pW := vm.ProgramToProgram[vm.Uint, W](pU)
@@ -442,7 +442,7 @@ func testConstraintsWithField[F field.Element[F]](t *testing.T, p vm.Program[vm.
 		// power of two)
 		traceCfg = constraints.DEFAULT_TRACE_CONFIG.WithPadding(paddingStrategy)
 		// generate trace
-		_, tr, errs = binf.Trace(inputs, traceCfg)
+		_, _, tr, errs = binf.Trace(inputs, traceCfg)
 	)
 	//
 	if test.expected {

--- a/pkg/util/termio/table.go
+++ b/pkg/util/termio/table.go
@@ -107,6 +107,20 @@ func (p *FormattedTable) SetMaxWidth(col uint, width uint) {
 	p.widths[col] = min(p.widths[col], width)
 }
 
+// PrintedWidth returns the total width (in characters) of this table as rendered
+// by Print.  This is useful when something of matching width needs to be drawn
+// alongside the table (e.g. a horizontal rule).  Each column contributes its
+// width plus a leading space, a trailing space and the separator.
+func (p *FormattedTable) PrintedWidth() uint {
+	var width uint
+	//
+	for _, w := range p.widths {
+		width += w + 2 + uint(len(p.separator))
+	}
+	//
+	return width
+}
+
 // Print the table with or without the use of ANSI escapes (e.g. for showing
 // colour).  Disabling escapes is useful in environments that don't support
 // escapes as, otherwise, you get a lot of visible excape characters being

--- a/pkg/zkc/constraints/binary_file.go
+++ b/pkg/zkc/constraints/binary_file.go
@@ -167,8 +167,11 @@ func (p *BinaryFile[F]) Execute(input map[string][]byte, n uint) (output map[str
 // vm.DecodeInputs() based on the register types of the corresponding memory.
 // This can return one (or more) errors if, for example, the input is malformed
 // (e.g. is missing expected fields and/or contains unexpected fields).
+// The raw (row-major) trace produced by the machine is also returned, since it
+// carries the original register / limb structure before AIR expansion (e.g. for
+// reporting statistics).  It is nil when execution fails.
 func (p *BinaryFile[F]) Trace(input map[string][]byte, cfg TraceConfig,
-) (output map[string][]byte, tr trace.Trace[F], errs []error) {
+) (output map[string][]byte, rtr rtrace.Trace[F], tr trace.Trace[F], errs []error) {
 	//
 	var (
 		processor = &postProcess[vm.Uint128, F]{}
@@ -176,8 +179,6 @@ func (p *BinaryFile[F]) Trace(input map[string][]byte, cfg TraceConfig,
 		stats = util.NewPerfStats()
 		// Lower bytecode program
 		prog64 = vm.ProgramToProgram[vm.Uint, vm.Uint128](p.program)
-		//
-		rtr rtrace.Trace[F]
 	)
 	// Execute machine in chunks of 1K steps
 	rtr, output, errs = vm.BootAndTrace(prog64, input, math.MaxUint, processor)
@@ -200,7 +201,7 @@ func (p *BinaryFile[F]) Trace(input map[string][]byte, cfg TraceConfig,
 	//
 	stats.Log("Trace generation")
 	//
-	return output, tr, errs
+	return output, rtr, tr, errs
 }
 
 func (p *BinaryFile[F]) cachedInterpreter() *vm.Interpreter[vm.Uint128] {


### PR DESCRIPTION
This adds a preliminary `trace` command which allows one to see stats and use the inspector again.