### PR TITLE
feat(gogen): native field registers for moduli ≤ 64 bits

### DIFF
--- a/pkg/zkc/vm/internal/gogen/intervals.go
+++ b/pkg/zkc/vm/internal/gogen/intervals.go
@@ -64,9 +64,7 @@ func newIntervals(fn *descFunction, isBoot, disabled bool) *intervals {
 	zero := big.NewInt(0)
 
 	for i, r := range regs {
-		w := min(widthOf(r), 128)
-
-		iv.caps[i] = widthMax(w)
+		iv.caps[i] = widthMax(min(widthOf(r), 128))
 		iv.entry[i] = zero
 
 		if !isBoot && uint(i) < fn.NumInputs() {


### PR DESCRIPTION
## Raison d'être

gogen rejected every program with a native (field-element) register. So the whole mixed suite ran interpreter-only, and gogen had a blind spot on the one thing those tests exist to exercise. This closes it for every field with a modulus ≤ 64 bits — i.e. all of them except BLS12-377.

## Hypothesis

A field element is just an integer in `[0, P)`. If `P ≤ 2^64` it fits a single `uint64`. The interpreter already treats a felt as an unbounded integer that is reduced mod P *only inside field ops* (add/sub/mul), stored raw everywhere else, and compared raw. gogen's mod-P emitters already do the same reduction. So there is nothing to compute differently — the only reason gogen said "unsupported" was that the register kind never got past the width lookup.

This makes gogen a bit-exact mirror of the interpreter for native registers, not an approximation.

## The diff

- **`regWidth`**: native register → width 64. Guarded on `modulus ≤ 64 bits`; a wider modulus (BLS12-377) stays a clean generation-time rejection instead of emitting wrong code.
- **`intervals`**: native register cap aligned to the uint64 representation.
- **`emit_call`**: native call parameters passed as-is (no width check — field values aren't width-bounded), native outputs returned as a single uint64.
- **`emit_memory`**: native memory data lines bound to the full uint64 range.
- **`emit_field`**: set `usesBits` only where a mod-P helper is actually emitted. The no-source add/mul paths store a constant directly and touch no `bits.*`; setting the flag unconditionally imported `math/bits` unused and the generated file failed to build. This path was previously dead (native regs were rejected upstream), which is why it surfaced now.
- **`zkc_mixed_test.go`**: `DEFAULT_MIXED_CONFIG` → `GoGen(true)`. The mixed suite now runs on gogen too — 12/12 green on KoalaBear.

No new arithmetic. ~62 lines, mostly letting existing code run.

## Bench gate cleanup

Dropped three stale `GoGen(false)` gates (Blake / Gcd / DivRem) — all pass with gogen enabled. `ModExp32` stays skipped: its failure is a trace-shape codegen issue that reproduces on the interpreter, nothing to do with gogen.

## Explicitly out of scope

Moduli > 64 bits (BLS12-377). A field element there needs a multi-limb representation; the register model can't express it as one local, so it remains a clean rejection. The BLS mixed fixtures are dormant anyway — `DEFAULT_FIELDS` is KoalaBear-only.

## Testing

- `Test_ZkcMixed_*`: 12/12 green with gogen.
- `Test_ZkcUnit` / `Test_ZkcInvalid`: green.
- Blake / Gcd / DivRem benches: green with gogen.
- gogen package tests, lint: green.

One pre-existing failure noted in passing: `Test_ZkcUtil_FillBytes/depth=65536` panics in trace-shape compilation (`CalculateSubBitwidth`). It reproduces on `main` without this change — not touched here.