### PR TITLE
feat: support bytecode validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,9 @@ require (
 	github.com/consensys/gnark-crypto v0.18.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
+	go.lsp.dev/jsonrpc2 v0.10.0
+	go.lsp.dev/protocol v0.12.0
+	go.lsp.dev/uri v0.3.0
 	golang.org/x/term v0.28.0
 )
 
@@ -16,10 +19,7 @@ require (
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.3.4 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	go.lsp.dev/jsonrpc2 v0.10.0 // indirect
 	go.lsp.dev/pkg v0.0.0-20210717090340-384b27a52fb2 // indirect
-	go.lsp.dev/protocol v0.12.0 // indirect
-	go.lsp.dev/uri v0.3.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.21.0 // indirect

--- a/pkg/zkc/compiler/codegen/compile.go
+++ b/pkg/zkc/compiler/codegen/compile.go
@@ -290,10 +290,13 @@ func (p *Compiler) compileFunction(id uint, mapping []uint, program []Declaratio
 		vectors[i] = compiler.compileStatement(uint(i), mapping, stmt)
 	}
 	//
-	native := slices.Contains(fn.Annotations(), "native")
+	kind := vm.BYTECODE_FUNCTION
+	if slices.Contains(fn.Annotations(), "native") {
+		kind = vm.NATIVE_FUNCTION
+	}
 	// Note: compiler.registers includes any temporaries allocated during
 	// statement compilation.
-	return vm.NewBytecodeFunction(fn.Name(), native, compiler.registers, vectors...), compiler.errors
+	return vm.NewBytecodeFunction(fn.Name(), kind, compiler.registers, vectors...), compiler.errors
 }
 
 // buildMemory constructs the memory descriptor module for a resolved memory

--- a/pkg/zkc/compiler/codegen/compile.go
+++ b/pkg/zkc/compiler/codegen/compile.go
@@ -205,6 +205,10 @@ func (p *Compiler) Compile(declarations []Declaration) (vm.Program[vm.Uint], []s
 	}
 	// Insert check casts to ensure appropriate safety checks during execution.
 	program = vm.InsertCheckCasts(program)
+	// Validate program to catch any introduced corruption as early as possible.
+	if err := vm.ValidateProgram(program); err != nil {
+		panic(err)
+	}
 	// Done
 	return program, errors
 }

--- a/pkg/zkc/vm/bytecode.go
+++ b/pkg/zkc/vm/bytecode.go
@@ -44,6 +44,22 @@ type Module[W Word[W]] = descriptor.Module[W]
 // analysis and/or translation into constraints.
 type Function[W Word[W]] = descriptor.Function[W]
 
+// FunctionKind identifies whether a function is implemented by bytecode or a
+// native circuit and whether calls may supply undefined arguments.
+type FunctionKind = descriptor.FunctionKind
+
+// Function kinds, re-exported for use with NewBytecodeFunction.
+var (
+	// BYTECODE_FUNCTION is a safe function implemented by bytecode.
+	BYTECODE_FUNCTION = descriptor.BYTECODE_FUNCTION
+	// NATIVE_FUNCTION is a safe function backed by a native circuit.
+	NATIVE_FUNCTION = descriptor.NATIVE_FUNCTION
+	// UNSAFE_ARGS_FUNCTION is a bytecode function which may receive undefined arguments.
+	UNSAFE_ARGS_FUNCTION = descriptor.UNSAFE_ARGS_FUNCTION
+	// NATIVE_UNSAFE_ARGS_FUNCTION is a native function which may receive undefined arguments.
+	NATIVE_UNSAFE_ARGS_FUNCTION = descriptor.NATIVE_UNSAFE_ARGS_FUNCTION
+)
+
 // Register describes a register
 type Register[W Word[W]] = descriptor.Register[W]
 
