### PR TITLE
feat: add validation for dangling registers

### DIFF
--- a/pkg/cmd/zkc/compile.go
+++ b/pkg/cmd/zkc/compile.go
@@ -108,6 +108,8 @@ func runCompileCmd[F field.Element[F]](cmd *cobra.Command, args []string, field 
 		// Print out requested artifacts
 		printArtifacts[F](field, artifacts, config)
 	}
+	// perform validation
+	validateArtifacts[F](field, artifacts, config)
 }
 
 func writeArtifacts[F field.Element[F]](filename string, build BuildConfig, artifacts BuildArtifacts) {
@@ -116,6 +118,18 @@ func writeArtifacts[F field.Element[F]](filename string, build BuildConfig, arti
 		build.config.GetMaxStaticDepth(), artifacts.ir)
 	// Write to disk
 	WriteBinaryFile(binfile, filename)
+}
+
+// Validate the given schema by ensuring that every register in every module is referenced in at least one vanishing
+// constraint.  If any such register is encountered, this should log an error which identifies the enclosing module
+// and register.
+func validateArtifacts[F field.Element[F]](field field.Config, artifacts BuildArtifacts, config CompileConfig) {
+	// Generate AIR representation
+	air := constraints.GenerateAirConstraints[vm.Uint, F](artifacts.ir, field, config.build.config.GetMaxStaticDepth())
+	// Perform validation check
+	if err := constraints.Validate(air); err != nil {
+		log.Warn(err)
+	}
 }
 
 func printArtifacts[F field.Element[F]](field field.Config, artifacts BuildArtifacts, config CompileConfig) {

--- a/pkg/cmd/zkc/compile.go
+++ b/pkg/cmd/zkc/compile.go
@@ -127,8 +127,10 @@ func validateArtifacts[F field.Element[F]](field field.Config, artifacts BuildAr
 	// Generate AIR representation
 	air := constraints.GenerateAirConstraints[vm.Uint, F](artifacts.ir, field, config.build.config.GetMaxStaticDepth())
 	// Perform validation check
-	if err := constraints.Validate(air); err != nil {
-		log.Warn(err)
+	if errs := constraints.Validate(air); len(errs) > 0 {
+		for _, err := range errs {
+			log.Warn(err)
+		}
 	}
 }
 

--- a/pkg/test/zkc_invalid_test.go
+++ b/pkg/test/zkc_invalid_test.go
@@ -939,6 +939,29 @@ func Test_ZkcInvalid_Inline_06(t *testing.T) {
 	checkZkcInvalid(t, "zkc/invalid/inline_06")
 }
 
+func Test_ZkcInvalid_Unused_01(t *testing.T) {
+	// A local variable which is never read or written is unused.
+	checkZkcInvalid(t, "zkc/invalid/unused_01")
+}
+
+func Test_ZkcInvalid_Unused_02(t *testing.T) {
+	// An unused local declared inside a (nested) block is still detected, and
+	// the error is anchored on its declaration.
+	checkZkcInvalid(t, "zkc/invalid/unused_02")
+}
+
+func Test_ZkcInvalid_Unused_03(t *testing.T) {
+	// In a multi-variable declaration, an unused variable is reported even when
+	// its siblings are used.
+	checkZkcInvalid(t, "zkc/invalid/unused_03")
+}
+
+func Test_ZkcInvalid_Unused_04(t *testing.T) {
+	// An unused local is detected in a non-entry function; the (used) parameter
+	// and return are not flagged.
+	checkZkcInvalid(t, "zkc/invalid/unused_04")
+}
+
 // ===================================================================
 // Test Helpers
 // ===================================================================

--- a/pkg/zkc/compiler/compiler.go
+++ b/pkg/zkc/compiler/compiler.go
@@ -73,10 +73,15 @@ func Compile(field field.Config, sourceFiles ...source.File,
 	program, srcmaps, linkErrs := Link(unlinkedSourceFiles...)
 	//
 	errors = append(errors, linkErrs...)
+	// Capture variable declarations before flattening discards them (they are
+	// needed to anchor unused-variable errors on the original declaration).
+	decls := validate.CollectVariableDeclarations(program)
 	// Flatten block-level constructs (if/else, switch, while, for) into flat if-goto form
 	lower.Flatten(program, srcmaps)
-	// Well-formedness checks (assuming unlimited field width).
-	errors = append(errors, validateProgram(program, field, srcmaps)...)
+	// Well-formedness checks (assuming unlimited field width).  Any parse or
+	// link errors accumulated above mean the program is not well-formed, which
+	// some downstream checks rely upon.
+	errors = append(errors, validateProgram(program, field, srcmaps, len(errors) != 0, decls)...)
 	// Lower fixed-size arrays into flat local access registers
 	if len(errors) == 0 {
 		lower.FlattenFixedArrays(field, program)
@@ -160,16 +165,23 @@ func scanForFurtherSourceFiles(sourceFile source.File, parsedSourceFile parser.U
 // number on rhs).  Likewise, variables cannot be used before they are defined,
 // and all control-flow paths must reach a "return" instruction, etc. Finally,
 // we cannot assign to an input register under the current calling convention.
-func validateProgram(program ast.Program, field field.Config, srcmaps source.Maps[any]) []source.SyntaxError {
+func validateProgram(program ast.Program, field field.Config, srcmaps source.Maps[any],
+	hasPriorErrors bool, decls validate.VariableDeclarations) []source.SyntaxError {
 	var errors []source.SyntaxError
 	// Check for cyclic definitions (constants and type aliases); if cycle is
 	// detected, skip remaining phases (for now).
 	if errors = validate.CycleDetection(program, srcmaps); len(errors) > 0 {
 		return errors
 	}
-	// Attempt to type the program; if this fails for some reaosn, skip
-	// remaining phases (for now).
+	// Attempt to type the program.
 	errors = append(errors, validate.Typing(program, field, srcmaps)...)
+	// Attempt to check that every variable in the program is used.  This is only
+	// meaningful for a well-formed program, as a variable may otherwise appear
+	// unused simply because an upstream error (e.g. an unresolved symbol in its
+	// type) prevented it from being wired up.
+	if !hasPriorErrors && len(errors) == 0 {
+		errors = append(errors, validate.VariableUses(program, field, srcmaps, decls)...)
+	}
 	// Check the entry point (if any) is well-formed.
 	errors = append(errors, validate.EntryPoint(program, srcmaps)...)
 	// Perform final validation

--- a/pkg/zkc/compiler/incremental_compiler.go
+++ b/pkg/zkc/compiler/incremental_compiler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/compiler/ast"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/compiler/lower"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/compiler/parser"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/compiler/validate"
 )
 
 // FileUpdate indicates that some change has been made to a given file
@@ -135,10 +136,15 @@ func (p *IncrementalCompiler) Apply(updates ...FileUpdate) []source.SyntaxError 
 
 	program, srcmaps, linkErrs = Link(items...)
 	errors = append(errors, linkErrs...)
+	// Capture variable declarations before flattening discards them (they are
+	// needed to anchor unused-variable errors on the original declaration).
+	decls := validate.CollectVariableDeclarations(program)
 	// Flatten block-level constructs (if/else, while, for) into flat if-goto form.
 	lower.Flatten(program, srcmaps)
-	// Well-formedness checks (assuming unlimited field width).
-	errors = append(errors, validateProgram(program, p.field, srcmaps)...)
+	// Well-formedness checks (assuming unlimited field width).  Any parse or
+	// link errors accumulated above mean the program is not well-formed, which
+	// some downstream checks rely upon.
+	errors = append(errors, validateProgram(program, p.field, srcmaps, len(errors) != 0, decls)...)
 	// Update internal program state.
 	p.program = program
 	p.srcmaps = srcmaps

--- a/pkg/zkc/compiler/validate/variable_uses.go
+++ b/pkg/zkc/compiler/validate/variable_uses.go
@@ -1,0 +1,149 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package validate
+
+import (
+	"fmt"
+
+	"github.com/LFDT-Lineth/zkc/pkg/util/collection/bit"
+	"github.com/LFDT-Lineth/zkc/pkg/util/field"
+	"github.com/LFDT-Lineth/zkc/pkg/util/source"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/compiler/ast"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/compiler/ast/decl"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/compiler/ast/stmt"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/compiler/ast/symbol"
+	"github.com/LFDT-Lineth/zkc/pkg/zkc/compiler/ast/variable"
+)
+
+// VariableDeclarations records, for each function, the source node (i.e. the
+// "var" declaration) which introduced each of its local variables.  This must
+// be captured before block-level constructs are flattened away, since
+// flattening discards the declaration nodes; it allows an unused-variable error
+// to be reported against the original declaration rather than the enclosing
+// function.
+type VariableDeclarations = map[*decl.ResolvedFunction]map[variable.Id]stmt.Resolved
+
+// CollectVariableDeclarations records the declaration node for every local
+// variable in the program.  It must be called before the program is flattened,
+// as flattening discards the (block-structured) declaration nodes.
+func CollectVariableDeclarations(program ast.Program) VariableDeclarations {
+	var decls = make(VariableDeclarations)
+	//
+	for _, d := range program.Components() {
+		if fn, ok := d.(*decl.ResolvedFunction); ok {
+			var m = make(map[variable.Id]stmt.Resolved)
+			//
+			collectDeclarations(fn.Code, m)
+			//
+			decls[fn] = m
+		}
+	}
+	//
+	return decls
+}
+
+// collectDeclarations records the declaration node for every variable
+// introduced by a "var" declaration within the given statements, descending
+// into any block-level constructs.
+func collectDeclarations(stmts []stmt.Resolved, decls map[variable.Id]stmt.Resolved) {
+	for _, s := range stmts {
+		switch s := s.(type) {
+		case *stmt.VarDecl[symbol.Resolved]:
+			for _, id := range s.Variables {
+				decls[id] = s
+			}
+		case *stmt.IfElse[symbol.Resolved]:
+			collectDeclarations(s.TrueBranch, decls)
+			collectDeclarations(s.FalseBranch, decls)
+		case *stmt.While[symbol.Resolved]:
+			collectDeclarations(s.Body, decls)
+		case *stmt.For[symbol.Resolved]:
+			collectDeclarations([]stmt.Resolved{s.Init, s.Post}, decls)
+			collectDeclarations(s.Body, decls)
+		case *stmt.Switch[symbol.Resolved]:
+			for _, b := range s.Branches {
+				collectDeclarations(b.Body, decls)
+			}
+		}
+	}
+}
+
+// VariableUses performs a check that every variable in a program is used at least once and, if not, reports a
+// syntax error that the variable is unused.  For now, a variable which is only assigned (i.e. written but never
+// read) is still considered used.  The declaration nodes gathered by
+// CollectVariableDeclarations (before flattening) are used to anchor each error
+// on the offending "var" declaration.
+func VariableUses(program ast.Program, _ field.Config, srcmaps source.Maps[any],
+	decls VariableDeclarations) []source.SyntaxError {
+	var errors []source.SyntaxError
+	//
+	for _, d := range program.Components() {
+		if fn, ok := d.(*decl.ResolvedFunction); ok {
+			errors = append(errors, validateFunctionUses(fn, decls[fn], srcmaps)...)
+		}
+	}
+	//
+	return errors
+}
+
+// validateFunctionUses checks that every variable declared within a given
+// function is used at least once.  A variable is considered used if it is read
+// or assigned by some instruction in the function body.
+func validateFunctionUses(fn *decl.ResolvedFunction, decls map[variable.Id]stmt.Resolved,
+	srcmaps source.Maps[any]) []source.SyntaxError {
+	var (
+		errors []source.SyntaxError
+		used   bit.Set
+	)
+	// Record every variable which is read or written by some instruction.
+	for _, insn := range fn.Code {
+		if insn == nil {
+			continue
+		}
+		//
+		for _, r := range insn.Uses() {
+			used.Insert(r)
+		}
+		//
+		for _, r := range insn.Definitions() {
+			used.Insert(r)
+		}
+	}
+	// Report any local variable which was never used.  Parameters and returns
+	// form the function's interface (they are implicitly used by the calling
+	// convention), whilst an unassigned return is caught separately as a
+	// control-flow error; hence, neither is considered here.
+	for i, v := range fn.Variables {
+		if v.IsLocal() && !used.Contains(uint(i)) {
+			msg := fmt.Sprintf("unused variable %s", v.Name)
+			errors = append(errors, unusedError(fn, decls[uint(i)], msg, srcmaps))
+		}
+	}
+	//
+	return errors
+}
+
+// unusedError constructs the syntax error for an unused variable.  It is
+// anchored on the variable's "var" declaration where available, falling back to
+// the enclosing function otherwise.
+func unusedError(fn *decl.ResolvedFunction, declaration stmt.Resolved, msg string,
+	srcmaps source.Maps[any]) source.SyntaxError {
+	// Prefer the declaration node, provided it has a known source location.
+	if declaration != nil {
+		if _, _, ok := srcmaps.Lookup(declaration); ok {
+			return *srcmaps.SyntaxError(declaration, msg)
+		}
+	}
+	// Otherwise, fall back to the enclosing function.
+	return *srcmaps.SyntaxError(fn, msg)
+}

--- a/pkg/zkc/constraints/validate.go
+++ b/pkg/zkc/constraints/validate.go
@@ -19,8 +19,8 @@ import (
 	"github.com/LFDT-Lineth/zkc/pkg/ir/mir"
 	"github.com/LFDT-Lineth/zkc/pkg/ir/term"
 	sc "github.com/LFDT-Lineth/zkc/pkg/schema"
+	"github.com/LFDT-Lineth/zkc/pkg/schema/constraint/lookup"
 	"github.com/LFDT-Lineth/zkc/pkg/schema/constraint/vanishing"
-	"github.com/LFDT-Lineth/zkc/pkg/schema/register"
 	"github.com/LFDT-Lineth/zkc/pkg/util/collection/bit"
 	"github.com/LFDT-Lineth/zkc/pkg/util/field"
 )
@@ -28,8 +28,11 @@ import (
 // Validate the given schema by ensuring that every register in every module is referenced in at least one vanishing
 // constraint.  If any such register is encountered, this should a suitable error which identifies the enclosing module
 // and register.
-func Validate[F field.Element[F]](schema sc.AnySchema[F]) error {
-	var validated = make([]bit.Set, schema.Modules().Count())
+func Validate[F field.Element[F]](schema sc.AnySchema[F]) []error {
+	var (
+		validated = make([]bit.Set, schema.Modules().Count())
+		errors    []error
+	)
 	// Iterate each constraint, marking any registers it uses.
 	for iter := schema.Constraints(); iter.HasNext(); {
 		var c = iter.Next()
@@ -41,34 +44,56 @@ func Validate[F field.Element[F]](schema sc.AnySchema[F]) error {
 		//
 		for i, r := range mod.Registers() {
 			if !validated[mid].Contains(uint(i)) {
-				return fmt.Errorf("dangling register \"%s\" in module \"%s\"", r.Name(), mod.Name().String())
+				err := fmt.Errorf("dangling register \"%s\" in module \"%s\"", r.Name(), mod.Name().String())
+				//
+				errors = append(errors, err)
 			}
 		}
 	}
 	//
-	return nil
+	return errors
 }
 
 func validateConstraint[F field.Element[F]](c sc.Constraint[F], validations []bit.Set, schema sc.AnySchema[F]) {
 	switch c := c.(type) {
 	case air.VanishingConstraint[F]:
-		validateVanishingConstraint(c.Unwrap(), validations, schema)
+		validateVanishingConstraint(c.Unwrap(), validations)
 	case mir.VanishingConstraint[F]:
-		validateVanishingConstraint(c, validations, schema)
+		validateVanishingConstraint(c, validations)
+	case air.LookupConstraint[F]:
+		validateLookupConstraint(c.Unwrap(), validations, schema)
+	case mir.LookupConstraint[F]:
+		validateLookupConstraint(c, validations, schema)
 	}
 }
 
 func validateVanishingConstraint[F field.Element[F], T term.Testable[F]](c vanishing.Constraint[F, T],
-	validations []bit.Set, schema sc.AnySchema[F]) {
-	//
-	var (
-		mid = c.Context
-		mod = schema.Module(mid)
-	)
+	validations []bit.Set) {
 	//
 	for _, rid := range *c.Constraint.RequiredRegisters() {
-		var reg = mod.Register(register.NewId(rid))
-		fmt.Printf("Marking register %s in module %s\n", reg.Name(), mod.Name().String())
-		validations[mid].Insert(rid)
+		validations[c.Context].Insert(rid)
+	}
+}
+
+func validateLookupConstraint[F field.Element[F], T term.Evaluable[F]](c lookup.Constraint[F, T],
+	validations []bit.Set, schema sc.AnySchema[F]) {
+	//
+	validateLookupVectors(c.Targets, validations)
+	validateLookupVectors(c.Sources, validations)
+}
+
+func validateLookupVectors[F field.Element[F], T term.Evaluable[F]](vs []lookup.Vector[F, T],
+	validations []bit.Set) {
+	for _, v := range vs {
+		validateLookupVector(v, validations)
+	}
+}
+
+func validateLookupVector[F field.Element[F], T term.Evaluable[F]](v lookup.Vector[F, T],
+	validations []bit.Set) {
+	for _, e := range v.Terms {
+		for _, rid := range *e.RequiredRegisters() {
+			validations[v.Context()].Insert(rid)
+		}
 	}
 }

--- a/pkg/zkc/constraints/validate.go
+++ b/pkg/zkc/constraints/validate.go
@@ -1,0 +1,74 @@
+// Copyright Consensys Software Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+package constraints
+
+import (
+	"fmt"
+
+	"github.com/LFDT-Lineth/zkc/pkg/ir/air"
+	"github.com/LFDT-Lineth/zkc/pkg/ir/mir"
+	"github.com/LFDT-Lineth/zkc/pkg/ir/term"
+	sc "github.com/LFDT-Lineth/zkc/pkg/schema"
+	"github.com/LFDT-Lineth/zkc/pkg/schema/constraint/vanishing"
+	"github.com/LFDT-Lineth/zkc/pkg/schema/register"
+	"github.com/LFDT-Lineth/zkc/pkg/util/collection/bit"
+	"github.com/LFDT-Lineth/zkc/pkg/util/field"
+)
+
+// Validate the given schema by ensuring that every register in every module is referenced in at least one vanishing
+// constraint.  If any such register is encountered, this should a suitable error which identifies the enclosing module
+// and register.
+func Validate[F field.Element[F]](schema sc.AnySchema[F]) error {
+	var validated = make([]bit.Set, schema.Modules().Count())
+	// Iterate each constraint, marking any registers it uses.
+	for iter := schema.Constraints(); iter.HasNext(); {
+		var c = iter.Next()
+		validateConstraint(c, validated, schema)
+	}
+	// Validate every register was marked
+	for iter, mid := schema.Modules(), 0; iter.HasNext(); mid++ {
+		var mod = iter.Next()
+		//
+		for i, r := range mod.Registers() {
+			if !validated[mid].Contains(uint(i)) {
+				return fmt.Errorf("dangling register \"%s\" in module \"%s\"", r.Name(), mod.Name().String())
+			}
+		}
+	}
+	//
+	return nil
+}
+
+func validateConstraint[F field.Element[F]](c sc.Constraint[F], validations []bit.Set, schema sc.AnySchema[F]) {
+	switch c := c.(type) {
+	case air.VanishingConstraint[F]:
+		validateVanishingConstraint(c.Unwrap(), validations, schema)
+	case mir.VanishingConstraint[F]:
+		validateVanishingConstraint(c, validations, schema)
+	}
+}
+
+func validateVanishingConstraint[F field.Element[F], T term.Testable[F]](c vanishing.Constraint[F, T],
+	validations []bit.Set, schema sc.AnySchema[F]) {
+	//
+	var (
+		mid = c.Context
+		mod = schema.Module(mid)
+	)
+	//
+	for _, rid := range *c.Constraint.RequiredRegisters() {
+		var reg = mod.Register(register.NewId(rid))
+		fmt.Printf("Marking register %s in module %s\n", reg.Name(), mod.Name().String())
+		validations[mid].Insert(rid)
+	}
+}

--- a/testdata/zkc/invalid/unused_01.zkc
+++ b/testdata/zkc/invalid/unused_01.zkc
@@ -1,0 +1,5 @@
+//error:3:5-13:unused variable a
+fn main() {
+    var a:u8
+    return
+}

--- a/testdata/zkc/invalid/unused_02.zkc
+++ b/testdata/zkc/invalid/unused_02.zkc
@@ -1,0 +1,9 @@
+//error:5:9-19:unused variable tmp
+fn main() {
+    var i:u8 = 0
+    while i != 10 {
+        var tmp:u8
+        i = i + 1
+    }
+    return
+}

--- a/testdata/zkc/invalid/unused_03.zkc
+++ b/testdata/zkc/invalid/unused_03.zkc
@@ -1,0 +1,6 @@
+//error:3:5-20:unused variable b
+fn main() {
+    var a:u8, b:u16
+    a = 0
+    return
+}

--- a/testdata/zkc/invalid/unused_04.zkc
+++ b/testdata/zkc/invalid/unused_04.zkc
@@ -1,0 +1,12 @@
+//error:3:5-16:unused variable junk
+fn f(x:u8) -> (r:u8) {
+    var junk:u8
+    r = x
+    return
+}
+
+fn main() {
+    if f(0) != 0 {
+        fail
+    }
+}

--- a/testdata/zkc/unit/basic_17.zkc
+++ b/testdata/zkc/unit/basic_17.zkc
@@ -1,22 +1,22 @@
 fn main() {
-    var as_X:u32
-    var break_X:u32
-    var continue_X:u32
-    var const_X:u32
-    var else_X:u32
-    var fail_X:u32
-    var fn_X:u32
-    var for_X:u32
-    var if_X:u32
-    var include_X:u32
-    var input_X:u32
-    var memory_X:u32
-    var return_X:u32
-    var static_X:u32
-    var output_X:u32
-    var printf_X:u32
-    var pub_X:u32
-    var while_X:u32
-    var var_X:u32
-    var type_X:u32
+    var as_X:u32 = 0
+    var break_X:u32 = 0
+    var continue_X:u32 = 0
+    var const_X:u32 = 0
+    var else_X:u32 = 0
+    var fail_X:u32 = 0
+    var fn_X:u32 = 0
+    var for_X:u32 = 0
+    var if_X:u32 = 0
+    var include_X:u32 = 0
+    var input_X:u32 = 0
+    var memory_X:u32 = 0
+    var return_X:u32 = 0
+    var static_X:u32 = 0
+    var output_X:u32 = 0
+    var printf_X:u32 = 0
+    var pub_X:u32 = 0
+    var while_X:u32 = 0
+    var var_X:u32 = 0
+    var type_X:u32 = 0
 }

--- a/testdata/zkc/unit/basic_18.zkc
+++ b/testdata/zkc/unit/basic_18.zkc
@@ -1,22 +1,22 @@
 fn main() {
-    var X_as:u32
-    var X_break:u32
-    var X_continue:u32
-    var X_const:u32
-    var X_else:u32
-    var X_fail:u32
-    var X_fn:u32
-    var X_for:u32
-    var X_if:u32
-    var X_include:u32
-    var X_input:u32
-    var X_memory:u32
-    var X_return:u32
-    var X_static:u32
-    var X_output:u32
-    var X_printf:u32
-    var X_pub:u32
-    var X_while:u32
-    var X_var:u32
-    var X_type:u32
+    var X_as:u32 = 0
+    var X_break:u32 = 0
+    var X_continue:u32 = 0
+    var X_const:u32 = 0
+    var X_else:u32 = 0
+    var X_fail:u32 = 0
+    var X_fn:u32 = 0
+    var X_for:u32 = 0
+    var X_if:u32 = 0
+    var X_include:u32 = 0
+    var X_input:u32 = 0
+    var X_memory:u32 = 0
+    var X_return:u32 = 0
+    var X_static:u32 = 0
+    var X_output:u32 = 0
+    var X_printf:u32 = 0
+    var X_pub:u32 = 0
+    var X_while:u32 = 0
+    var X_var:u32 = 0
+    var X_type:u32 = 0
 }

--- a/testdata/zkc/unit/basic_19.zkc
+++ b/testdata/zkc/unit/basic_19.zkc
@@ -1,22 +1,22 @@
 fn main() {
-    var X_as_Y:u32
-    var X_break_Y:u32
-    var X_continue_Y:u32
-    var X_const_Y:u32
-    var X_else_Y:u32
-    var X_fail_Y:u32
-    var X_fn_Y:u32
-    var X_for_Y:u32
-    var X_if_Y:u32
-    var X_include_Y:u32
-    var X_input_Y:u32
-    var X_memory_Y:u32
-    var X_return_Y:u32
-    var X_static_Y:u32
-    var X_output_Y:u32
-    var X_printf_Y:u32
-    var X_pub_Y:u32
-    var X_while_Y:u32
-    var X_var_Y:u32
-    var X_type_Y:u32
+    var X_as_Y:u32 = 0
+    var X_break_Y:u32 = 0
+    var X_continue_Y:u32 = 0
+    var X_const_Y:u32 = 0
+    var X_else_Y:u32 = 0
+    var X_fail_Y:u32 = 0
+    var X_fn_Y:u32 = 0
+    var X_for_Y:u32 = 0
+    var X_if_Y:u32 = 0
+    var X_include_Y:u32 = 0
+    var X_input_Y:u32 = 0
+    var X_memory_Y:u32 = 0
+    var X_return_Y:u32 = 0
+    var X_static_Y:u32 = 0
+    var X_output_Y:u32 = 0
+    var X_printf_Y:u32 = 0
+    var X_pub_Y:u32 = 0
+    var X_while_Y:u32 = 0
+    var X_var_Y:u32 = 0
+    var X_type_Y:u32 = 0
 }

--- a/testdata/zkc/unit/basic_61.zkc
+++ b/testdata/zkc/unit/basic_61.zkc
@@ -5,7 +5,6 @@ pub output out(address:u16) -> (byte:u16)
 fn main() {
     var v:u16 = in[0]
     var w:u16
-    var b:u1
     //
     w = (v as u16) - 1
     //

--- a/testdata/zkc/unit/fixed_array_01.zkc
+++ b/testdata/zkc/unit/fixed_array_01.zkc
@@ -1,4 +1,5 @@
 fn main() {
     var items:[u8;3]
+    items[0] = 0
     return
 }


### PR DESCRIPTION
This adds a validation check for so-called "dangling registers".  That is, registers which are not used in any vanishing constraint.  At this stage, when the check fails it simply producing a warning.  The next step is to investigate the warnings we have and address them.