### PR TITLE
fix: support wide intrinsics in gogen

### DIFF
--- a/pkg/test/zkc_unit_test.go
+++ b/pkg/test/zkc_unit_test.go
@@ -1203,11 +1203,11 @@ func Test_ZkcUnit_BigNum_03(t *testing.T) {
 }
 
 func Test_ZkcUnit_BigNum_04(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/bignum_04", DEFAULT_UNIT_CONFIG.GoGen(false))
+	checkZkcUnit(t, "zkc/unit/bignum_04", DEFAULT_UNIT_CONFIG)
 }
 
 func Test_ZkcUnit_BigNum_05(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/bignum_05", DEFAULT_UNIT_CONFIG.GoGen(false))
+	checkZkcUnit(t, "zkc/unit/bignum_05", DEFAULT_UNIT_CONFIG)
 }
 
 func Test_ZkcUnit_BigNum_06(t *testing.T) {
@@ -1255,11 +1255,11 @@ func Test_ZkcUnit_BigNum_16(t *testing.T) {
 }
 
 func Test_ZkcUnit_BigNum_17(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/bignum_17", DEFAULT_UNIT_CONFIG.GoGen(false))
+	checkZkcUnit(t, "zkc/unit/bignum_17", DEFAULT_UNIT_CONFIG)
 }
 
 func Test_ZkcUnit_BigNum_18(t *testing.T) {
-	checkZkcUnit(t, "zkc/unit/bignum_18", DEFAULT_UNIT_CONFIG.GoGen(false))
+	checkZkcUnit(t, "zkc/unit/bignum_18", DEFAULT_UNIT_CONFIG)
 }
 
 // ===================================================================

--- a/pkg/zkc/vm/internal/gogen/emit_bitwise.go
+++ b/pkg/zkc/vm/internal/gogen/emit_bitwise.go
@@ -228,9 +228,8 @@ func orMax(a, b *big.Int) *big.Int {
 	return widthMax(uint(n))
 }
 
-// emitShiftHelpers writes the 128-bit variable shifts, each only when
-// referenced.  Counts of 128 or more clear the value, matching the unbounded
-// word semantics under a ≤128-bit mask.
+// emitShiftHelpers writes the variable-shift helpers actually referenced by
+// the generated program.
 func (g *generator) emitShiftHelpers(c *code) {
 	if g.usesHelper(helperShl128) {
 		c.line("func shl128(lo, hi, n uint64) (uint64, uint64) {")
@@ -259,6 +258,42 @@ func (g *generator) emitShiftHelpers(c *code) {
 		c.line("return lo, hi")
 		c.line("default:")
 		c.line("return lo>>n | hi<<(64-n), hi >> n")
+		c.line("}")
+		c.line("}")
+		c.line("")
+	}
+
+	if g.usesHelper(helperWideShl) {
+		c.line("// wideShl shifts little-endian words into a zeroed destination.")
+		c.line("func wideShl(dst, src []uint64, n uint64) {")
+		c.line("word, shift := int(n/64), n%64")
+		c.line("for i, v := range src {")
+		c.line("j := i + word")
+		c.line("if j >= len(dst) {")
+		c.line("break")
+		c.line("}")
+		c.line("dst[j] |= v << shift")
+		c.line("if shift != 0 && j+1 < len(dst) {")
+		c.line("dst[j+1] |= v >> (64 - shift)")
+		c.line("}")
+		c.line("}")
+		c.line("}")
+		c.line("")
+	}
+
+	if g.usesHelper(helperWideShr) {
+		c.line("// wideShr shifts little-endian words into a zeroed destination.")
+		c.line("func wideShr(dst, src []uint64, n uint64) {")
+		c.line("word, shift := int(n/64), n%64")
+		c.line("for j := range dst {")
+		c.line("i := j + word")
+		c.line("if i >= len(src) {")
+		c.line("break")
+		c.line("}")
+		c.line("dst[j] = src[i] >> shift")
+		c.line("if shift != 0 && i+1 < len(src) {")
+		c.line("dst[j] |= src[i+1] << (64 - shift)")
+		c.line("}")
 		c.line("}")
 		c.line("}")
 		c.line("")

--- a/pkg/zkc/vm/internal/gogen/emit_field.go
+++ b/pkg/zkc/vm/internal/gogen/emit_field.go
@@ -16,6 +16,7 @@ package gogen
 import (
 	"fmt"
 	"math/big"
+	"strings"
 
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/bytecode"
 	"github.com/LFDT-Lineth/zkc/pkg/zkc/vm/internal/word"
@@ -205,8 +206,67 @@ func (g *generator) emitModPHelpers(c *code) {
 	}
 }
 
-// emitIntrinsic emits the DIV_HINT intrinsic (executeDivHint), the only intrinsic
-// operation gogen supports: targets[0] = q, targets[1] = r, targets[2] = w where
+// emitWideIntHelper writes the portable uint64-word to big.Int conversion used
+// only by the multiword division fallback (see emitWideDivision).  SetBits
+// adopts the prepared word slice in one step instead of rebuilding the integer
+// through repeated shifts and ORs.  The input words are copied, not retained,
+// so callers can pass slices of stack-backed arrays without forcing them onto
+// the heap.
+func (g *generator) emitWideIntHelper(c *code) {
+	if !g.usesHelper(helperWideInt) {
+		return
+	}
+
+	c.line("func wideInt(words []uint64) (out big.Int) {")
+	c.line("if bits.UintSize == 64 {")
+	c.line("limbs := make([]big.Word, len(words))")
+	c.line("for i, word := range words {")
+	c.line("limbs[i] = big.Word(word)")
+	c.line("}")
+	c.line("out.SetBits(limbs)")
+	c.line("return out")
+	c.line("}")
+	c.line("limbs := make([]big.Word, 2*len(words))")
+	c.line("for i, word := range words {")
+	c.line("limbs[2*i] = big.Word(word)")
+	c.line("limbs[2*i+1] = big.Word(word >> 32)")
+	c.line("}")
+	c.line("out.SetBits(limbs)")
+	c.line("return out")
+	c.line("}")
+	c.line("")
+}
+
+// emitIntrinsic dispatches DIV_HINT and the wide operations introduced by
+// register splitting.  Shifts stay on native uint64 words; division and
+// remainder divide natively whenever both runtime values fit a single word,
+// falling back to big.Int only for genuinely multiword values.
+func (g *generator) emitIntrinsic(c *code, fn *descFunction, x *bytecode.Intrinsic[word.Uint]) error {
+	switch x.Op {
+	case bytecode.DIV_HINT:
+		if len(x.Sources) != 2 || len(x.Targets) != 3 {
+			return fmt.Errorf("gogen: malformed division hint (%d sources, %d targets)", len(x.Sources), len(x.Targets))
+		}
+
+		return g.emitDivHint(c, fn, x)
+	case bytecode.WIDE_SHL, bytecode.WIDE_SHR, bytecode.WIDE_DIV, bytecode.WIDE_REM:
+		if len(x.Sources) != 2 || len(x.Targets) != 1 {
+			return fmt.Errorf("gogen: malformed wide intrinsic (%d sources, %d targets)",
+				len(x.Sources), len(x.Targets))
+		}
+
+		if x.Op == bytecode.WIDE_DIV || x.Op == bytecode.WIDE_REM {
+			return g.emitWideDivision(c, fn, x)
+		}
+
+		return g.emitWideShift(c, fn, x)
+	default:
+		return fmt.Errorf("gogen: unsupported intrinsic operation (%d)", x.Op)
+	}
+}
+
+// emitDivHint emits DIV_HINT, which sets targets[0] = q, targets[1] = r,
+// targets[2] = w where
 //
 //	q = dividend / divisor,  r = dividend % divisor,  w = divisor - r - 1.
 //
@@ -215,14 +275,18 @@ func (g *generator) emitModPHelpers(c *code) {
 // register vector: single-limb vectors read/write a single register, while
 // multi-limb vectors (produced by register-splitting a value on a narrow field)
 // are reconstructed / distributed across their limbs (see assembleHintOperand
-// and storeNamed).  Operands whose total width exceeds 64 bits stay unsupported.
-func (g *generator) emitIntrinsic(c *code, fn *descFunction, x *bytecode.Intrinsic[word.Uint]) error {
-	if x.Op != bytecode.DIV_HINT {
-		return fmt.Errorf("gogen: unsupported intrinsic operation (%d)", x.Op)
-	}
+// and storeNamed).  Operands whose total width exceeds 64 bits share the
+// multiword division path (emitWideDivision).
+func (g *generator) emitDivHint(c *code, fn *descFunction, x *bytecode.Intrinsic[word.Uint]) error {
+	for _, source := range x.Sources {
+		width, err := g.vectorWidth(fn, source)
+		if err != nil {
+			return err
+		}
 
-	if len(x.Sources) != 2 || len(x.Targets) != 3 {
-		return fmt.Errorf("gogen: malformed division hint (%d sources, %d targets)", len(x.Sources), len(x.Targets))
+		if width > 64 {
+			return g.emitWideDivision(c, fn, x)
+		}
 	}
 
 	dividend, err := g.assembleHintOperand(fn, x.Sources[0])
@@ -273,6 +337,337 @@ func (g *generator) emitIntrinsic(c *code, fn *descFunction, x *bytecode.Intrins
 			{expr: "w", max: divisorMax},
 		} {
 			if inner = g.storeNamed(c, targets[i], op); inner != nil {
+				return
+			}
+		}
+	})
+
+	return inner
+}
+
+// vectorWidth is the total bit width of a register vector.
+func (g *generator) vectorWidth(fn *descFunction, vec bytecode.RegisterVector) (uint, error) {
+	var total uint
+
+	for _, id := range vec.Registers() {
+		w, err := g.regWidth(fn, id)
+		if err != nil {
+			return 0, err
+		}
+
+		total += w
+	}
+
+	return total, nil
+}
+
+// packWords flattens a register vector into little-endian 64-bit word
+// expressions (plus the vector's total bit width).  Any limb layout is
+// accepted: full 64-bit words (fast-mode splitting), narrow limbs packed
+// several to a word (e.g. the 16-bit limbs of tracing-mode splitting), limbs
+// straddling a word boundary, and two-limb (lo/hi pair) registers.
+func (g *generator) packWords(fn *descFunction, vec bytecode.RegisterVector) ([]string, uint, error) {
+	// A piece is one Go variable holding up to 64 contiguous bits of the value.
+	type piece struct {
+		name  string
+		width uint
+	}
+
+	var (
+		pieces []piece
+		total  uint
+	)
+
+	for _, id := range reversedRegisters(vec) {
+		limb, err := g.limbOf(fn, id)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		if limb.width <= 64 {
+			pieces = append(pieces, piece{limb.lo(), limb.width})
+		} else {
+			pieces = append(pieces,
+				piece{limb.lo(), 64},
+				piece{limb.hiName(), limb.width - 64})
+		}
+
+		total += limb.width
+	}
+
+	if total == 0 {
+		return nil, 0, fmt.Errorf("gogen: wide intrinsic has an empty register vector")
+	}
+
+	parts := make([][]string, (total+63)/64)
+	offset := uint(0)
+
+	for _, p := range pieces {
+		w, shift := offset/64, offset%64
+
+		if shift == 0 {
+			parts[w] = append(parts[w], p.name)
+		} else {
+			parts[w] = append(parts[w], fmt.Sprintf("%s<<%d", p.name, shift))
+		}
+		// Bits spilling past the word boundary land in the next word.
+		if shift+p.width > 64 {
+			parts[w+1] = append(parts[w+1], fmt.Sprintf("%s>>%d", p.name, 64-shift))
+		}
+
+		offset += p.width
+	}
+
+	words := make([]string, len(parts))
+	for i, ps := range parts {
+		words[i] = strings.Join(ps, " | ")
+	}
+
+	return words, total, nil
+}
+
+// unpackWords distributes little-endian 64-bit words (word(i) yields the i'th
+// word expression) across a register vector — the reverse of packWords.  Each
+// limb takes its bits from one word (or two, when it straddles a word
+// boundary), masked to the limb's width.
+func (g *generator) unpackWords(c *code, fn *descFunction, vec bytecode.RegisterVector,
+	word func(i uint) string) error {
+	offset := uint(0)
+
+	assign := func(lvalue string, width uint) {
+		var (
+			w, shift = offset / 64, offset % 64
+			expr     = word(w)
+		)
+
+		if shift != 0 {
+			expr = fmt.Sprintf("%s>>%d", expr, shift)
+		}
+
+		if shift+width > 64 {
+			expr = fmt.Sprintf("%s | %s<<%d", expr, word(w+1), 64-shift)
+		}
+
+		c.linef("%s = %s", lvalue, maskExpr(expr, width))
+		offset += width
+	}
+
+	for _, id := range reversedRegisters(vec) {
+		limb, err := g.limbOf(fn, id)
+		if err != nil {
+			return err
+		}
+
+		if limb.width <= 64 {
+			assign(limb.lo(), limb.width)
+		} else {
+			assign(limb.lo(), 64)
+			assign(limb.hiName(), limb.width-64)
+		}
+
+		g.iv.assign(id, widthMax(limb.width))
+	}
+
+	return nil
+}
+
+// emitWideShift emits an allocation-free shift over stack-backed uint64 word
+// arrays.  A non-zero upper shift-count word, or a count at least as wide as
+// the target, leaves the zero-initialised result unchanged.
+func (g *generator) emitWideShift(c *code, fn *descFunction, x *bytecode.Intrinsic[word.Uint]) error {
+	value, _, err := g.packWords(fn, x.Sources[0])
+	if err != nil {
+		return err
+	}
+
+	amount, _, err := g.packWords(fn, x.Sources[1])
+	if err != nil {
+		return err
+	}
+
+	width, err := g.vectorWidth(fn, x.Targets[0])
+	if err != nil {
+		return err
+	}
+
+	helper := helperWideShl
+	if x.Op == bytecode.WIDE_SHR {
+		helper = helperWideShr
+	}
+	//
+	g.useHelper(helper)
+
+	condition := fmt.Sprintf("n < %d", width)
+	if len(amount) > 1 {
+		condition = fmt.Sprintf("(%s) == 0 && %s",
+			strings.Join(amount[1:], " | "), condition)
+	}
+
+	var inner error
+
+	c.block(func() {
+		c.linef("src := [...]uint64{%s}", strings.Join(value, ", "))
+		c.linef("var dst [%d]uint64", (width+63)/64)
+		c.linef("n := %s", amount[0])
+		c.linef("if %s {", condition)
+		c.linef("%s(dst[:], src[:], n)", helper)
+		c.line("}")
+		//
+		inner = g.unpackWords(c, fn, x.Targets[0], func(i uint) string {
+			return fmt.Sprintf("dst[%d]", i)
+		})
+	})
+
+	return inner
+}
+
+// emitWideDivision emits WIDE_DIV / WIDE_REM and the wide (>64-bit) form of
+// DIV_HINT.  Each operand is packed into a stack-backed word array, and values
+// that both fit their least-significant word divide natively — so big.Int is
+// confined to values that are genuinely multiword at runtime, not merely
+// wide-typed.
+func (g *generator) emitWideDivision(c *code, fn *descFunction, x *bytecode.Intrinsic[word.Uint]) error {
+	dividend, nX, err := g.packWords(fn, x.Sources[0])
+	if err != nil {
+		return err
+	}
+
+	divisor, nY, err := g.packWords(fn, x.Sources[1])
+	if err != nil {
+		return err
+	}
+	// A result is one value of the division: its local word-array name, the
+	// target vector receiving it, a bound on the value (q ≤ dividend; r < divisor
+	// and never above the dividend; w = divisor - r - 1 < divisor), and its
+	// single-word expression for the native fast path.
+	type result struct {
+		name  string
+		vec   bytecode.RegisterVector
+		bound *big.Int
+		fast  string
+	}
+
+	var (
+		divisorMax = new(big.Int).Sub(widthMax(nY), big.NewInt(1))
+		results    []result
+	)
+
+	switch x.Op {
+	case bytecode.WIDE_DIV:
+		results = []result{{"q", x.Targets[0], widthMax(nX), "a[0] / b[0]"}}
+	case bytecode.WIDE_REM:
+		results = []result{{"r", x.Targets[0], bigMin(widthMax(nX), divisorMax), "a[0] % b[0]"}}
+	default: // DIV_HINT (see emitDivHint)
+		results = []result{
+			{"q", x.Targets[0], widthMax(nX), "a[0] / b[0]"},
+			{"r", x.Targets[1], bigMin(widthMax(nX), divisorMax), "a[0] % b[0]"},
+			{"w", x.Targets[2], divisorMax, "b[0] - r[0] - 1"},
+		}
+	}
+	// Word counts per result target; also the fits-check widths.
+	widths := make([]uint, len(results))
+	for i, res := range results {
+		if widths[i], err = g.vectorWidth(fn, res.vec); err != nil {
+			return err
+		}
+	}
+	// High words of both operands: all zero at runtime means the values fit
+	// their least-significant words and divide natively.
+	var high []string
+	for i := 1; i < len(dividend); i++ {
+		high = append(high, fmt.Sprintf("a[%d]", i))
+	}
+
+	for i := 1; i < len(divisor); i++ {
+		high = append(high, fmt.Sprintf("b[%d]", i))
+	}
+
+	if len(high) > 0 {
+		g.useHelper(helperWideInt)
+		g.usesBits = true
+	}
+
+	zero := make([]string, len(divisor))
+	for i := range divisor {
+		zero[i] = fmt.Sprintf("b[%d]", i)
+	}
+
+	var inner error
+
+	c.block(func() {
+		// Packing snapshots the sources before any target register is written
+		// (a target may alias a source).
+		c.linef("a := [%d]uint64{%s}", len(dividend), strings.Join(dividend, ", "))
+		c.linef("b := [%d]uint64{%s}", len(divisor), strings.Join(divisor, ", "))
+		c.linef("if (%s) == 0 {", strings.Join(zero, " | "))
+		c.line(`fail("division by zero")`)
+		c.line("}")
+
+		for i, res := range results {
+			c.linef("var %s [%d]uint64", res.name, (widths[i]+63)/64)
+		}
+
+		if len(high) > 0 {
+			c.linef("if (%s) == 0 {", strings.Join(high, " | "))
+		}
+
+		for i, res := range results {
+			c.linef("%s[0] = %s", res.name, res.fast)
+			// A single word always fits a target of 64+ bits; narrower targets
+			// need the runtime check only when the bound does not already fit.
+			if widths[i] < 64 && !fits(res.bound, widths[i]) {
+				c.linef("if %s[0] >= 1<<%d {", res.name, widths[i])
+				c.linef("fail(%q)", widthFailMsg(widths[i]))
+				c.line("}")
+			}
+		}
+
+		if len(high) > 0 {
+			bigs := make([]string, len(results))
+			for i, res := range results {
+				bigs[i] = res.name + "b"
+			}
+
+			c.line("} else {")
+			c.line("x, y := wideInt(a[:]), wideInt(b[:])")
+			c.linef("var %s big.Int", strings.Join(bigs, ", "))
+
+			switch x.Op {
+			case bytecode.WIDE_DIV:
+				c.line("qb.Quo(&x, &y)")
+			case bytecode.WIDE_REM:
+				c.line("rb.Rem(&x, &y)")
+			default:
+				c.line("qb.QuoRem(&x, &y, &rb)")
+				c.line("wb.Sub(&y, &rb)")
+				c.line("wb.Sub(&wb, big.NewInt(1))")
+			}
+
+			for i, res := range results {
+				if !fits(res.bound, widths[i]) {
+					c.linef("if %s.BitLen() > %d {", bigs[i], widths[i])
+					c.linef("fail(%q)", widthFailMsg(widths[i]))
+					c.line("}")
+				}
+				// Extraction consumes the big value, shifting a word at a time.
+				for w := uint(0); w < (widths[i]+63)/64; w++ {
+					c.linef("%s[%d] = %s.Uint64()", res.name, w, bigs[i])
+
+					if w+1 < (widths[i]+63)/64 {
+						c.linef("%s.Rsh(&%s, 64)", bigs[i], bigs[i])
+					}
+				}
+			}
+
+			c.line("}")
+		}
+
+		for _, res := range results {
+			name := res.name
+
+			if inner = g.unpackWords(c, fn, res.vec, func(i uint) string {
+				return fmt.Sprintf("%s[%d]", name, i)
+			}); inner != nil {
 				return
 			}
 		}

--- a/pkg/zkc/vm/internal/gogen/gen.go
+++ b/pkg/zkc/vm/internal/gogen/gen.go
@@ -243,6 +243,9 @@ const (
 	helperShl128     = "shl128"
 	helperShr128     = "shr128"
 	helperU128       = "u128"
+	helperWideInt    = "wideInt"
+	helperWideShl    = "wideShl"
+	helperWideShr    = "wideShr"
 )
 
 func (g *generator) useHelper(name string) {
@@ -391,6 +394,7 @@ func (g *generator) emitFile(c *code, order []uint, bodies map[uint]*code) {
 	c.line("")
 	g.emitMemHelpers(c)
 	g.emitShiftHelpers(c)
+	g.emitWideIntHelper(c)
 	g.emitModPHelpers(c)
 
 	c.line("// Run executes the program on the given input memories, returning its")
@@ -479,7 +483,8 @@ func (g *generator) emitImports(c *code) {
 			deps = append(deps, `"fmt"`)
 		}
 
-		if g.usesHelper(helperDbgB) || g.usesHelper(helperU128) || g.usesHelper(helperCatU64) {
+		if g.usesHelper(helperDbgB) || g.usesHelper(helperU128) ||
+			g.usesHelper(helperCatU64) || g.usesHelper(helperWideInt) {
 			deps = append(deps, `"math/big"`)
 		}
 	}

--- a/pkg/zkc/vm/internal/gogen/gen_test.go
+++ b/pkg/zkc/vm/internal/gogen/gen_test.go
@@ -480,6 +480,7 @@ func TestGenValidGo(t *testing.T) {
 		"recSum":       recSumSrc,
 		"bitwise":      bitwiseSrc,
 		"shift":        shiftSrc,
+		"wideShift":    wideShiftSrc,
 		"concat":       concatSrc,
 		"endian":       endianSrc,
 		"carry":        carrySrc,

--- a/pkg/zkc/vm/internal/gogen/gen_test.go
+++ b/pkg/zkc/vm/internal/gogen/gen_test.go
@@ -508,25 +508,6 @@ func TestGenValidGo(t *testing.T) {
 	}
 }
 
-func TestGenWideShiftsUseNativeWords(t *testing.T) {
-	src, err := vm.GenerateGo(compileUint(t, wideShiftSrc, true), vm.GoGenConfig{Package: "wide"})
-	if err != nil {
-		t.Fatalf("GenerateGo: %v", err)
-	}
-
-	for _, helper := range []string{"func wideShl(", "func wideShr("} {
-		if !strings.Contains(src, helper) {
-			t.Errorf("generated source missing %q", helper)
-		}
-	}
-
-	for _, unwanted := range []string{`"math/big"`, "big.Int", "wideInt("} {
-		if strings.Contains(src, unwanted) {
-			t.Errorf("wide shifts unexpectedly use %q", unwanted)
-		}
-	}
-}
-
 // TestGenDifferential compiles each generated program once and checks that, for
 // a range of inputs, it produces outputs identical to the reference executor —
 // and errors exactly when the reference errors.  The corpus is shared with the

--- a/pkg/zkc/vm/internal/gogen/gen_test.go
+++ b/pkg/zkc/vm/internal/gogen/gen_test.go
@@ -203,6 +203,18 @@ fn main() {
 }
 `
 
+// wideShiftSrc forces fast-mode splitting to produce WIDE_SHL / WIDE_SHR.
+const wideShiftSrc = `pub input data(address:u8) -> (word:u256)
+pub output result(address:u8) -> (word:u256)
+fn main() {
+    var x:u256 = data[0]
+    var n:u256 = data[1]
+    result[0] = x << n
+    result[1] = x >> n
+    return
+}
+`
+
 // concatSrc exercises BIT_CONCAT: byte-swap a u16 by destructuring then
 // re-concatenating in the opposite order (sources[0] lands in the low bits).
 const concatSrc = `pub input data(address:u8) -> (w:u16)
@@ -361,6 +373,28 @@ fn main() {
 }
 `
 
+// divMod128Src is u128 division over values built from u64 inputs (a widening
+// multiply, so genuinely >64-bit values are reachable): the fast shape splits
+// it into WIDE_DIV / WIDE_REM over 64-bit words, while the lowered shape
+// produces a division HINT over 16-bit limb vectors — both the multiword
+// division paths, including their native small-value branch.
+const divMod128Src = `pub input data(address:u8) -> (word:u64)
+pub output result(address:u8) -> (word:u64)
+fn main() {
+    var x:u128 = (data[0] as u128) * (data[1] as u128)
+    var y:u128 = (data[2] as u128) * (data[3] as u128)
+    var hi:u64
+    var lo:u64
+    hi::lo = x / y
+    result[0] = lo
+    result[1] = hi
+    hi::lo = x % y
+    result[2] = lo
+    result[3] = hi
+    return
+}
+`
+
 // pagedSrc exercises the paged scratch memory across page boundaries
 // (PAGE_SIZE = 1M words): writes land in pages 0, 1 and 3, and reads hit both
 // written cells and never-written cells in allocated (page 0) and unallocated
@@ -470,6 +504,25 @@ func TestGenValidGo(t *testing.T) {
 
 				t.Logf("generated %d bytes of Go", len(out))
 			})
+		}
+	}
+}
+
+func TestGenWideShiftsUseNativeWords(t *testing.T) {
+	src, err := vm.GenerateGo(compileUint(t, wideShiftSrc, true), vm.GoGenConfig{Package: "wide"})
+	if err != nil {
+		t.Fatalf("GenerateGo: %v", err)
+	}
+
+	for _, helper := range []string{"func wideShl(", "func wideShr("} {
+		if !strings.Contains(src, helper) {
+			t.Errorf("generated source missing %q", helper)
+		}
+	}
+
+	for _, unwanted := range []string{`"math/big"`, "big.Int", "wideInt("} {
+		if strings.Contains(src, unwanted) {
+			t.Errorf("wide shifts unexpectedly use %q", unwanted)
 		}
 	}
 }
@@ -683,6 +736,20 @@ var diffCases = []diffCase{
 			{"data": {0, 9}},
 			{"data": {12345678901234567, 1}},
 			{"data": {5, 0}}, // division by zero -> error
+		},
+	},
+	{
+		name: "divmod128", // multiword division: WIDE_DIV/REM (fast); wide HINT_DIVISION (lowered)
+		src:  divMod128Src,
+		vectors: []map[string][]uint64{
+			{"data": {7, 1, 3, 1}}, // small values: native branch
+			{"data": {0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFF, 3}}, // wide / wide: big.Int branch
+			{"data": {0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 1, 1}},          // wide / 1
+			{"data": {5, 1, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF}},          // small / wide: q=0, r=x
+			{"data": {0xFFFFFFFFFFFFFFFF, 2, 0xFFFFFFFFFFFFFFFF, 1}},          // (2^64-1)·2 / (2^64-1)
+			{"data": {0x0123456789ABCDEF, 0xFEDCBA9876543210, 0xDEADBEEF, 0xCAFEBABE}},
+			{"data": {0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF}}, // q=1, r=0
+			{"data": {7, 1, 0, 5}}, // division by zero -> error
 		},
 	},
 	{


### PR DESCRIPTION
Fixes #2032.

Adds gogen support for `WIDE_SHL`, `WIDE_SHR`, `WIDE_DIV`, and `WIDE_REM`. Wide shifts use native words; division and remainder use `big.Int`.

Note: first shot used big.Int everywhere and I was worried about perf, this version is a in between perf and verbosity, may revisit if that shows up on profile too much