@@ -152,9 +168,9 @@ func NewBytecodeVector[W word.Word[W]](codes ...Bytecode[W]) BytecodeVector[W] {
 
 // NewBytecodeFunction constructs a bytecode (descriptor) function module from its
 // registers and a body of bytecode vectors.
-func NewBytecodeFunction[W word.Word[W]](name string, native bool, registers []Register[W],
+func NewBytecodeFunction[W word.Word[W]](name string, kind FunctionKind, registers []Register[W],
 	code ...BytecodeVector[W]) *Function[W] {
-	return descriptor.NewFunction[W](name, registers, native, code)
+	return descriptor.NewFunction[W](name, registers, kind, code)
 }
 
 // NewRegister constructs a new register descriptor, where native

--- a/pkg/zkc/vm/bytecode.go
+++ b/pkg/zkc/vm/bytecode.go
@@ -125,6 +125,19 @@ func CompileProgram[W word.Word[W]](p Program[W]) BinaryProgram[W] {
 	return interpreter.CompileProgram(p, false)
 }
 
+// ValidateProgram performs various sanity checks on the bytecode vectors of
+// each function within a program.  Sanity checks include: (1) ensuring that
+// vectors themselves are well-formed (e.g. with respect to write conflicts,
+// jump/skip destinations, terminal instructions, etc); (2) that each individual
+// bytecode is well formed within its function.  For example, that: any
+// registers it refers to actually exist; that registers it uses are of the
+// correct form (e.g. some instructions cannot operate on native registers);
+// that any call targets exist and are functions and, likewise, that any memory
+// accesses exist and are memories.  It returns nil when no problems are found.
+func ValidateProgram[W word.Word[W]](p Program[W]) error {
+	return validateBytecodeProgram(p)
+}
+
 // NewBytecodeProgram assembles a bytecode program directly from pre-lowered
 // descriptor modules, bypassing the word-machine round trip.
 func NewBytecodeProgram[W word.Word[W]](field field.Config, modules ...Module[W]) Program[W] {

--- a/pkg/zkc/vm/internal/bytecode/arith.go
+++ b/pkg/zkc/vm/internal/bytecode/arith.go
@@ -50,8 +50,8 @@ func (p *Arith[W]) Definitions() []RegisterId {
 }
 
 // Validate implementation for Bytecode interface.
-func (p *Arith[W]) Validate(_ uint, _ FieldConfig, _ Environment[W]) []error {
-	return nil
+func (p *Arith[W]) Validate(_ FieldConfig, env Environment[W]) []error {
+	return validateOperands(env, p.Source, p.Target)
 }
 
 func (p *Arith[W]) String(env Environment[W]) string {

--- a/pkg/zkc/vm/internal/bytecode/bitwise.go
+++ b/pkg/zkc/vm/internal/bytecode/bitwise.go
@@ -44,8 +44,8 @@ func (p *Bitwise[W]) Definitions() []RegisterId {
 }
 
 // Validate implementation for Bytecode interface.
-func (p *Bitwise[W]) Validate(_ uint, _ FieldConfig, _ Environment[W]) []error {
-	return nil
+func (p *Bitwise[W]) Validate(_ FieldConfig, env Environment[W]) []error {
+	return validateOperands(env, p.Uses(), p.Definitions())
 }
 
 func (p *Bitwise[W]) String(env Environment[W]) string {

--- a/pkg/zkc/vm/internal/bytecode/bytecode.go
+++ b/pkg/zkc/vm/internal/bytecode/bytecode.go
@@ -172,10 +172,9 @@ type Bytecode[W word.Word[W]] interface {
 	// bytecode.
 	Definitions() []RegisterId
 	// Validate checks that this bytecode is well-formed, returning any errors
-	// found (or nil when it is well-formed).  Here, width is the number of
-	// bytecodes in the enclosing vector, field is the surrounding field
-	// configuration and env resolves register information.
-	Validate(width uint, field FieldConfig, env Environment[W]) []error
+	// found (or nil when it is well-formed).  Field is the surrounding field
+	// configuration and env resolves register and module information.
+	Validate(field FieldConfig, env Environment[W]) []error
 	// String returns a suitable string representation of this bytecode.
 	String(Environment[W]) string
 }
@@ -187,16 +186,21 @@ type Bytecode[W word.Word[W]] interface {
 type Environment[W word.Word[W]] interface {
 	// Name returns the name of the enclosing function.
 	Name() string
-	// HasRegister checks whether a register with the given name exists and, if
-	// so, returns its register identifier.  Otherwise, it returns none.
-	HasModule(name string) util.Option[RegisterId]
+	// HasModule checks whether a module with the given name exists and, if so,
+	// returns its module identifier. Otherwise, it returns none.
+	HasModule(name string) util.Option[ModuleId]
 	// HasRegister checks whether a register with the given name exists and, if
 	// so, returns its register identifier.  Otherwise, it returns none.
 	HasRegister(name string) util.Option[RegisterId]
-	// Register returns the ith register used in this module.
-	Module(id ModuleId) ModuleInfo
+	// Module returns information about the given module, or none if it does not
+	// exist.
+	Module(id ModuleId) util.Option[ModuleInfo]
 	// Register returns the ith register used in this module.
 	Register(id RegisterId) RegisterInfo
+	// RegisterCount returns the number of registers in the enclosing module.
+	RegisterCount() uint
+	// VectorCount returns the number of vectors in the enclosing function.
+	VectorCount() uint
 	// ValueOf optionally returns the current value held in the given register.
 	// This is used (for example) by the debugger to render register values
 	// inline within an instruction's string representation.  Environments which
@@ -219,8 +223,46 @@ type RegisterInfo interface {
 // ModuleInfo provides a minimal amount of information about a module in the
 // enclosing environment.
 type ModuleInfo interface {
-	// Name returns the  name of this register
+	// Name returns the name of this module.
 	Name() string
+	// IsFunction indicates whether this module can be called.
+	IsFunction() bool
+	// IsMemory indicates whether this module supports memory accesses.
+	IsMemory() bool
+	// IsReadOnly indicates whether this module forbids writes.
+	IsReadOnly() bool
+	// IsWriteOnly indicates whether this module forbids reads.
+	IsWriteOnly() bool
+	// NumInputs returns the number of input registers in this module.
+	NumInputs() uint
+	// NumOutputs returns the number of output registers in this module.
+	NumOutputs() uint
+	// Width returns the total number of registers in this module.
+	Width() uint
+}
+
+// validateOperands ensures that every register operand exists in the enclosing
+// module. Repeated operands are reported at most once.
+func validateOperands[W word.Word[W]](env Environment[W], operands ...[]RegisterId) []error {
+	var (
+		errors []error
+		seen   = make(map[RegisterId]bool)
+	)
+
+	for _, group := range operands {
+		for _, id := range group {
+			if seen[id] {
+				continue
+			}
+
+			seen[id] = true
+			if uint(id) >= env.RegisterCount() {
+				errors = append(errors, fmt.Errorf("register %d does not exist", id))
+			}
+		}
+	}
+
+	return errors
 }
 
 // ============================================================================

--- a/pkg/zkc/vm/internal/bytecode/bytecode.go
+++ b/pkg/zkc/vm/internal/bytecode/bytecode.go
@@ -227,6 +227,8 @@ type ModuleInfo interface {
 	Name() string
 	// IsFunction indicates whether this module can be called.
 	IsFunction() bool
+	// HasUnsafeArgs indicates whether a function accepts maybe-undefined arguments.
+	HasUnsafeArgs() bool
 	// IsMemory indicates whether this module supports memory accesses.
 	IsMemory() bool
 	// IsReadOnly indicates whether this module forbids writes.

--- a/pkg/zkc/vm/internal/bytecode/call.go
+++ b/pkg/zkc/vm/internal/bytecode/call.go
@@ -60,8 +60,8 @@ func (p *Call[W]) Validate(_ FieldConfig, env Environment[W]) []error {
 			callee.Name(), callee.NumInputs(), len(p.Arguments)))
 	}
 
-	if len(p.Returns) != int(callee.NumOutputs()) {
-		errors = append(errors, fmt.Errorf("call to %s expects %d returns (found %d)",
+	if len(p.Returns) > int(callee.NumOutputs()) {
+		errors = append(errors, fmt.Errorf("call to %s provides only %d returns (found %d)",
 			callee.Name(), callee.NumOutputs(), len(p.Returns)))
 	}
 

--- a/pkg/zkc/vm/internal/bytecode/call.go
+++ b/pkg/zkc/vm/internal/bytecode/call.go
@@ -42,8 +42,30 @@ func (p *Call[W]) Definitions() []RegisterId {
 }
 
 // Validate implementation for Bytecode interface.
-func (p *Call[W]) Validate(_ uint, _ FieldConfig, _ Environment[W]) []error {
-	return nil
+func (p *Call[W]) Validate(_ FieldConfig, env Environment[W]) []error {
+	errors := validateOperands(env, p.Arguments, p.Returns)
+
+	module := env.Module(p.Target)
+	if module.IsEmpty() {
+		return append(errors, fmt.Errorf("call target %d does not exist", p.Target))
+	}
+
+	callee := module.Unwrap()
+	if !callee.IsFunction() {
+		return append(errors, fmt.Errorf("call target %d (%s) is not a function", p.Target, callee.Name()))
+	}
+
+	if len(p.Arguments) != int(callee.NumInputs()) {
+		errors = append(errors, fmt.Errorf("call to %s expects %d arguments (found %d)",
+			callee.Name(), callee.NumInputs(), len(p.Arguments)))
+	}
+
+	if len(p.Returns) != int(callee.NumOutputs()) {
+		errors = append(errors, fmt.Errorf("call to %s expects %d returns (found %d)",
+			callee.Name(), callee.NumOutputs(), len(p.Returns)))
+	}
+
+	return errors
 }
 
 func (p *Call[W]) String(env Environment[W]) string {
@@ -60,7 +82,12 @@ func (p *Call[W]) String(env Environment[W]) string {
 		builder.WriteString(" = ")
 	}
 	//
-	fmt.Fprintf(&builder, "%s(%s)", mod.Name(), RegistersToString(p.Arguments, env, ","))
+	name := "???"
+	if mod.HasValue() {
+		name = mod.Unwrap().Name()
+	}
+
+	fmt.Fprintf(&builder, "%s(%s)", name, RegistersToString(p.Arguments, env, ","))
 	//
 	return builder.String()
 }

--- a/pkg/zkc/vm/internal/bytecode/cat.go
+++ b/pkg/zkc/vm/internal/bytecode/cat.go
@@ -38,8 +38,8 @@ func (p *Cat[W]) Definitions() []RegisterId {
 }
 
 // Validate implementation for Bytecode interface.
-func (p *Cat[W]) Validate(_ uint, _ FieldConfig, _ Environment[W]) []error {
-	return nil
+func (p *Cat[W]) Validate(_ FieldConfig, env Environment[W]) []error {
+	return validateOperands(env, p.Sources, p.Targets)
 }
 
 func (p *Cat[W]) String(env Environment[W]) string {

--- a/pkg/zkc/vm/internal/bytecode/checkcast.go
+++ b/pkg/zkc/vm/internal/bytecode/checkcast.go
@@ -40,8 +40,8 @@ func (p *CheckCast[W]) Definitions() []RegisterId {
 }
 
 // Validate implementation for Bytecode interface.
-func (p *CheckCast[W]) Validate(_ uint, _ FieldConfig, _ Environment[W]) []error {
-	return nil
+func (p *CheckCast[W]) Validate(_ FieldConfig, env Environment[W]) []error {
+	return validateOperands(env, p.Uses())
 }
 
 func (p *CheckCast[W]) String(env Environment[W]) string {

--- a/pkg/zkc/vm/internal/bytecode/debug.go
+++ b/pkg/zkc/vm/internal/bytecode/debug.go
@@ -52,8 +52,8 @@ func (p *Debug[W]) Definitions() []RegisterId {
 }
 
 // Validate implementation for Bytecode interface.
-func (p *Debug[W]) Validate(_ uint, _ FieldConfig, _ Environment[W]) []error {
-	return nil
+func (p *Debug[W]) Validate(_ FieldConfig, env Environment[W]) []error {
+	return validateOperands(env, p.Uses())
 }
 
 func (p *Debug[W]) String(env Environment[W]) string {

--- a/pkg/zkc/vm/internal/bytecode/div.go
+++ b/pkg/zkc/vm/internal/bytecode/div.go
@@ -41,8 +41,8 @@ func (p *DivRem[W]) Definitions() []RegisterId {
 }
 
 // Validate implementation for Bytecode interface.
-func (p *DivRem[W]) Validate(_ uint, _ FieldConfig, _ Environment[W]) []error {
-	return nil
+func (p *DivRem[W]) Validate(_ FieldConfig, env Environment[W]) []error {
+	return validateOperands(env, p.Uses(), p.Definitions())
 }
 
 func (p *DivRem[W]) String(mapping Environment[W]) string {

--- a/pkg/zkc/vm/internal/bytecode/fail.go
+++ b/pkg/zkc/vm/internal/bytecode/fail.go
@@ -52,8 +52,8 @@ func (p *Fail[W]) Definitions() []RegisterId {
 }
 
 // Validate implementation for Bytecode interface.
-func (p *Fail[W]) Validate(_ uint, _ FieldConfig, _ Environment[W]) []error {
-	return nil
+func (p *Fail[W]) Validate(_ FieldConfig, env Environment[W]) []error {
+	return validateOperands(env, p.Uses())
 }
 
 func (p *Fail[W]) String(env Environment[W]) string {

--- a/pkg/zkc/vm/internal/bytecode/field.go
+++ b/pkg/zkc/vm/internal/bytecode/field.go
@@ -48,8 +48,8 @@ func (p *FieldArith[W]) Definitions() []RegisterId {
 }
 
 // Validate implementation for Bytecode interface.
-func (p *FieldArith[W]) Validate(_ uint, _ FieldConfig, _ Environment[W]) []error {
-	return nil
+func (p *FieldArith[W]) Validate(_ FieldConfig, env Environment[W]) []error {
+	return validateOperands(env, p.Sources, p.Definitions())
 }
 
 func (p *FieldArith[W]) String(env Environment[W]) string {

--- a/pkg/zkc/vm/internal/bytecode/intrinsic.go
+++ b/pkg/zkc/vm/internal/bytecode/intrinsic.go
@@ -87,8 +87,8 @@ func (p *Intrinsic[W]) Definitions() []RegisterId {
 
 // Validate implementation for Bytecode interface.  This checks that the number
 // of arguments and returns matches what the selected operation expects.
-func (p *Intrinsic[W]) Validate(_ uint, _ FieldConfig, _ Environment[W]) []error {
-	var errs []error
+func (p *Intrinsic[W]) Validate(_ FieldConfig, env Environment[W]) []error {
+	errs := validateOperands(env, p.Uses(), p.Definitions())
 	//
 	switch p.Op {
 	case DIV_HINT:

--- a/pkg/zkc/vm/internal/bytecode/jmp.go
+++ b/pkg/zkc/vm/internal/bytecode/jmp.go
@@ -32,7 +32,7 @@ func (p *Jmp[W]) Definitions() []RegisterId {
 }
 
 // Validate implementation for Bytecode interface.
-func (p *Jmp[W]) Validate(_ uint, _ FieldConfig, _ Environment[W]) []error {
+func (p *Jmp[W]) Validate(_ FieldConfig, _ Environment[W]) []error {
 	return nil
 }
 

--- a/pkg/zkc/vm/internal/bytecode/readwrite.go
+++ b/pkg/zkc/vm/internal/bytecode/readwrite.go
@@ -55,8 +55,36 @@ func (p *ReadWrite[W]) Definitions() []RegisterId {
 }
 
 // Validate implementation for Bytecode interface.
-func (p *ReadWrite[W]) Validate(_ uint, _ FieldConfig, _ Environment[W]) []error {
-	return nil
+func (p *ReadWrite[W]) Validate(_ FieldConfig, env Environment[W]) []error {
+	errors := validateOperands(env, p.Address, p.Data)
+
+	module := env.Module(p.Id)
+	if module.IsEmpty() {
+		return append(errors, fmt.Errorf("memory target %d does not exist", p.Id))
+	}
+
+	memory := module.Unwrap()
+	if !memory.IsMemory() {
+		return append(errors, fmt.Errorf("memory target %d (%s) is not a memory", p.Id, memory.Name()))
+	}
+
+	if p.Write && memory.IsReadOnly() {
+		errors = append(errors, fmt.Errorf("cannot write to read-only memory %s", memory.Name()))
+	} else if !p.Write && memory.IsWriteOnly() {
+		errors = append(errors, fmt.Errorf("cannot read from write-only memory %s", memory.Name()))
+	}
+
+	if len(p.Address) != int(memory.NumInputs()) {
+		errors = append(errors, fmt.Errorf("memory %s expects %d address registers (found %d)",
+			memory.Name(), memory.NumInputs(), len(p.Address)))
+	}
+
+	if len(p.Data) != int(memory.NumOutputs()) {
+		errors = append(errors, fmt.Errorf("memory %s expects %d data registers (found %d)",
+			memory.Name(), memory.NumOutputs(), len(p.Data)))
+	}
+
+	return errors
 }
 
 func (p *ReadWrite[W]) String(env Environment[W]) string {
@@ -67,7 +95,9 @@ func (p *ReadWrite[W]) String(env Environment[W]) string {
 	)
 	//
 	if env != nil {
-		name = env.Module(p.Id).Name()
+		if module := env.Module(p.Id); module.HasValue() {
+			name = module.Unwrap().Name()
+		}
 	}
 	//
 	if p.Write {

--- a/pkg/zkc/vm/internal/bytecode/ret.go
+++ b/pkg/zkc/vm/internal/bytecode/ret.go
@@ -33,7 +33,7 @@ func (p *Ret[W]) Definitions() []RegisterId {
 }
 
 // Validate implementation for Bytecode interface.
-func (p *Ret[W]) Validate(_ uint, _ FieldConfig, _ Environment[W]) []error {
+func (p *Ret[W]) Validate(_ FieldConfig, _ Environment[W]) []error {
 	return nil
 }
 

--- a/pkg/zkc/vm/internal/bytecode/skip.go
+++ b/pkg/zkc/vm/internal/bytecode/skip.go
@@ -32,7 +32,7 @@ func (p *Skip[W]) Definitions() []RegisterId {
 }
 
 // Validate implementation for Bytecode interface.
-func (p *Skip[W]) Validate(_ uint, _ FieldConfig, _ Environment[W]) []error {
+func (p *Skip[W]) Validate(_ FieldConfig, _ Environment[W]) []error {
 	return nil
 }
 

--- a/pkg/zkc/vm/internal/bytecode/skip_if.go
+++ b/pkg/zkc/vm/internal/bytecode/skip_if.go
@@ -54,11 +54,15 @@ func (p *SkipIf[W]) Definitions() []RegisterId {
 // right (mirroring base.SkipIf.MicroValidate): a narrower left operand could
 // not faithfully hold the value it is compared against.  When either vector
 // involves a native register (and hence has no fixed width) no check applies.
-func (p *SkipIf[W]) Validate(_ uint, _ FieldConfig, env Environment[W]) []error {
+func (p *SkipIf[W]) Validate(_ FieldConfig, env Environment[W]) []error {
+	errors := validateOperands(env, p.Left.Registers(), p.Right.Registers())
+	if len(errors) != 0 {
+		return errors
+	}
+
 	var (
-		errors []error
-		lw     = vectorBitwidth(p.Left, env)
-		rw     = vectorBitwidth(p.Right, env)
+		lw = vectorBitwidth(p.Left, env)
+		rw = vectorBitwidth(p.Right, env)
 	)
 	//
 	if lw.HasValue() && rw.HasValue() && lw.Unwrap() < rw.Unwrap() {

--- a/pkg/zkc/vm/internal/bytecode/skip_if.go
+++ b/pkg/zkc/vm/internal/bytecode/skip_if.go
@@ -15,7 +15,6 @@ package bytecode
 import (
 	"fmt"
 
-	"github.com/LFDT-Lineth/zkc/pkg/util"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/word"
 )
 
@@ -49,46 +48,9 @@ func (p *SkipIf[W]) Definitions() []RegisterId {
 	return nil
 }
 
-// Validate implementation for Bytecode interface.  A conditional skip is
-// well-formed only when its left operand vector is at least as wide as its
-// right (mirroring base.SkipIf.MicroValidate): a narrower left operand could
-// not faithfully hold the value it is compared against.  When either vector
-// involves a native register (and hence has no fixed width) no check applies.
+// Validate implementation for Bytecode interface.
 func (p *SkipIf[W]) Validate(_ FieldConfig, env Environment[W]) []error {
-	errors := validateOperands(env, p.Left.Registers(), p.Right.Registers())
-	if len(errors) != 0 {
-		return errors
-	}
-
-	var (
-		lw = vectorBitwidth(p.Left, env)
-		rw = vectorBitwidth(p.Right, env)
-	)
-	//
-	if lw.HasValue() && rw.HasValue() && lw.Unwrap() < rw.Unwrap() {
-		errors = append(errors, fmt.Errorf("bit overflow (u%d into u%d)", lw.Unwrap(), rw.Unwrap()))
-	}
-	//
-	return errors
-}
-
-// vectorBitwidth returns the total bitwidth of a register vector under the
-// given environment, or the empty option when any constituent register is
-// native (and hence has no fixed bitwidth).
-func vectorBitwidth[W word.Word[W]](v RegisterVector, env Environment[W]) util.Option[uint] {
-	var total uint
-	//
-	for _, r := range v.Registers() {
-		bw := env.Register(r).Bitwidth()
-		//
-		if !bw.HasValue() {
-			return util.None[uint]()
-		}
-		//
-		total += bw.Unwrap()
-	}
-	//
-	return util.Some(total)
+	return validateOperands(env, p.Left.Registers(), p.Right.Registers())
 }
 
 func (p *SkipIf[W]) String(env Environment[W]) string {

--- a/pkg/zkc/vm/internal/bytecode/switch.go
+++ b/pkg/zkc/vm/internal/bytecode/switch.go
@@ -68,11 +68,15 @@ func (p *Switch[W]) Definitions() []RegisterId {
 // first match wins, a duplicate is unreachable and almost certainly a mistake)
 // and must fit within the source register's width.  A native source register
 // holds arbitrary-width values, so no value can overflow it.
-func (p *Switch[W]) Validate(_ uint, _ FieldConfig, env Environment[W]) []error {
+func (p *Switch[W]) Validate(_ FieldConfig, env Environment[W]) []error {
+	errors := validateOperands(env, p.Uses())
+	if len(errors) != 0 {
+		return errors
+	}
+
 	var (
-		errors []error
-		seen   = make(map[string]bool)
-		width  = env.Register(p.Source).Bitwidth()
+		seen  = make(map[string]bool)
+		width = env.Register(p.Source).Bitwidth()
 	)
 	//
 	for _, c := range p.Cases {

--- a/pkg/zkc/vm/internal/bytecode/vector.go
+++ b/pkg/zkc/vm/internal/bytecode/vector.go
@@ -177,14 +177,16 @@ func (p *Vector[W]) validateReadWriteConflicts(env Environment[W]) []error {
 			ith      = p.Bytecodes[i]
 		)
 		// Sanity check for conflicting reads.
-		for _, r := range ith.Uses() {
-			if isZeroWidth(r, env) {
-				continue
-			}
+		if !isUnsafeCall(ith, env) {
+			for _, r := range ith.Uses() {
+				if isZeroWidth(r, env) {
+					continue
+				}
 
-			if rid := register.NewId(uint(r)); ithState.MaybeAssigned(rid) && !ithState.DefinitelyAssigned(rid) {
-				errors = append(errors,
-					fmt.Errorf("conflicting read on register \"%s\" in \"%s\"", RegisterToString(r, env), ith.String(env)))
+				if rid := register.NewId(uint(r)); ithState.MaybeAssigned(rid) && !ithState.DefinitelyAssigned(rid) {
+					errors = append(errors,
+						fmt.Errorf("conflicting read on register \"%s\" in \"%s\"", RegisterToString(r, env), ith.String(env)))
+				}
 			}
 		}
 		// Sanity check for conflicting writes.
@@ -201,6 +203,22 @@ func (p *Vector[W]) validateReadWriteConflicts(env Environment[W]) []error {
 	}
 	//
 	return errors
+}
+
+func isUnsafeCall[W word.Word[W]](code Bytecode[W], env Environment[W]) bool {
+	call, ok := code.(*Call[W])
+	if !ok {
+		return false
+	}
+
+	module := env.Module(call.Target)
+	if module.IsEmpty() {
+		return false
+	}
+
+	callee := module.Unwrap()
+
+	return callee.IsFunction() && callee.HasUnsafeArgs()
 }
 
 // validateControlFlow checks the intra-vector control-flow graph.  Every skip

--- a/pkg/zkc/vm/internal/bytecode/vector.go
+++ b/pkg/zkc/vm/internal/bytecode/vector.go
@@ -14,6 +14,7 @@ package bytecode
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/LFDT-Lineth/zkc/pkg/asm/io/micro/dfa"
@@ -108,22 +109,79 @@ func (p *Vector[W]) String(env Environment[W]) string {
 // which _may_ (but not _definitely_) have been written.
 func (p *Vector[W]) Validate(field FieldConfig, env Environment[W]) []error {
 	var (
+		errors, structureSafe      = p.validateStructure(env)
+		controlErrors, controlSafe = p.validateControlFlow()
+	)
+
+	errors = append(errors, controlErrors...)
+	// Validate individual bytecodes. Each bytecode checks its operands before
+	// performing any environment lookup.
+	for _, b := range p.Bytecodes {
+		if !isNilBytecode(b) {
+			errors = append(errors, b.Validate(field, env)...)
+		}
+	}
+	// WriteMap assumes that every control-flow destination is in bounds and
+	// every bytecode is non-nil.
+	if !structureSafe || !controlSafe {
+		return errors
+	}
+
+	return append(errors, p.validateReadWriteConflicts(env)...)
+}
+
+// validateStructure checks every index which an environment lookup or jump
+// would dereference. The returned boolean indicates whether environment-
+// dependent bytecode validation and write-map construction are safe.
+func (p *Vector[W]) validateStructure(env Environment[W]) ([]error, bool) {
+	var (
+		errors []error
+		safe   = true
+	)
+
+	for i, code := range p.Bytecodes {
+		if isNilBytecode(code) {
+			errors = append(errors, fmt.Errorf("bytecode %d is nil", i))
+			safe = false
+
+			continue
+		}
+
+		for _, registers := range [][]RegisterId{code.Uses(), code.Definitions()} {
+			for _, id := range registers {
+				if uint(id) >= env.RegisterCount() {
+					safe = false
+				}
+			}
+		}
+
+		if jump, ok := code.(*Jmp[W]); ok && uint(jump.Target) >= env.VectorCount() {
+			errors = append(errors, fmt.Errorf("bytecode %d: jump target %d does not exist", i, jump.Target))
+			safe = false
+		}
+	}
+
+	return errors, safe
+}
+
+// validateReadWriteConflicts checks for ambiguous reads and writes along every
+// execution path through this vector.
+func (p *Vector[W]) validateReadWriteConflicts(env Environment[W]) []error {
+	var (
 		errors   []error
-		nCodes   = uint(len(p.Bytecodes))
 		writeMap = p.WriteMap()
 	)
-	// Validate individual bytecodes.
-	for _, b := range p.Bytecodes {
-		errors = append(errors, b.Validate(nCodes, field, env)...)
-	}
-	// Validate there are no read/write conflicts.
-	for i := range nCodes {
+	for i := range uint(len(p.Bytecodes)) {
 		var (
 			ithState = writeMap.StateOf(i)
 			ith      = p.Bytecodes[i]
 		)
 		// Sanity check for conflicting reads.
 		for _, r := range ith.Uses() {
+			if isZeroWidth(r, env) {
+				continue
+			}
+
 			if rid := register.NewId(uint(r)); ithState.MaybeAssigned(rid) && !ithState.DefinitelyAssigned(rid) {
 				errors = append(errors,
 					fmt.Errorf("conflicting read on register \"%s\" in \"%s\"", RegisterToString(r, env), ith.String(env)))
@@ -131,6 +189,10 @@ func (p *Vector[W]) Validate(field FieldConfig, env Environment[W]) []error {
 		}
 		// Sanity check for conflicting writes.
 		for _, r := range ith.Definitions() {
+			if isZeroWidth(r, env) {
+				continue
+			}
+
 			if rid := register.NewId(uint(r)); ithState.MaybeAssigned(rid) {
 				errors = append(errors,
 					fmt.Errorf("conflicting write on register \"%s\" in \"%s\"", RegisterToString(r, env), ith.String(env)))
@@ -139,6 +201,121 @@ func (p *Vector[W]) Validate(field FieldConfig, env Environment[W]) []error {
 	}
 	//
 	return errors
+}
+
+// validateControlFlow checks the intra-vector control-flow graph.  Every skip
+// destination must exist, including destinations in unreachable code, and
+// every reachable path must end in a terminal bytecode.
+func (p *Vector[W]) validateControlFlow() ([]error, bool) {
+	var (
+		errors []error
+		n      = uint(len(p.Bytecodes))
+		safe   = n != 0
+	)
+	if n == 0 {
+		return []error{fmt.Errorf("empty vector")}, false
+	}
+
+	for i, code := range p.Bytecodes {
+		if isNilBytecode(code) {
+			safe = false
+			continue
+		}
+
+		micro := uint(i)
+
+		switch code := code.(type) {
+		case *Skip[W]:
+			errors, safe = validateSkipDestination(errors, safe, micro, uint(code.Skip), n)
+		case *SkipIf[W]:
+			errors, safe = validateSkipDestination(errors, safe, micro, uint(code.Skip), n)
+		case *Switch[W]:
+			for _, c := range code.Cases {
+				errors, safe = validateSkipDestination(errors, safe, micro, uint(c.Skip), n)
+			}
+		}
+	}
+	// Explore only valid successors. Invalid destinations were reported above.
+	var (
+		visited = make([]bool, n)
+		visit   func(uint)
+	)
+
+	visit = func(micro uint) {
+		if micro >= n {
+			errors = append(errors, fmt.Errorf("reachable path falls off end of vector"))
+			safe = false
+
+			return
+		}
+
+		if visited[micro] {
+			return
+		}
+
+		visited[micro] = true
+
+		code := p.Bytecodes[micro]
+		if isNilBytecode(code) {
+			return
+		}
+
+		switch code := code.(type) {
+		case *Fail[W], *Jmp[W], *Ret[W]:
+			return
+		case *Skip[W]:
+			visitSkipDestination(micro, uint(code.Skip), n, visit)
+		case *SkipIf[W]:
+			visit(micro + 1)
+			visitSkipDestination(micro, uint(code.Skip), n, visit)
+		case *Switch[W]:
+			visit(micro + 1)
+
+			for _, c := range code.Cases {
+				visitSkipDestination(micro, uint(c.Skip), n, visit)
+			}
+		default:
+			visit(micro + 1)
+		}
+	}
+	visit(0)
+
+	return errors, safe
+}
+
+func validateSkipDestination(errors []error, safe bool, micro, skip, length uint) ([]error, bool) {
+	target := micro + skip + 1
+	if target >= length {
+		errors = append(errors, fmt.Errorf("bytecode %d: skip target %d does not exist", micro, target))
+		return errors, false
+	}
+
+	return errors, safe
+}
+
+func visitSkipDestination(micro, skip, length uint, visit func(uint)) {
+	target := micro + skip + 1
+	if target < length {
+		visit(target)
+	}
+}
+
+func isNilBytecode[W word.Word[W]](code Bytecode[W]) bool {
+	if code == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(code)
+
+	return value.Kind() == reflect.Pointer && value.IsNil()
+}
+
+// Zero-width registers are placeholders introduced by register splitting. They
+// carry no data, so apparent reads and writes to a shared placeholder cannot
+// conflict.
+func isZeroWidth[W word.Word[W]](id RegisterId, env Environment[W]) bool {
+	width := env.Register(id).Bitwidth()
+	return width.HasValue() && width.Unwrap() == 0
 }
 
 // WriteMap constructs the write map for this vector instruction.

--- a/pkg/zkc/vm/internal/descriptor/function.go
+++ b/pkg/zkc/vm/internal/descriptor/function.go
@@ -30,18 +30,21 @@ var _ Module[word.Uint] = &Function[word.Uint]{}
 // line) or backed by a native circuit rather than bytecode instructions.
 type Function[W word.Word[W]] struct {
 	moduleBase[W]
-	// Native indicates whether this function is backed by a native circuit
-	// (i.e. declared with the @native annotation) rather than by the
-	// instructions in code.
-	native bool
+	// Kind records the execution-relevant properties of this function.
+	kind FunctionKind
 	// Code defines the body of this function.
 	vectors []bytecode.Vector[W]
 }
 
 // NewFunction constructs a new function with the given components.
-func NewFunction[W word.Word[W]](name string, registers []Register[W], native bool,
+func NewFunction[W word.Word[W]](name string, registers []Register[W], kind FunctionKind,
 	code []bytecode.Vector[W]) *Function[W] {
-	return &Function[W]{newModuleBase(name, registers), native, code}
+	return &Function[W]{newModuleBase(name, registers), kind, code}
+}
+
+// Kind returns the execution kind of this function.
+func (p *Function[W]) Kind() FunctionKind {
+	return p.kind
 }
 
 // IsOneLine determines whether or not this function contains a single "line"
@@ -57,7 +60,13 @@ func (p *Function[W]) IsOneLine() bool {
 // declared with the @native annotation) rather than by the bytecode in its
 // vectors.
 func (p *Function[W]) IsNative() bool {
-	return p.native
+	return p.kind.IsNative()
+}
+
+// HasUnsafeArgs reports whether calls may supply arguments which are undefined
+// on some paths reaching the call.
+func (p *Function[W]) HasUnsafeArgs() bool {
+	return p.kind.AllowsUnsafeArgs()
 }
 
 // IsFunction identifies this module as a callable function.
@@ -122,7 +131,7 @@ func (p *Function[W]) GobEncode() ([]byte, error) {
 		return nil, err
 	}
 	//
-	if err := gobEncoder.Encode(p.native); err != nil {
+	if err := gobEncoder.Encode(&p.kind); err != nil {
 		return nil, err
 	}
 	//
@@ -152,7 +161,7 @@ func (p *Function[W]) GobDecode(data []byte) error {
 		return err
 	}
 	//
-	if err := gobDecoder.Decode(&p.native); err != nil {
+	if err := gobDecoder.Decode(&p.kind); err != nil {
 		return err
 	}
 	//

--- a/pkg/zkc/vm/internal/descriptor/function.go
+++ b/pkg/zkc/vm/internal/descriptor/function.go
@@ -60,6 +60,26 @@ func (p *Function[W]) IsNative() bool {
 	return p.native
 }
 
+// IsFunction identifies this module as a callable function.
+func (p *Function[W]) IsFunction() bool {
+	return true
+}
+
+// IsMemory identifies this module as a function rather than a memory.
+func (p *Function[W]) IsMemory() bool {
+	return false
+}
+
+// IsReadOnly is false because memory access modes do not apply to functions.
+func (p *Function[W]) IsReadOnly() bool {
+	return false
+}
+
+// IsWriteOnly is false because memory access modes do not apply to functions.
+func (p *Function[W]) IsWriteOnly() bool {
+	return false
+}
+
 // PcWidth returns the bit width required for this function's program counter
 // register, which must be able to index every code line plus the (one past the
 // end) halt value.  Only meaningful for non-atomic functions, which are the

--- a/pkg/zkc/vm/internal/descriptor/function_kind.go
+++ b/pkg/zkc/vm/internal/descriptor/function_kind.go
@@ -1,0 +1,80 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package descriptor
+
+import (
+	"bytes"
+	"encoding/gob"
+)
+
+// FunctionKind captures the execution-relevant properties of a function.
+type FunctionKind struct {
+	native, unsafeArgs bool
+}
+
+// IsNative reports whether this function is backed by a native circuit rather
+// than bytecode instructions.
+func (p FunctionKind) IsNative() bool {
+	return p.native
+}
+
+// AllowsUnsafeArgs reports whether calls may supply arguments which are undefined
+// on some paths reaching the call.
+func (p FunctionKind) AllowsUnsafeArgs() bool {
+	return p.unsafeArgs
+}
+
+// GobEncode marshals this function kind.
+//
+// nolint
+func (p *FunctionKind) GobEncode() ([]byte, error) {
+	var buffer bytes.Buffer
+	gobEncoder := gob.NewEncoder(&buffer)
+	//
+	if err := gobEncoder.Encode(p.native); err != nil {
+		return nil, err
+	}
+	//
+	if err := gobEncoder.Encode(p.unsafeArgs); err != nil {
+		return nil, err
+	}
+	//
+	return buffer.Bytes(), nil
+}
+
+// GobDecode unmarshals this function kind.
+//
+// nolint
+func (p *FunctionKind) GobDecode(data []byte) error {
+	var (
+		buffer     = bytes.NewBuffer(data)
+		gobDecoder = gob.NewDecoder(buffer)
+	)
+	//
+	if err := gobDecoder.Decode(&p.native); err != nil {
+		return err
+	}
+	//
+	return gobDecoder.Decode(&p.unsafeArgs)
+}
+
+var (
+	// BYTECODE_FUNCTION represents a safe function implemented by bytecode.
+	BYTECODE_FUNCTION = FunctionKind{false, false}
+	// NATIVE_FUNCTION represents a safe function backed by a native circuit.
+	NATIVE_FUNCTION = FunctionKind{true, false}
+	// UNSAFE_ARGS_FUNCTION represents a bytecode function which may receive undefined arguments.
+	UNSAFE_ARGS_FUNCTION = FunctionKind{false, true}
+	// NATIVE_UNSAFE_ARGS_FUNCTION represents a native function which may receive undefined arguments.
+	NATIVE_UNSAFE_ARGS_FUNCTION = FunctionKind{true, true}
+)

--- a/pkg/zkc/vm/internal/descriptor/memory.go
+++ b/pkg/zkc/vm/internal/descriptor/memory.go
@@ -96,6 +96,16 @@ func (p *Memory[W]) IsPaged() bool {
 	return p.kind.IsPaged()
 }
 
+// IsFunction identifies this module as a memory rather than a callable function.
+func (p *Memory[W]) IsFunction() bool {
+	return false
+}
+
+// IsMemory identifies this module as a memory.
+func (p *Memory[W]) IsMemory() bool {
+	return true
+}
+
 // StaticContents returns the static contents of this memory (if
 // applicable).  This will panic if !Kind().IsStatic().
 func (p *Memory[W]) StaticContents() []W {

--- a/pkg/zkc/vm/internal/descriptor/memory.go
+++ b/pkg/zkc/vm/internal/descriptor/memory.go
@@ -101,6 +101,11 @@ func (p *Memory[W]) IsFunction() bool {
 	return false
 }
 
+// HasUnsafeArgs is false because memories are not callable functions.
+func (p *Memory[W]) HasUnsafeArgs() bool {
+	return false
+}
+
 // IsMemory identifies this module as a memory.
 func (p *Memory[W]) IsMemory() bool {
 	return true

--- a/pkg/zkc/vm/internal/descriptor/module.go
+++ b/pkg/zkc/vm/internal/descriptor/module.go
@@ -26,6 +26,14 @@ import (
 // this interface captures the register-related structure common to them.
 type Module[W word.Word[W]] interface {
 	RegisterMap[W]
+	// IsFunction indicates whether this module is a callable function.
+	IsFunction() bool
+	// IsMemory indicates whether this module supports memory accesses.
+	IsMemory() bool
+	// IsReadOnly indicates whether this module forbids writes.
+	IsReadOnly() bool
+	// IsWriteOnly indicates whether this module forbids reads.
+	IsWriteOnly() bool
 	// Inputs returns the set of input registers for this module.
 	Inputs() []Register[W]
 	// NumInputs returns the number of input registers for this module.

--- a/pkg/zkc/vm/internal/descriptor/module.go
+++ b/pkg/zkc/vm/internal/descriptor/module.go
@@ -28,6 +28,8 @@ type Module[W word.Word[W]] interface {
 	RegisterMap[W]
 	// IsFunction indicates whether this module is a callable function.
 	IsFunction() bool
+	// HasUnsafeArgs indicates whether a function accepts maybe-undefined arguments.
+	HasUnsafeArgs() bool
 	// IsMemory indicates whether this module supports memory accesses.
 	IsMemory() bool
 	// IsReadOnly indicates whether this module forbids writes.

--- a/pkg/zkc/vm/internal/descriptor/program.go
+++ b/pkg/zkc/vm/internal/descriptor/program.go
@@ -336,14 +336,45 @@ func (p moduleEnvironment[W]) HasRegister(name string) util.Option[RegisterId] {
 	return p.modules[p.module].HasRegister(name)
 }
 
-// Register returns the ith register used in this module.
-func (p moduleEnvironment[W]) Module(id ModuleId) bytecode.ModuleInfo {
-	return p.modules[id]
+// Module returns information about the given module, or none when the module
+// identifier is invalid or refers to a nil descriptor.
+func (p moduleEnvironment[W]) Module(id ModuleId) util.Option[bytecode.ModuleInfo] {
+	if uint(id) >= uint(len(p.modules)) {
+		return util.None[bytecode.ModuleInfo]()
+	}
+
+	module := p.modules[id]
+	switch module := module.(type) {
+	case *Function[W]:
+		if module == nil {
+			return util.None[bytecode.ModuleInfo]()
+		}
+	case *Memory[W]:
+		if module == nil {
+			return util.None[bytecode.ModuleInfo]()
+		}
+	}
+
+	return util.Some[bytecode.ModuleInfo](module)
 }
 
 // Register returns the ith register used in this module.
 func (p moduleEnvironment[W]) Register(id RegisterId) bytecode.RegisterInfo {
 	return p.modules[p.module].Register(id)
+}
+
+// RegisterCount returns the number of registers in the enclosing module.
+func (p moduleEnvironment[W]) RegisterCount() uint {
+	return p.modules[p.module].Width()
+}
+
+// VectorCount returns the number of vectors in the enclosing function.
+func (p moduleEnvironment[W]) VectorCount() uint {
+	if function, ok := p.modules[p.module].(*Function[W]); ok {
+		return uint(len(function.Vectors()))
+	}
+
+	return 0
 }
 
 // ValueOf implementation for the bytecode.Environment interface.  A module

--- a/pkg/zkc/vm/internal/gogen/field_test.go
+++ b/pkg/zkc/vm/internal/gogen/field_test.go
@@ -96,7 +96,7 @@ func fieldTestProgram[W vm.Word[W]]() vm.Program[W] {
 		field.KOALABEAR_16,
 		vm.NewBytecodeMemory[W]("data", vm.PUBLIC_READ_ONLY_MEMORY, memRegs()),
 		vm.NewBytecodeMemory[W]("result", vm.PUBLIC_WRITE_ONCE_MEMORY, memRegs()),
-		vm.NewBytecodeFunction("main", false, regs, code),
+		vm.NewBytecodeFunction("main", vm.BYTECODE_FUNCTION, regs, code),
 	)
 }
 

--- a/pkg/zkc/vm/internal/gogen/gen_test.go
+++ b/pkg/zkc/vm/internal/gogen/gen_test.go
@@ -778,7 +778,7 @@ func TestGenSubConstWrapWidth(t *testing.T) {
 			vm.NewComputedRegister("t", u8, zero),
 			vm.NewComputedRegister("e", u8, zero),
 		}
-		main = vm.NewBytecodeFunction("main", false, regs,
+		main = vm.NewBytecodeFunction("main", vm.BYTECODE_FUNCTION, regs,
 			vm.NewBytecodeVector[vm.Uint](vm.LoadConst(0, zero.SetUint64(1))),               // x = 1
 			vm.NewBytecodeVector[vm.Uint](vm.Sub(1, []vm.RegisterId{0}, c16.SetUint64(16))), // t = x - 16
 			vm.NewBytecodeVector[vm.Uint](vm.LoadConst(2, c17.SetUint64(17))),               // e = 17

--- a/pkg/zkc/vm/internal/transform/check_casts.go
+++ b/pkg/zkc/vm/internal/transform/check_casts.go
@@ -60,7 +60,7 @@ func insertFunctionCasts[W word.Word[W]](fn *descriptor.Function[W], modules []d
 		})
 	}
 	//
-	return descriptor.NewFunction(fn.Name(), fn.Registers(), fn.IsNative(), vectors)
+	return descriptor.NewFunction(fn.Name(), fn.Registers(), fn.Kind(), vectors)
 }
 
 // castPacket returns the given bytecode wrapped with the cast checks it requires.

--- a/pkg/zkc/vm/internal/transform/factor_skip_conditions.go
+++ b/pkg/zkc/vm/internal/transform/factor_skip_conditions.go
@@ -77,7 +77,7 @@ func factorSkipConditionsFunction[W word.Word[W]](fn *descriptor.Function[W]) *d
 		})
 	}
 
-	return descriptor.NewFunction(fn.Name(), alloc.Registers(), fn.IsNative(), nvecs)
+	return descriptor.NewFunction(fn.Name(), alloc.Registers(), fn.Kind(), nvecs)
 }
 
 // factorableSkips returns the set of code indices holding a SkipIf worth factoring.

--- a/pkg/zkc/vm/internal/transform/flatten_calls.go
+++ b/pkg/zkc/vm/internal/transform/flatten_calls.go
@@ -75,7 +75,7 @@ func flattenCallsFunction[W word.Word[W]](fn *descriptor.Function[W]) *descripto
 		})
 	}
 
-	return descriptor.NewFunction(fn.Name(), alloc.Registers(), fn.IsNative(), nvecs)
+	return descriptor.NewFunction(fn.Name(), alloc.Registers(), fn.Kind(), nvecs)
 }
 
 // flattenableArgs returns, for each call in the vector, the set of argument

--- a/pkg/zkc/vm/internal/transform/inline_functions.go
+++ b/pkg/zkc/vm/internal/transform/inline_functions.go
@@ -172,7 +172,7 @@ func inlineAllCalls[W word.Word[W]](fn *descriptor.Function[W], calleeId uint,
 		return fn
 	}
 	//
-	return descriptor.NewFunction(fn.Name(), alloc.Registers(), fn.IsNative(), code)
+	return descriptor.NewFunction(fn.Name(), alloc.Registers(), fn.Kind(), code)
 }
 
 // findCall locates the first call to a given callee, returning the enclosing
@@ -633,7 +633,7 @@ func remapModuleIds[W word.Word[W]](fn *descriptor.Function[W], idMap []uint) *d
 		return fn
 	}
 	//
-	return descriptor.NewFunction(fn.Name(), fn.Registers(), fn.IsNative(), code)
+	return descriptor.NewFunction(fn.Name(), fn.Registers(), fn.Kind(), code)
 }
 
 func remapModuleId[W word.Word[W]](insn Bytecode[W], idMap []uint) Bytecode[W] {

--- a/pkg/zkc/vm/internal/transform/lower_bitwise.go
+++ b/pkg/zkc/vm/internal/transform/lower_bitwise.go
@@ -65,7 +65,7 @@ func lowerBitwiseFunction[W word.Word[W]](fn *descriptor.Function[W], helpers *b
 		})
 	}
 
-	return descriptor.NewFunction(fn.Name(), alloc.Registers(), fn.IsNative(), nvecs)
+	return descriptor.NewFunction(fn.Name(), alloc.Registers(), fn.Kind(), nvecs)
 }
 
 func lowerBitwiseCode[W word.Word[W]](

--- a/pkg/zkc/vm/internal/transform/lower_comparison.go
+++ b/pkg/zkc/vm/internal/transform/lower_comparison.go
@@ -52,7 +52,7 @@ func lowerComparisonFunction[W word.Word[W]](fn *descriptor.Function[W]) *descri
 		})
 	}
 
-	return descriptor.NewFunction(fn.Name(), alloc.Registers(), fn.IsNative(), nvecs)
+	return descriptor.NewFunction(fn.Name(), alloc.Registers(), fn.Kind(), nvecs)
 }
 
 func lowerComparisonCode[W word.Word[W]](

--- a/pkg/zkc/vm/internal/transform/lower_division.go
+++ b/pkg/zkc/vm/internal/transform/lower_division.go
@@ -60,7 +60,7 @@ func lowerDivisionFunction[W word.Word[W]](fn *descriptor.Function[W]) *descript
 		})
 	}
 
-	return descriptor.NewFunction(fn.Name(), alloc.Registers(), fn.IsNative(), nvecs)
+	return descriptor.NewFunction(fn.Name(), alloc.Registers(), fn.Kind(), nvecs)
 }
 
 func lowerDivisionCode[W word.Word[W]](

--- a/pkg/zkc/vm/internal/transform/lower_or_xor_and.go
+++ b/pkg/zkc/vm/internal/transform/lower_or_xor_and.go
@@ -268,7 +268,7 @@ func newDecomposedNaryHelper[W word.Word[W]](
 
 	b.emit(bytecode.NewRet[W]())
 
-	return descriptor.NewFunction(helperName(key), b.regs(), false,
+	return descriptor.NewFunction(helperName(key), b.regs(), descriptor.BYTECODE_FUNCTION,
 		[]BytecodeVector[W]{bytecode.NewVector(b.code...)})
 }
 

--- a/pkg/zkc/vm/internal/transform/lower_shift.go
+++ b/pkg/zkc/vm/internal/transform/lower_shift.go
@@ -108,7 +108,7 @@ func newShlHelper[W word.Word[W]](key bitwiseHelperKey, selfID uint, amtWidth ui
 	b.emit(bytecode.CallFun[W](uint16(selfID), []bytecode.RegisterId{doubled, n1}, []bytecode.RegisterId{out}))
 	b.emit(bytecode.NewRet[W]())
 
-	return descriptor.NewFunction(helperName(key), b.regs(), false,
+	return descriptor.NewFunction(helperName(key), b.regs(), descriptor.BYTECODE_FUNCTION,
 		[]BytecodeVector[W]{bytecode.NewVector(b.code...)})
 }
 
@@ -156,6 +156,6 @@ func newShrHelper[W word.Word[W]](key bitwiseHelperKey, selfID uint, amtWidth ui
 	b.emit(bytecode.CallFun[W](uint16(selfID), []bytecode.RegisterId{half, n1}, []bytecode.RegisterId{out}))
 	b.emit(bytecode.NewRet[W]())
 
-	return descriptor.NewFunction(helperName(key), b.regs(), false,
+	return descriptor.NewFunction(helperName(key), b.regs(), descriptor.BYTECODE_FUNCTION,
 		[]BytecodeVector[W]{bytecode.NewVector(b.code...)})
 }

--- a/pkg/zkc/vm/internal/transform/lower_switch.go
+++ b/pkg/zkc/vm/internal/transform/lower_switch.go
@@ -55,7 +55,7 @@ func lowerSwitchFunction[W word.Word[W]](fn *descriptor.Function[W]) *descriptor
 		nvecs[i] = lowerSwitchVector(vec, alloc)
 	}
 
-	return descriptor.NewFunction(fn.Name(), alloc.Registers(), fn.IsNative(), nvecs)
+	return descriptor.NewFunction(fn.Name(), alloc.Registers(), fn.Kind(), nvecs)
 }
 
 // lowerSwitchVector expands every Switch bytecode within a vector, recalculating

--- a/pkg/zkc/vm/internal/transform/optimize_division.go
+++ b/pkg/zkc/vm/internal/transform/optimize_division.go
@@ -74,7 +74,7 @@ func optimizeDivisionFunction[W word.Word[W]](fn *descriptor.Function[W]) *descr
 		})
 	}
 	// Registers are reused in place, so the register set is unchanged.
-	return descriptor.NewFunction(fn.Name(), regs, fn.IsNative(), nvecs)
+	return descriptor.NewFunction(fn.Name(), regs, fn.Kind(), nvecs)
 }
 
 // planDivisionReloads scans a function and returns, for each divisor register

--- a/pkg/zkc/vm/internal/transform/program_to_program.go
+++ b/pkg/zkc/vm/internal/transform/program_to_program.go
@@ -79,7 +79,7 @@ func (p programToProgram[W1, W2]) lowerFunction(fn *descriptor.Function[W1]) *de
 		nvecs[i] = p.lowerVector(v)
 	}
 	//
-	return descriptor.NewFunction(fn.Name(), regs, fn.IsNative(), nvecs)
+	return descriptor.NewFunction(fn.Name(), regs, fn.Kind(), nvecs)
 }
 
 func (p programToProgram[W1, W2]) lowerMemory(m *descriptor.Memory[W1]) *descriptor.Memory[W2] {

--- a/pkg/zkc/vm/internal/transform/range_constraints.go
+++ b/pkg/zkc/vm/internal/transform/range_constraints.go
@@ -282,7 +282,8 @@ func newRecursiveRangeModule[W word.Word[W]](name string, width uint, s rangeSpl
 	codes = appendRangeCheck(codes, hiID, s.hi, moduleOf, maxStaticWidth)
 	codes = append(codes, bytecode.NewRet[W]())
 	//
-	return descriptor.NewFunction(name, regs, false, []BytecodeVector[W]{bytecode.NewVector(codes...)})
+	return descriptor.NewFunction(name, regs, descriptor.UNSAFE_ARGS_FUNCTION,
+		[]BytecodeVector[W]{bytecode.NewVector(codes...)})
 }
 
 // appendRangeCheck appends to codes a range-check of register r (of width w)
@@ -383,5 +384,5 @@ func addRangeChecks[W word.Word[W]](mod descriptor.Module[W], idOf map[string]ui
 		})
 	}
 	//
-	return descriptor.NewFunction(fn.Name(), fn.Registers(), fn.IsNative(), nvecs)
+	return descriptor.NewFunction(fn.Name(), fn.Registers(), fn.Kind(), nvecs)
 }

--- a/pkg/zkc/vm/internal/transform/split_registers.go
+++ b/pkg/zkc/vm/internal/transform/split_registers.go
@@ -152,7 +152,7 @@ func splitFunction[W word.Word[W]](mapping descriptor.LimbsMap[W], mods []descri
 		code  = splitBytecodeVector(mapping, mods, alloc, m.Vectors())
 	)
 	//
-	return descriptor.NewFunction(m.Name(), alloc.Registers(), m.IsNative(), code)
+	return descriptor.NewFunction(m.Name(), alloc.Registers(), m.Kind(), code)
 }
 
 func splitBytecodeVector[W word.Word[W]](mapping descriptor.LimbsMap[W], mods []descriptor.Module[W],

--- a/pkg/zkc/vm/internal/transform/vectorize.go
+++ b/pkg/zkc/vm/internal/transform/vectorize.go
@@ -118,7 +118,7 @@ func vectorizeFunction[W word.Word[W]](fn *descriptor.Function[W]) *descriptor.F
 	// Remove unreachable vectors and rebind jump targets.
 	insns = pruneUnreachableInstructions[W](insns)
 	//
-	return descriptor.NewFunction(fn.Name(), fn.Registers(), fn.IsNative(), insns)
+	return descriptor.NewFunction(fn.Name(), fn.Registers(), fn.Kind(), insns)
 }
 
 // prepareCode appends a fall-through Jmp(pc+1) to any vector that does not

--- a/pkg/zkc/vm/validation.go
+++ b/pkg/zkc/vm/validation.go
@@ -1,0 +1,91 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"reflect"
+
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/descriptor"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/word"
+)
+
+func validateBytecodeProgram[W word.Word[W]](program Program[W]) error {
+	var (
+		errs    []error
+		modules = program.Modules()
+		names   = make(map[string]uint)
+	)
+	// A module identifier is a uint16, so 2^16 distinct modules are addressable.
+	if uint64(len(modules)) > uint64(math.MaxUint16)+1 {
+		errs = append(errs, fmt.Errorf("program has too many modules (%d)", len(modules)))
+	}
+	// Validate module-level invariants before constructing any environments.
+	for mid, module := range modules {
+		if isNilInterface(module) {
+			errs = append(errs, fmt.Errorf("module %d is nil", mid))
+			continue
+		}
+
+		if previous, ok := names[module.Name()]; ok {
+			errs = append(errs, fmt.Errorf("module %d (%s): duplicate name (first used by module %d)",
+				mid, module.Name(), previous))
+		} else {
+			names[module.Name()] = uint(mid)
+		}
+
+		if uint64(module.Width()) > uint64(math.MaxUint16)+1 {
+			errs = append(errs, fmt.Errorf("module %d (%s): too many registers (%d)",
+				mid, module.Name(), module.Width()))
+		}
+	}
+	// An environment stores its enclosing module as a uint16.  If the module
+	// count is already invalid, do not truncate module indices while validating.
+	if uint64(len(modules)) > uint64(math.MaxUint16)+1 {
+		return errors.Join(errs...)
+	}
+
+	for mid, module := range modules {
+		if isNilInterface(module) {
+			continue
+		}
+
+		fn, ok := module.(*descriptor.Function[W])
+		if !ok || fn.IsNative() {
+			continue
+		}
+
+		env := program.EnvironmentOf(uint16(mid))
+
+		for pc, vector := range fn.Vectors() {
+			location := fmt.Sprintf("function %s, vector %d", fn.Name(), pc)
+			for _, err := range vector.Validate(program.Field(), env) {
+				errs = append(errs, fmt.Errorf("%s: %w", location, err))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func isNilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+
+	reflected := reflect.ValueOf(value)
+
+	return reflected.Kind() == reflect.Pointer && reflected.IsNil()
+}


### PR DESCRIPTION
This adds support for validating the bytecode program at the end of code generation.  This is to catch any malformed bytecodes before the program is passed into subsequent phases.