### PR TITLE
fix(gogen): align subtraction wrap width

### DIFF
--- a/pkg/zkc/vm/internal/gogen/emit_arith.go
+++ b/pkg/zkc/vm/internal/gogen/emit_arith.go
@@ -61,6 +61,12 @@ func (g *generator) emitArith(c *code, fn *descFunction, x *bytecode.Arith[word.
 		if err != nil {
 			return err
 		}
+		// The general vector encoding widens arithmetic to the target width.
+		// The compact SUBC and SUB_2n1 encodings retain their source-derived
+		// wrap widths, so only mirror the target widening when SUB_nm is used.
+		if usesVectorSubEncoding(x) {
+			wrap = max(wrap, store.total)
+		}
 
 		return g.emitSub(c, srcs, konst, store, wrap)
 	case bytecode.OP_MUL:
@@ -68,6 +74,21 @@ func (g *generator) emitArith(c *code, fn *descFunction, x *bytecode.Arith[word.
 	default:
 		return fmt.Errorf("gogen: unsupported arithmetic operation (%d)", x.Op)
 	}
+}
+
+// usesVectorSubEncoding mirrors the subtraction cases selected by
+// encoding.Arith.  A one-source subtraction with a small constant uses SUBC,
+// and a two-source subtraction without a constant uses SUB_2n1.  Every other
+// subtraction uses SUB_nm, whose encoded wrap width includes the target width.
+func usesVectorSubEncoding(x *bytecode.Arith[word.Uint]) bool {
+	var (
+		n                = len(x.Source)
+		m                = len(x.Target)
+		constantIsZero   = bytecode.IsUnusedConstant(x.Op, x.Constant)
+		constantIsUint24 = x.Constant.Cmp64(0x100_0000) < 0
+	)
+
+	return !((n == 1 && m == 1 && constantIsUint24) || (n == 2 && m == 1 && constantIsZero))
 }
 
 // anyWide reports whether some operand is a lo/hi pair.
@@ -165,12 +186,12 @@ func (g *generator) emitAdd(c *code, srcs []operand, konst operand, store storeV
 	return inner
 }
 
-// subWrapWidth mirrors calculateArithBitwidth for OP_SUB: the width in which a
-// vectored subtraction is performed.  On underflow the value wraps modulo
-// 2^width (executeSub_nm), which is what places the borrow bit of a
-// subtract-with-borrow into the top target limb.  Widths are the declared
-// register widths — not the interval-sharpened bounds — because that is what
-// the reference interpreter encodes.
+// subWrapWidth mirrors CalculateSubBitwidth: the source-derived width in which
+// a subtraction is performed. On underflow the value wraps modulo 2^width,
+// which is what places the borrow bit of a subtract-with-borrow into the top
+// target limb. Widths are the declared register widths — not the
+// interval-sharpened bounds — because that is what the reference interpreter
+// encodes. The caller additionally applies the target width for SUB_nm.
 func (g *generator) subWrapWidth(fn *descFunction, sources []regId, constant word.Uint) (uint, error) {
 	lhs, err := g.regWidth(fn, sources[0])
 	if err != nil {

--- a/pkg/zkc/vm/internal/gogen/gen_test.go
+++ b/pkg/zkc/vm/internal/gogen/gen_test.go
@@ -693,25 +693,24 @@ var diffCases = []diffCase{
 			{"data": {0xFFFFFFFFFFFFFFFF, 0, 0xDEADBEEF}},
 		},
 	},
-	// {
-	// 	name: "subWrap", // x - y - c: single-step two's-complement wrap on underflow
-	// 	src:  subWrapSrc,
-	// 	vectors: []map[string][]uint64{
-	// 		{"data": {10, 3}},    // 5
-	// 		{"data": {5, 10}},    // -7 -> 1017 (mod 2^10)
-	// 		{"data": {0, 255}},   // -257 -> 767
-	// 		{"data": {255, 0}},   // 253
-	// 		{"data": {0, 0}},     // -2 -> 1022
-	// 		{"data": {255, 255}}, // -2 -> 1022
-	// 	},
-	// },
+	{
+		name: "subWrap", // x - y - c: single-step two's-complement wrap on underflow
+		src:  subWrapSrc,
+		vectors: []map[string][]uint64{
+			{"data": {10, 3}},    // 5
+			{"data": {5, 10}},    // -7 -> 65529 (mod 2^16)
+			{"data": {0, 255}},   // -257 -> 65279
+			{"data": {255, 0}},   // 253
+			{"data": {0, 0}},     // -2 -> 65534
+			{"data": {255, 255}}, // -2 -> 65534
+		},
+	},
 }
 
 // subWrapSrc compiles its subtraction into a single SUB with two register
 // sources AND a constant subtrahend: the shape whose two-step (SUB_2n1 + SUBC)
 // encoding used to wrap each step separately rather than once at the
-// CalculateSubBitwidth width.  The result type is u10, so an underflow wraps
-// modulo 2^10 and the wrapped value is observable through the widening cast.
+// encoded width. The result target is u16, so an underflow wraps modulo 2^16.
 // nolint
 const subWrapSrc = `pub input data(address:u8) -> (byte:u8)
 pub output result(address:u8) -> (word:u16)


### PR DESCRIPTION
Fixes #2002.

Align the gogen SUB_nm wrap width with the interpreter by including the target width. Re-enable the subWrap differential case while preserving compact subtraction semantics.

Test: go test ./pkg/zkc/vm/... -count=1